### PR TITLE
Add comments && question to kvdb

### DIFF
--- a/pkgs/kvdb/methods.go
+++ b/pkgs/kvdb/methods.go
@@ -8,11 +8,13 @@ import (
 	"github.com/taubyte/go-interfaces/kvdb"
 )
 
+// retrieves a value from the database
 func (kvd *kvDatabase) Get(ctx context.Context, key string) ([]byte, error) {
 	k := ds.NewKey(key)
 	return kvd.datastore.Get(ctx, k)
 }
 
+// inserts or updates a value in the database
 func (kvd *kvDatabase) Put(ctx context.Context, key string, v []byte) error {
 	k := ds.NewKey(key)
 	return kvd.datastore.Put(ctx, k, v)
@@ -22,7 +24,7 @@ func (kvd *kvDatabase) Delete(ctx context.Context, key string) error {
 	k := ds.NewKey(key)
 	return kvd.datastore.Delete(ctx, k)
 }
-
+// returns a list of keys in the database that have the given prefix
 func (kvd *kvDatabase) List(ctx context.Context, prefix string) ([]string, error) {
 	result, err := kvd.list(ctx, prefix)
 	if err != nil {
@@ -41,7 +43,7 @@ func (kvd *kvDatabase) ListAsync(ctx context.Context, prefix string) (chan strin
 	if err != nil {
 		return nil, err
 	}
-
+	// iterate over the query results and send the keys to the string channel.
 	c := make(chan string, QueryBufferSize)
 	go func() {
 		defer close(c)
@@ -64,6 +66,7 @@ func (kvd *kvDatabase) ListAsync(ctx context.Context, prefix string) (chan strin
 	return c, nil
 }
 
+// list queries the underlying data store with the provided context and prefix to retrieve results matching the prefix.
 func (kvd *kvDatabase) list(ctx context.Context, prefix string) (query.Results, error) {
 	return kvd.datastore.Query(ctx, query.Query{
 		Prefix:   prefix,
@@ -71,6 +74,7 @@ func (kvd *kvDatabase) list(ctx context.Context, prefix string) (query.Results, 
 	})
 }
 
+// Batch creates a new Batch object that allows for batch operations on the key-value database.
 func (kvd *kvDatabase) Batch(ctx context.Context) (kvdb.Batch, error) {
 	b, err := kvd.datastore.Batch(ctx)
 	if err != nil {

--- a/pkgs/kvdb/regexp_methods.go
+++ b/pkgs/kvdb/regexp_methods.go
@@ -13,6 +13,8 @@ type FilterKeyRegEx struct {
 	re []*regexp.Regexp
 }
 
+// Filter applies the regular expression filters to the entry's key.
+// It returns true if any of the regular expressions match the key.
 func (f *FilterKeyRegEx) Filter(e query.Entry) bool {
 	for _, r := range f.re {
 		if r == nil {
@@ -26,6 +28,8 @@ func (f *FilterKeyRegEx) Filter(e query.Entry) bool {
 	return false
 }
 
+// NewFilterKeyRegEx creates a new FilterKeyRegEx with the given regular expressions.
+// It compiles each regular expression and returns an error if any of them fails to compile.
 func NewFilterKeyRegEx(regexs ...string) (*FilterKeyRegEx, error) {
 	f := &FilterKeyRegEx{
 		re: make([]*regexp.Regexp, 0, len(regexs)),
@@ -42,6 +46,7 @@ func NewFilterKeyRegEx(regexs ...string) (*FilterKeyRegEx, error) {
 	return f, nil
 }
 
+// ListRegEx retrieves keys from the key-value database that match the given prefix and regular expressions.
 func (kvd *kvDatabase) ListRegEx(ctx context.Context, prefix string, regexs ...string) ([]string, error) {
 	result, err := kvd.listRegEx(ctx, prefix, regexs...)
 	if err != nil {
@@ -61,6 +66,8 @@ func (kvd *kvDatabase) ListRegEx(ctx context.Context, prefix string, regexs ...s
 	return keys, nil
 }
 
+
+// ListRegExAsync retrieves keys asynchronously from the key-value database that match the given prefix and regular expressions.
 func (kvd *kvDatabase) ListRegExAsync(ctx context.Context, prefix string, regexs ...string) (chan string, error) {
 	result, err := kvd.listRegEx(ctx, prefix, regexs...)
 	if err != nil {
@@ -91,6 +98,8 @@ func (kvd *kvDatabase) ListRegExAsync(ctx context.Context, prefix string, regexs
 	return c, nil
 }
 
+
+// listRegEx performs a query on the key-value database using regular expressions for filtering.
 func (kvd *kvDatabase) listRegEx(ctx context.Context, prefix string, regexs ...string) (query.Results, error) {
 	filter, err := NewFilterKeyRegEx(regexs...)
 	if err != nil {

--- a/pkgs/kvdb/service.go
+++ b/pkgs/kvdb/service.go
@@ -13,6 +13,7 @@ import (
 	ds "github.com/ipfs/go-datastore"
 )
 
+// make sure kvdb is closed
 func (kvd *kvDatabase) cleanup() {
 	if kvd != nil {
 		if kvd.datastore != nil && !kvd.closed {
@@ -29,6 +30,7 @@ func (kvd *kvDatabase) Close() {
 	kvd.factory.deleteDB(kvd.path)
 }
 
+// close all kvdb
 func (f *factory) Close() {
 	for _, k := range f.dbs {
 		k.Close()
@@ -37,6 +39,7 @@ func (f *factory) Close() {
 	f.wg.Wait()
 }
 
+// RWMutex allows multiple readers to access resource while ensuring exclusive access for a single writer
 type factory struct {
 	dbs     map[string]*kvDatabase
 	wg      sync.WaitGroup
@@ -44,6 +47,7 @@ type factory struct {
 	node    peer.Node
 }
 
+// new a pointer of factory
 func New(node peer.Node) kvdb.Factory {
 	return &factory{
 		dbs:  make(map[string]*kvDatabase),
@@ -51,12 +55,14 @@ func New(node peer.Node) kvdb.Factory {
 	}
 }
 
+// safely access and retrieve a database path with a read lock
 func (f *factory) getDB(path string) *kvDatabase {
 	f.dbsLock.RLock()
 	defer f.dbsLock.RUnlock()
 	return f.dbs[path]
 }
 
+// safely delete a database path with a write lock
 func (f *factory) deleteDB(path string) {
 	f.dbsLock.Lock()
 	defer f.dbsLock.Unlock()
@@ -66,10 +72,11 @@ func (f *factory) deleteDB(path string) {
 
 func (f *factory) New(logger logging.StandardLogger, path string, rebroadcastIntervalSec int) (kvdb.KVDB, error) {
 	cachedDB := f.getDB(path)
+	// return cachedDB if it already exists
 	if cachedDB != nil {
 		return cachedDB, nil
 	}
-
+	// assign a database to current factory
 	s := &kvDatabase{
 		factory: f,
 		path:    path,
@@ -77,6 +84,7 @@ func (f *factory) New(logger logging.StandardLogger, path string, rebroadcastInt
 
 	var err error
 	s.closeCtx, s.closeCtxC = f.node.NewChildContextWithCancel()
+	//CRDTs are data types that can be replicated across multiple computers in a network
 	s.broadcaster, err = crdt.NewPubSubBroadcaster(s.closeCtx, f.node.Messaging(), path+"/broadcast")
 	if err != nil {
 		s.closeCtxC()
@@ -86,11 +94,17 @@ func (f *factory) New(logger logging.StandardLogger, path string, rebroadcastInt
 
 	opts := crdt.DefaultOptions()
 	opts.Logger = logger
+	
+	// Set default rebroadcast interval if not provided
 	if rebroadcastIntervalSec == 0 {
 		rebroadcastIntervalSec = defaultRebroadcastIntervalSec
 	}
 
 	opts.RebroadcastInterval = time.Duration(rebroadcastIntervalSec * int(time.Second))
+	// The PutHook function is triggered whenever an element
+	// is successfully added to the datastore (either by a local
+	// or remote update), and only when that addition is considered the
+	// prevalent value.
 	opts.PutHook = func(k ds.Key, v []byte) {
 		logger.Infof("Added: [%s] -> %s\n", k, string(v))
 
@@ -99,7 +113,7 @@ func (f *factory) New(logger logging.StandardLogger, path string, rebroadcastInt
 	opts.DeleteHook = func(k ds.Key) {
 		logger.Infof("Removed: [%s]\n", k)
 	}
-
+	// try to creates a new CRDT (Conflict-free Replicated Data Type) datastore
 	s.datastore, err = crdt.New(f.node.Store(), ds.NewKey("crdt/"+path), f.node.DAG(), s.broadcaster, opts)
 	if err != nil {
 		logger.Error("kvdb.New failed with ", err)
@@ -108,6 +122,8 @@ func (f *factory) New(logger logging.StandardLogger, path string, rebroadcastInt
 	}
 
 	f.wg.Add(1)
+	// anonymous goroutine periodically logs the number of heads in the CRDT datastore 
+	// every 3 seconds while the database is active
 	go func() {
 		defer f.wg.Done()
 		for {
@@ -120,6 +136,7 @@ func (f *factory) New(logger logging.StandardLogger, path string, rebroadcastInt
 		}
 	}()
 
+	// Safely add the created kvDatabase to the factory's dbs map
 	f.dbsLock.Lock()
 	defer f.dbsLock.Unlock()
 	f.dbs[path] = s


### PR DESCRIPTION
Interview pre-screen for Yiqiu.
1. 
The New function at `kvdb/service.go` is chunky:
```
func (f *factory) New(logger logging.StandardLogger, path string, rebroadcastIntervalSec int) (kvdb.KVDB, error) {
....
```

Maybe there is a more elegant way like put this log function separately:
```
	f.wg.Add(1)
	// anonymous goroutine periodically logs the number of heads in the CRDT datastore 
	// every 3 seconds while the database is active
	go func() {
		defer f.wg.Done()
		for {
			select {
			case <-time.After(3 * time.Second):
				logger.Debug("KVDB ", path, "HEADS -> ", s.datastore.InternalStats().Heads)
			case <-s.closeCtx.Done():
				return
			}
		}
	}()
```

2. 
At `kvdb/consts.go`
```	
QueryBufferSize        = 1024
```
Should this value be configurable? As `kvdb` is designed to handle all objects, as `list` method can potentially grab a lot of things.

3.
What's the use case for Batch?
```
type Batch struct {
	ctx   context.Context
	store ds.Batch
}
```