### PR TITLE
113 create robust scoring system for gateway tunnels

### DIFF
--- a/clients/p2p/substrate/vars.go
+++ b/clients/p2p/substrate/vars.go
@@ -13,11 +13,4 @@ const (
 	BodyHost   = "host"
 	BodyPath   = "path"
 	BodyMethod = "method"
-
-	ResponseCached     = "cached"
-	ResponseAverageRun = "average-run"
-	ResponseColdStart  = "cold-start"
-	ResponseMemory     = "memory"
-	ResponseCpuCount   = "cpus"
-	ResponseAverageCpu = "average-cpu"
 )

--- a/clients/p2p/substrate/vars.go
+++ b/clients/p2p/substrate/vars.go
@@ -14,5 +14,10 @@ const (
 	BodyPath   = "path"
 	BodyMethod = "method"
 
-	ResponseCached = "cached"
+	ResponseCached     = "cached"
+	ResponseAverageRun = "average-run"
+	ResponseColdStart  = "cold-start"
+	ResponseMemory     = "memory"
+	ResponseCpuCount   = "cpus"
+	ResponseAverageCpu = "average-cpu"
 )

--- a/clients/p2p/substrate/vars.go
+++ b/clients/p2p/substrate/vars.go
@@ -4,7 +4,7 @@ import "time"
 
 var (
 	DefaultTimeOut   = 10 * time.Millisecond
-	DefaultThreshold = 5
+	DefaultThreshold = 3
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/taubyte/tau
 
 go 1.19
 
+replace github.com/taubyte/go-interfaces => ../go-interfaces
+
 require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/avast/retry-go v3.0.0+incompatible
@@ -30,6 +32,7 @@ require (
 	github.com/otiai10/copy v1.12.0
 	github.com/pkg/errors v0.9.1
 	github.com/pterm/pterm v0.12.65
+	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/spf13/afero v1.9.5
 	github.com/taubyte/builder v0.2.1
 	github.com/taubyte/cli-common v0.1.1
@@ -226,7 +229,6 @@ require (
 	github.com/rs/cors v1.8.3 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
-	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/taubyte/go-sdk-symbols v0.2.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/taubyte/tau
 
 go 1.19
 
-replace github.com/taubyte/go-interfaces => ../go-interfaces
-
 require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/avast/retry-go v3.0.0+incompatible
@@ -38,7 +36,7 @@ require (
 	github.com/taubyte/cli-common v0.1.1
 	github.com/taubyte/config-compiler v0.4.6
 	github.com/taubyte/domain-validation v1.0.1
-	github.com/taubyte/go-interfaces v0.2.14-0.20230921175616-0dd966927da2
+	github.com/taubyte/go-interfaces v0.2.14-0.20230928164739-cb43412ebf90
 	github.com/taubyte/go-project-schema v0.9.3
 	github.com/taubyte/go-sdk v0.3.9
 	github.com/taubyte/go-sdk-smartops v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -885,6 +885,8 @@ github.com/taubyte/config-compiler v0.4.6 h1:9s3xn955imE7gAyVFpcsBEkowhCir78b1HP
 github.com/taubyte/config-compiler v0.4.6/go.mod h1:gaohk1BSknIudo16QSgeQqVWVGLyusPPdLn+wQ+xAmY=
 github.com/taubyte/domain-validation v1.0.1 h1:T1iRls4p5+uJLR8R/wf+dBt9Rlahg9BcCtBVbkoD0Ik=
 github.com/taubyte/domain-validation v1.0.1/go.mod h1:/X3yd7sBjnE323rA8I9PiUt5+NlKU4I02nQik25Vqe8=
+github.com/taubyte/go-interfaces v0.2.14-0.20230928164739-cb43412ebf90 h1:vs5vfSUD6enNlvMB0XjRtTm0b9ze+PYaQ7MJEA6k6W4=
+github.com/taubyte/go-interfaces v0.2.14-0.20230928164739-cb43412ebf90/go.mod h1:OWQlR4DriWCjkgmfFFrlynXd4yjigUxKGIeUBWv1Mmw=
 github.com/taubyte/go-project-schema v0.9.3 h1:2H0ClUZq7f97OgtL0FUe9tv2v12wOmnTAIiJGLei/gU=
 github.com/taubyte/go-project-schema v0.9.3/go.mod h1:8Rt5zsVfj8qbYCT+7++oax/nFVKvVfAepzVkqXrNTs8=
 github.com/taubyte/go-sdk v0.3.9 h1:mwwjiub/Jc987kfWvVfAcx63fMRAYB9cj4yhJq+CSyo=

--- a/go.sum
+++ b/go.sum
@@ -885,8 +885,6 @@ github.com/taubyte/config-compiler v0.4.6 h1:9s3xn955imE7gAyVFpcsBEkowhCir78b1HP
 github.com/taubyte/config-compiler v0.4.6/go.mod h1:gaohk1BSknIudo16QSgeQqVWVGLyusPPdLn+wQ+xAmY=
 github.com/taubyte/domain-validation v1.0.1 h1:T1iRls4p5+uJLR8R/wf+dBt9Rlahg9BcCtBVbkoD0Ik=
 github.com/taubyte/domain-validation v1.0.1/go.mod h1:/X3yd7sBjnE323rA8I9PiUt5+NlKU4I02nQik25Vqe8=
-github.com/taubyte/go-interfaces v0.2.14-0.20230921175616-0dd966927da2 h1:hy6J8zeFXlJGMiEX9wYuGg2dU8E5zb7ujV+0F8FFVaE=
-github.com/taubyte/go-interfaces v0.2.14-0.20230921175616-0dd966927da2/go.mod h1:OWQlR4DriWCjkgmfFFrlynXd4yjigUxKGIeUBWv1Mmw=
 github.com/taubyte/go-project-schema v0.9.3 h1:2H0ClUZq7f97OgtL0FUe9tv2v12wOmnTAIiJGLei/gU=
 github.com/taubyte/go-project-schema v0.9.3/go.mod h1:8Rt5zsVfj8qbYCT+7++oax/nFVKvVfAepzVkqXrNTs8=
 github.com/taubyte/go-sdk v0.3.9 h1:mwwjiub/Jc987kfWvVfAcx63fMRAYB9cj4yhJq+CSyo=

--- a/protocols/gateway/handle.go
+++ b/protocols/gateway/handle.go
@@ -35,6 +35,19 @@ func (g *Gateway) handleHttp(w goHttp.ResponseWriter, r *goHttp.Request) error {
 		if err != nil {
 			logger.Debugf("response from node `%s` failed with: %s", response.PID().Pretty(), err.Error())
 		}
+
+		used, _ := response.Get("used")
+		free, _ := response.Get("free")
+		total, _ := response.Get("total")
+		required, _ := response.Get("required")
+		u, _ := used.(uint64)
+		f, _ := free.(uint64)
+		t, _ := total.(uint64)
+		r, _ := required.(uint64)
+		c := g.Get(response).Cached()
+
+		fmt.Printf("Peer: %s\nCached: %v\nTotal: %d\nUsed: %d\nFree: %d\nRequired: %d\n----------------------------------\n", response.PID().Pretty(), c, t, u, f, r)
+
 		if err == nil && g.Get(response).Cached() {
 			matches = append([]*client.Response{response}, matches...)
 		} else {

--- a/protocols/gateway/handle.go
+++ b/protocols/gateway/handle.go
@@ -3,12 +3,14 @@ package gateway
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	goHttp "net/http"
 
 	http "github.com/taubyte/http"
 	"github.com/taubyte/p2p/streams/client"
 	tunnel "github.com/taubyte/p2p/streams/tunnels/http"
+	"github.com/taubyte/tau/protocols/substrate/components/metrics"
 )
 
 func (g *Gateway) attach() {
@@ -23,49 +25,88 @@ func (g *Gateway) attach() {
 	})
 }
 
+type wrappedResponse[T metrics.Function | metrics.Website] struct {
+	metrics T
+	*client.Response
+}
+
+func (wr wrappedResponse[T]) Decode(data interface{}) error {
+	switch metricsData := data.(type) {
+	case []byte:
+		var m T
+		return metrics.Iface(m).Decode(metricsData)
+	default:
+		return errors.New("metrics data not []byte")
+	}
+
+}
+
 func (g *Gateway) handleHttp(w goHttp.ResponseWriter, r *goHttp.Request) error {
 	resCh, err := g.substrateClient.ProxyHTTP(r.Host, r.URL.Path, r.Method)
 	if err != nil {
 		return fmt.Errorf("substrate client proxyHttp failed with: %w", err)
 	}
 
-	matches := make([]*client.Response, 0)
+	websiteMatches := make([]wrappedResponse[metrics.Website], 0)
+	funcMatches := make([]wrappedResponse[metrics.Function], 0)
+	discard := make([]*client.Response, 0)
 	for response := range resCh {
 		err := response.Error()
 		if err != nil {
 			logger.Debugf("response from node `%s` failed with: %s", response.PID().Pretty(), err.Error())
 		}
 
-		used, _ := response.Get("used")
-		free, _ := response.Get("free")
-		total, _ := response.Get("total")
-		required, _ := response.Get("required")
-		u, _ := used.(uint64)
-		f, _ := free.(uint64)
-		t, _ := total.(uint64)
-		r, _ := required.(uint64)
-		c := g.Get(response).Cached()
-
-		fmt.Printf("Peer: %s\nCached: %v\nTotal: %d\nUsed: %d\nFree: %d\nRequired: %d\n----------------------------------\n", response.PID().Pretty(), c, t, u, f, r)
-
-		if err == nil && g.Get(response).Cached() {
-			matches = append([]*client.Response{response}, matches...)
-		} else {
-			matches = append(matches, response)
+		if _metrics, err := response.Get("website"); err == nil {
+			wres := wrappedResponse[metrics.Website]{Response: response}
+			err = wres.Decode(_metrics)
+			if err == nil {
+				websiteMatches = append([]wrappedResponse[metrics.Website]{wres}, websiteMatches...)
+				continue
+			}
 		}
+
+		if _metrics, err := response.Get("function"); err == nil {
+			wres := wrappedResponse[metrics.Function]{Response: response}
+			err = wres.Decode(_metrics)
+			if err == nil {
+				funcMatches = append([]wrappedResponse[metrics.Function]{wres}, funcMatches...)
+				continue
+			}
+		}
+
+		// all else
+		discard = append(discard, response)
 	}
-	if len(matches) < 1 {
+
+	if len(websiteMatches) == 0 && len(funcMatches) == 0 {
 		return errors.New("no substrate match found")
 	}
+
+	var pick *client.Response
+
+	if len(websiteMatches) > len(funcMatches) {
+		sort.Slice(websiteMatches, func(i, j int) bool { return websiteMatches[i].metrics.Less(websiteMatches[j].metrics) })
+		pick = websiteMatches[0].Response
+	} else {
+		sort.Slice(funcMatches, func(i, j int) bool { return funcMatches[i].metrics.Less(funcMatches[j].metrics) })
+		pick = funcMatches[0].Response
+	}
+
 	defer func() {
-		for _, match := range matches {
-			match.Close()
+		for _, res := range discard {
+			res.Close()
+		}
+		for _, res := range websiteMatches {
+			res.Close()
+		}
+		for _, res := range funcMatches {
+			res.Close()
 		}
 	}()
 
-	w.Header().Add(ProxyHeader, matches[0].PID().Pretty())
+	w.Header().Add(ProxyHeader, pick.PID().Pretty())
 
-	if err := tunnel.Frontend(w, r, matches[0]); err != nil {
+	if err := tunnel.Frontend(w, r, pick); err != nil {
 		return fmt.Errorf("tunneling Frontend failed with: %w", err)
 	}
 

--- a/protocols/gateway/handle.go
+++ b/protocols/gateway/handle.go
@@ -84,10 +84,10 @@ func (g *Gateway) handleHttp(w goHttp.ResponseWriter, r *goHttp.Request) error {
 	var pick *client.Response
 
 	if len(websiteMatches) > len(funcMatches) {
-		sort.Slice(websiteMatches, func(i, j int) bool { return websiteMatches[i].metrics.Less(websiteMatches[j].metrics) })
+		sort.Slice(websiteMatches, func(i, j int) bool { return websiteMatches[j].metrics.Less(websiteMatches[i].metrics) })
 		pick = websiteMatches[0].Response
 	} else {
-		sort.Slice(funcMatches, func(i, j int) bool { return funcMatches[i].metrics.Less(funcMatches[j].metrics) })
+		sort.Slice(funcMatches, func(i, j int) bool { return funcMatches[j].metrics.Less(funcMatches[i].metrics) })
 		pick = funcMatches[0].Response
 	}
 

--- a/protocols/gateway/handle.go
+++ b/protocols/gateway/handle.go
@@ -38,7 +38,6 @@ func (wr wrappedResponse[T]) Decode(data interface{}) error {
 	default:
 		return errors.New("metrics data not []byte")
 	}
-
 }
 
 func (g *Gateway) handleHttp(w goHttp.ResponseWriter, r *goHttp.Request) error {

--- a/protocols/gateway/methods.go
+++ b/protocols/gateway/methods.go
@@ -1,0 +1,18 @@
+package gateway
+
+import (
+	http "github.com/taubyte/http"
+	"github.com/taubyte/p2p/peer"
+)
+
+func (g *Gateway) Node() peer.Node {
+	return g.node
+}
+
+func (g *Gateway) Http() http.Service {
+	return g.http
+}
+
+func (g *Gateway) Close() error {
+	return g.substrateClient.Close()
+}

--- a/protocols/gateway/types.go
+++ b/protocols/gateway/types.go
@@ -6,6 +6,8 @@ import (
 	"github.com/taubyte/go-interfaces/services/substrate"
 	http "github.com/taubyte/http"
 	"github.com/taubyte/p2p/peer"
+	"github.com/taubyte/p2p/streams/client"
+	"github.com/taubyte/tau/protocols/substrate/components/metrics"
 )
 
 type Gateway struct {
@@ -19,14 +21,7 @@ type Gateway struct {
 	verbose bool
 }
 
-func (g *Gateway) Node() peer.Node {
-	return g.node
-}
-
-func (g *Gateway) Http() http.Service {
-	return g.http
-}
-
-func (g *Gateway) Close() error {
-	return nil
+type wrappedResponse struct {
+	metrics metrics.Metric
+	*client.Response
 }

--- a/protocols/gateway/types.go
+++ b/protocols/gateway/types.go
@@ -22,6 +22,6 @@ type Gateway struct {
 }
 
 type wrappedResponse struct {
-	metrics metrics.Metric
+	metrics metrics.Iface
 	*client.Response
 }

--- a/protocols/substrate/components/common/types.go
+++ b/protocols/substrate/components/common/types.go
@@ -1,8 +1,0 @@
-package common
-
-type Metrics struct {
-	Cached     float32 `cbor:"0,keyasint"`
-	ColdStart  int64   `cbor:"1,keyasint"`
-	Memory     float64 `cbor:"2,keyasint"`
-	AvgRunTime int64   `cbor:"3,keyasint"`
-}

--- a/protocols/substrate/components/common/types.go
+++ b/protocols/substrate/components/common/types.go
@@ -1,0 +1,8 @@
+package common
+
+type Metrics struct {
+	Cached     float32 `cbor:"0,keyasint"`
+	ColdStart  int64   `cbor:"1,keyasint"`
+	Memory     float64 `cbor:"2,keyasint"`
+	AvgRunTime int64   `cbor:"3,keyasint"`
+}

--- a/protocols/substrate/components/http/common/types.go
+++ b/protocols/substrate/components/http/common/types.go
@@ -8,18 +8,24 @@ var _ commonIface.MatchDefinition = &MatchDefinition{}
 
 func New(host, path, method string) *MatchDefinition {
 	return &MatchDefinition{
-		Host:   host,
-		Path:   path,
-		Method: method,
+		Request: &Request{
+			Host:   host,
+			Path:   path,
+			Method: method,
+		},
 		params: make(map[string]string, 0),
 	}
 }
 
-// TODO: Maybe move this to interfaces?
-type MatchDefinition struct {
+type Request struct {
 	Host   string
 	Path   string
 	Method string
+}
+
+// TODO: Maybe move this to interfaces?
+type MatchDefinition struct {
+	*Request
 	params map[string]string
 }
 

--- a/protocols/substrate/components/http/common/vars.go
+++ b/protocols/substrate/components/http/common/vars.go
@@ -1,6 +1,0 @@
-package common
-
-const (
-	NoMatch    = 0
-	ValidMatch = 1
-)

--- a/protocols/substrate/components/http/common/vars.go
+++ b/protocols/substrate/components/http/common/vars.go
@@ -1,0 +1,6 @@
+package common
+
+const (
+	NoMatch    = 0
+	ValidMatch = 1
+)

--- a/protocols/substrate/components/http/function/function.go
+++ b/protocols/substrate/components/http/function/function.go
@@ -25,24 +25,26 @@ func (f *Function) Provision() (function httpComp.Serviceable, err error) {
 		f.readyCtxC()
 	}()
 
-	if f.Function, err = vm.New(f.instanceCtx, f, f.branch, f.commit); err != nil {
-		return nil, fmt.Errorf("initializing wasm module failed with: %w", err)
-	}
-
 	cachedFunc, err := f.srv.Cache().Add(f, f.branch)
 	if err != nil {
 		return nil, fmt.Errorf("adding function to cache failed with: %w", err)
 	}
+
 	if f != cachedFunc {
 		_f, ok := cachedFunc.(httpComp.Function)
 		if ok {
 			return _f, nil
 		}
-
-		// TODO: Debug Logger if this case is met
 	}
 
+	if f.Function, err = vm.New(f.instanceCtx, f, f.branch, f.commit); err != nil {
+		return nil, fmt.Errorf("initializing wasm module failed with: %w", err)
+	}
+
+	f.metrics.Cached = 1
+
 	f.provisioned = true
+
 	return f, nil
 }
 

--- a/protocols/substrate/components/http/function/methods.go
+++ b/protocols/substrate/components/http/function/methods.go
@@ -1,0 +1,54 @@
+package function
+
+import (
+	"github.com/taubyte/go-interfaces/services/substrate/components"
+	structureSpec "github.com/taubyte/go-specs/structure"
+)
+
+func (f *Function) Service() components.ServiceComponent {
+	return f.srv
+}
+
+func (f *Function) Config() *structureSpec.Function {
+	return &f.config
+}
+
+func (f *Function) Commit() string {
+	return f.commit
+}
+
+func (f *Function) Matcher() components.MatchDefinition {
+	return f.matcher
+}
+
+func (f *Function) Id() string {
+	return f.config.Id
+}
+
+func (f *Function) Ready() error {
+	if !f.readyDone {
+		<-f.readyCtx.Done()
+	}
+
+	return f.readyError
+}
+
+func (f *Function) CachePrefix() string {
+	return f.matcher.Host
+}
+
+func (f *Function) Application() string {
+	return f.application
+}
+
+func (f *Function) AssetId() string {
+	return f.assetId
+}
+
+func (f *Function) Project() string {
+	return f.project
+}
+
+func (f *Function) IsProvisioned() bool {
+	return f.provisioned
+}

--- a/protocols/substrate/components/http/function/methods.go
+++ b/protocols/substrate/components/http/function/methods.go
@@ -3,6 +3,7 @@ package function
 import (
 	"github.com/taubyte/go-interfaces/services/substrate/components"
 	structureSpec "github.com/taubyte/go-specs/structure"
+	"github.com/taubyte/tau/clients/p2p/seer/usage"
 )
 
 func (f *Function) Service() components.ServiceComponent {
@@ -11,6 +12,22 @@ func (f *Function) Service() components.ServiceComponent {
 
 func (f *Function) Config() *structureSpec.Function {
 	return &f.config
+}
+
+// TODO: move to file
+type Metrics struct {
+	Cached     float32 `cbor:"0,keyasint"`
+	ClostStart int64   `cbor:"1,keyasint"`
+	Memory     float64 `cbor:"2,keyasint"`
+	AvgRunTime int64   `cbor:"3,keyasint"`
+}
+
+func (f *Function) Metrics() Metrics {
+	m := f.metrics
+	if mem, err := usage.GetMemoryUsage(); err == nil {
+		m.Memory = float64(mem.Free) / float64(f.config.Memory)
+	}
+	return m
 }
 
 func (f *Function) Commit() string {

--- a/protocols/substrate/components/http/function/methods.go
+++ b/protocols/substrate/components/http/function/methods.go
@@ -1,13 +1,11 @@
 package function
 
 import (
-	"fmt"
-
 	"github.com/taubyte/go-interfaces/services/substrate/components"
 	"github.com/taubyte/go-interfaces/vm"
 	structureSpec "github.com/taubyte/go-specs/structure"
 	"github.com/taubyte/tau/clients/p2p/seer/usage"
-	"github.com/taubyte/tau/protocols/substrate/components/common"
+	"github.com/taubyte/tau/protocols/substrate/components/metrics"
 )
 
 const WasmMemorySizeLimit = uint64(vm.MemoryPageSize) * uint64(vm.MemoryLimitPages)
@@ -20,11 +18,11 @@ func (f *Function) Config() *structureSpec.Function {
 	return &f.config
 }
 
-func (f *Function) Metrics() (common.Metrics, error) {
+func (f *Function) Metrics() metrics.Function {
 	m := f.metrics
 	mem, err := usage.GetMemoryUsage()
 	if err != nil {
-		return common.Metrics{}, fmt.Errorf("getting memory stats failed with: %w", err)
+		panic(err)
 	}
 
 	maxMemory := f.config.Memory
@@ -41,7 +39,7 @@ func (f *Function) Metrics() (common.Metrics, error) {
 
 	m.Memory = float64(mem.Free) / float64(maxMemory)
 
-	return m, nil
+	return m
 }
 
 func (f *Function) Commit() string {

--- a/protocols/substrate/components/http/function/methods.go
+++ b/protocols/substrate/components/http/function/methods.go
@@ -4,8 +4,6 @@ import (
 	"github.com/taubyte/go-interfaces/services/substrate/components"
 	"github.com/taubyte/go-interfaces/vm"
 	structureSpec "github.com/taubyte/go-specs/structure"
-	"github.com/taubyte/tau/clients/p2p/seer/usage"
-	"github.com/taubyte/tau/protocols/substrate/components/metrics"
 )
 
 const WasmMemorySizeLimit = uint64(vm.MemoryPageSize) * uint64(vm.MemoryLimitPages)
@@ -16,30 +14,6 @@ func (f *Function) Service() components.ServiceComponent {
 
 func (f *Function) Config() *structureSpec.Function {
 	return &f.config
-}
-
-func (f *Function) Metrics() metrics.Function {
-	m := f.metrics
-	mem, err := usage.GetMemoryUsage()
-	if err != nil {
-		panic(err)
-	}
-
-	maxMemory := f.config.Memory
-	if f.provisioned {
-		m.AvgRunTime = f.CallTime().Nanoseconds()
-		m.ColdStart = f.ColdStart().Nanoseconds()
-		maxMemory = f.MemoryMax()
-	}
-
-	// Memory == 0 no memory limit
-	if maxMemory <= 0 {
-		maxMemory = WasmMemorySizeLimit
-	}
-
-	m.Memory = float64(mem.Free) / float64(maxMemory)
-
-	return m
 }
 
 func (f *Function) Commit() string {

--- a/protocols/substrate/components/http/function/new.go
+++ b/protocols/substrate/components/http/function/new.go
@@ -38,8 +38,8 @@ func New(srv components.ServiceComponent, object tns.Object, matcher *common.Mat
 		return nil, fmt.Errorf("getting asset id failed with: %w", err)
 	}
 
-	assetCid, _ := cid.Decode(match.AssetId())
-	if exists, _ := s.node.DAG().HasBlock(s.ctx, assetCid); exists {
+	assetCid, _ := cid.Decode(f.assetId)
+	if exists, _ := srv.Node().DAG().HasBlock(srv.Context(), assetCid); exists {
 		f.metrics.Cached += 0.3
 	}
 

--- a/protocols/substrate/components/http/function/new.go
+++ b/protocols/substrate/components/http/function/new.go
@@ -3,6 +3,7 @@ package function
 import (
 	"fmt"
 
+	"github.com/ipfs/go-cid"
 	"github.com/taubyte/go-interfaces/services/substrate/components"
 	"github.com/taubyte/go-interfaces/services/substrate/components/http"
 	"github.com/taubyte/go-interfaces/services/tns"
@@ -35,6 +36,11 @@ func New(srv components.ServiceComponent, object tns.Object, matcher *common.Mat
 	f.assetId, err = cache.ResolveAssetCid(f, f.branch)
 	if err != nil {
 		return nil, fmt.Errorf("getting asset id failed with: %w", err)
+	}
+
+	assetCid, _ := cid.Decode(match.AssetId())
+	if exists, _ := s.node.DAG().HasBlock(s.ctx, assetCid); exists {
+		f.metrics.Cached += 0.3
 	}
 
 	return f, nil

--- a/protocols/substrate/components/http/function/new.go
+++ b/protocols/substrate/components/http/function/new.go
@@ -1,18 +1,17 @@
 package function
 
 import (
-	"context"
 	"fmt"
 
-	commonIface "github.com/taubyte/go-interfaces/services/substrate/components"
+	"github.com/taubyte/go-interfaces/services/substrate/components"
+	"github.com/taubyte/go-interfaces/services/substrate/components/http"
 	"github.com/taubyte/go-interfaces/services/tns"
 	"github.com/taubyte/go-specs/extract"
 	"github.com/taubyte/tau/protocols/substrate/components/http/common"
-	"github.com/taubyte/tau/vm"
 	"github.com/taubyte/tau/vm/cache"
 )
 
-func New(srv commonIface.ServiceComponent, object tns.Object, matcher *common.MatchDefinition) (commonIface.Serviceable, error) {
+func New(srv components.ServiceComponent, object tns.Object, matcher *common.MatchDefinition) (http.Serviceable, error) {
 	parser, err := extract.Tns().BasicPath(object.Path().String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse tns path `%s` with: %s", object.Path().String(), err)
@@ -33,29 +32,9 @@ func New(srv commonIface.ServiceComponent, object tns.Object, matcher *common.Ma
 	}
 
 	f.config.Id = id
-	f.instanceCtx, f.instanceCtxC = context.WithCancel(srv.Context())
-	f.readyCtx, f.readyCtxC = context.WithCancel(srv.Context())
-	defer func() {
-		f.readyError = err
-		f.readyDone = true
-		f.readyCtxC()
-	}()
-
 	f.assetId, err = cache.ResolveAssetCid(f, f.branch)
 	if err != nil {
 		return nil, fmt.Errorf("getting asset id failed with: %w", err)
-	}
-
-	if f.Function, err = vm.New(f.instanceCtx, f, f.branch, f.commit); err != nil {
-		return nil, fmt.Errorf("initializing wasm module failed with: %w", err)
-	}
-
-	_f, err := srv.Cache().Add(f, f.branch)
-	if err != nil {
-		return nil, fmt.Errorf("adding http function serviceable failed with: %s", err)
-	}
-	if f != _f {
-		return _f, nil
 	}
 
 	return f, nil

--- a/protocols/substrate/components/http/function/types.go
+++ b/protocols/substrate/components/http/function/types.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/taubyte/go-interfaces/services/substrate/components"
 	structureSpec "github.com/taubyte/go-specs/structure"
-	compCommon "github.com/taubyte/tau/protocols/substrate/components/common"
 	"github.com/taubyte/tau/protocols/substrate/components/http/common"
+	"github.com/taubyte/tau/protocols/substrate/components/metrics"
 	"github.com/taubyte/tau/vm"
 )
 
@@ -32,7 +32,7 @@ type Function struct {
 	instanceCtx  context.Context
 	instanceCtxC context.CancelFunc
 
-	metrics compCommon.Metrics
+	metrics metrics.Function
 
 	*vm.Function
 }

--- a/protocols/substrate/components/http/function/types.go
+++ b/protocols/substrate/components/http/function/types.go
@@ -26,6 +26,8 @@ type Function struct {
 	readyCtxC  context.CancelFunc
 	readyError error
 
+	provisioned bool
+
 	instanceCtx  context.Context
 	instanceCtxC context.CancelFunc
 

--- a/protocols/substrate/components/http/function/types.go
+++ b/protocols/substrate/components/http/function/types.go
@@ -3,14 +3,15 @@ package function
 import (
 	"context"
 
-	iface "github.com/taubyte/go-interfaces/services/substrate/components"
+	"github.com/taubyte/go-interfaces/services/substrate/components"
 	structureSpec "github.com/taubyte/go-specs/structure"
+	compCommon "github.com/taubyte/tau/protocols/substrate/components/common"
 	"github.com/taubyte/tau/protocols/substrate/components/http/common"
 	"github.com/taubyte/tau/vm"
 )
 
 type Function struct {
-	srv iface.ServiceComponent
+	srv components.ServiceComponent
 
 	config      structureSpec.Function
 	matcher     *common.MatchDefinition
@@ -31,7 +32,7 @@ type Function struct {
 	instanceCtx  context.Context
 	instanceCtxC context.CancelFunc
 
-	metrics Metrics
+	metrics compCommon.Metrics
 
 	*vm.Function
 }

--- a/protocols/substrate/components/http/function/types.go
+++ b/protocols/substrate/components/http/function/types.go
@@ -31,6 +31,8 @@ type Function struct {
 	instanceCtx  context.Context
 	instanceCtxC context.CancelFunc
 
+	metrics Metrics
+
 	*vm.Function
 }
 

--- a/protocols/substrate/components/http/helpers/serviceable.go
+++ b/protocols/substrate/components/http/helpers/serviceable.go
@@ -1,5 +1,0 @@
-package helpers
-
-func ServiceId(projectId, host, resourceId string) string {
-	return "." + projectId[:8] + "." + host + "." + resourceId
-}

--- a/protocols/substrate/components/http/lookup.go
+++ b/protocols/substrate/components/http/lookup.go
@@ -20,32 +20,13 @@ import (
 	"github.com/taubyte/tau/vm/helpers"
 )
 
-// TODO: Debug loggers should be added all over
+// TODO: Debug loggers
 
 var (
 	//go:embed domain_public.key
 	domainValPublicKeyData []byte
-	TheServiceables        = []spec.PathVariable{websiteSpec.PathVariable, functionSpec.PathVariable}
+	ValidResources         = []spec.PathVariable{websiteSpec.PathVariable, functionSpec.PathVariable}
 )
-
-func (s *Service) CurrentTnsPath(resourceType spec.PathVariable, host string) ([]tns.Path, error) {
-	servKey, err := methods.HttpPath(host, resourceType)
-	if err != nil {
-		return nil, fmt.Errorf("creating new tns path for serviceable type `%s` on host `%s` failed with: %s", resourceType, host, err)
-	}
-
-	indexObject, err := s.Tns().Fetch(servKey.Versioning().Links())
-	if err != nil {
-		return nil, fmt.Errorf("fetching versioning links failed with: %w", err)
-	}
-
-	pathList, err := indexObject.Current(spec.DefaultBranch)
-	if err != nil {
-		return nil, fmt.Errorf("getting `current` paths failed with: %w", err)
-	}
-
-	return pathList, nil
-}
 
 func (s *Service) CheckTns(matcherIface commonIface.MatchDefinition) ([]commonIface.Serviceable, error) {
 	matcher, ok := matcherIface.(*common.MatchDefinition)
@@ -55,9 +36,18 @@ func (s *Service) CheckTns(matcherIface commonIface.MatchDefinition) ([]commonIf
 
 	host := helpers.ExtractHost(matcher.Host)
 	var candidates []commonIface.Serviceable
-	for _, stype := range TheServiceables {
-		if paths, err := s.CurrentTnsPath(stype, host); err == nil {
-			candidates = append(candidates, s.handleTNSPaths(stype, matcher, paths)...)
+	for _, rtype := range ValidResources {
+		servKey, err := methods.HttpPath(host, rtype)
+		if err != nil {
+			return nil, fmt.Errorf("creating new tns path for serviceable type `%s` on host `%s` failed with: %w", rtype, host, err)
+		}
+
+		indexObject, err := s.Tns().Fetch(servKey.Versioning().Links())
+		if err == nil {
+			pathList, err := indexObject.Current(spec.DefaultBranch)
+			if err == nil {
+				candidates = append(candidates, s.handleTNSPaths(rtype, matcher, pathList)...)
+			}
 		}
 	}
 
@@ -70,7 +60,7 @@ func (s *Service) CheckTns(matcherIface commonIface.MatchDefinition) ([]commonIf
 		}
 
 		if err := domainSpec.ValidateDNS(pick.Project(), matcher.Host, s.Dev(), dv.PublicKey(publicKey)); err != nil {
-			return nil, fmt.Errorf("validating dns failed for match definition `%v` failed with: %s", *matcher, err)
+			return nil, fmt.Errorf("validating dns failed for match definition `%v` failed with: %w", *matcher, err)
 		}
 
 		return []commonIface.Serviceable{pick}, nil

--- a/protocols/substrate/components/http/website/methods.go
+++ b/protocols/substrate/components/http/website/methods.go
@@ -1,0 +1,59 @@
+package website
+
+import (
+	commonIface "github.com/taubyte/go-interfaces/services/substrate/components"
+	structureSpec "github.com/taubyte/go-specs/structure"
+)
+
+func (w *Website) Service() commonIface.ServiceComponent {
+	return w.srv
+}
+
+func (w *Website) Config() *structureSpec.Website {
+	return &w.config
+}
+
+func (w *Website) Commit() string {
+	return w.commit
+}
+
+func (w *Website) Matcher() commonIface.MatchDefinition {
+	return w.matcher
+}
+
+func (w *Website) AssetId() string {
+	return w.assetId
+}
+
+func (w *Website) Id() string {
+	return w.config.Id
+}
+
+func (w *Website) CachePrefix() string {
+	return w.matcher.Host
+}
+
+func (w *Website) Ready() error {
+	if !w.readyDone {
+		<-w.readyCtx.Done()
+	}
+
+	return w.readyError
+}
+
+func (w *Website) Close() {
+	w.instanceCtxC()
+}
+
+func (w *Website) Project() string {
+	return w.project
+}
+
+// Fulfill Serviceable interface, used to ensure TVM.New() fails if using a website
+func (w *Website) Structure() *structureSpec.Function {
+	return nil
+}
+
+func (w *Website) IsProvisioned() bool {
+	return w.provisioned
+}

--- a/protocols/substrate/components/http/website/new.go
+++ b/protocols/substrate/components/http/website/new.go
@@ -3,6 +3,7 @@ package website
 import (
 	"fmt"
 
+	"github.com/ipfs/go-cid"
 	"github.com/taubyte/go-interfaces/services/substrate/components"
 	"github.com/taubyte/go-interfaces/services/substrate/components/http"
 	"github.com/taubyte/go-interfaces/services/tns"
@@ -36,6 +37,11 @@ func New(srv components.ServiceComponent, object tns.Object, matcher *common.Mat
 	w.assetId, err = cache.ResolveAssetCid(w, w.branch)
 	if err != nil {
 		return nil, fmt.Errorf("getting website asset id failed with: %w", err)
+	}
+
+	assetCid, _ := cid.Decode(w.assetId)
+	if exists, _ := srv.Node().DAG().HasBlock(srv.Context(), assetCid); exists {
+		w.metrics.Cached += 0.3
 	}
 
 	return w, nil

--- a/protocols/substrate/components/http/website/new.go
+++ b/protocols/substrate/components/http/website/new.go
@@ -1,17 +1,17 @@
 package website
 
 import (
-	"context"
 	"fmt"
 
-	commonIface "github.com/taubyte/go-interfaces/services/substrate/components"
+	"github.com/taubyte/go-interfaces/services/substrate/components"
+	"github.com/taubyte/go-interfaces/services/substrate/components/http"
 	"github.com/taubyte/go-interfaces/services/tns"
 	"github.com/taubyte/go-specs/extract"
 	"github.com/taubyte/tau/protocols/substrate/components/http/common"
 	"github.com/taubyte/tau/vm/cache"
 )
 
-func New(srv commonIface.ServiceComponent, object tns.Object, matcher *common.MatchDefinition) (serviceable commonIface.Serviceable, err error) {
+func New(srv components.ServiceComponent, object tns.Object, matcher *common.MatchDefinition) (serviceable http.Serviceable, err error) {
 	parser, err := extract.Tns().BasicPath(object.Path().String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse tns path `%s` with: %w", object.Path().String(), err)
@@ -33,42 +33,10 @@ func New(srv commonIface.ServiceComponent, object tns.Object, matcher *common.Ma
 	}
 	w.config.Id = id
 
-	w.instanceCtx, w.instanceCtxC = context.WithCancel(srv.Context())
-	w.readyCtx, w.readyCtxC = context.WithCancel(srv.Context())
-	defer func() {
-		w.readyDone = true
-		w.readyError = err
-		w.readyCtxC()
-	}()
-
 	w.assetId, err = cache.ResolveAssetCid(w, w.branch)
 	if err != nil {
-		return nil, fmt.Errorf("getting asset id failed with: %w", err)
-	}
-
-	_w, err := srv.Cache().Add(w, w.branch)
-	if err != nil {
-		return nil, fmt.Errorf("adding website serviceable failed with: %s", err)
-	}
-
-	w.ctx, w.ctxC = context.WithCancel(w.srv.Context())
-
-	if w != _w {
-		return _w, nil
-	}
-
-	err = w.getAsset()
-	if err != nil {
-		return nil, fmt.Errorf("getting website `%s`assets failed with: %s", w.config.Name, err)
+		return nil, fmt.Errorf("getting website asset id failed with: %w", err)
 	}
 
 	return w, nil
-}
-
-func (w *Website) Ready() error {
-	if !w.readyDone {
-		<-w.readyCtx.Done()
-	}
-
-	return w.readyError
 }

--- a/protocols/substrate/components/http/website/types.go
+++ b/protocols/substrate/components/http/website/types.go
@@ -7,6 +7,7 @@ import (
 	commonIface "github.com/taubyte/go-interfaces/services/substrate/components"
 	structureSpec "github.com/taubyte/go-specs/structure"
 	"github.com/taubyte/tau/protocols/substrate/components/http/common"
+	"github.com/taubyte/tau/protocols/substrate/components/metrics"
 )
 
 type Website struct {
@@ -30,6 +31,7 @@ type Website struct {
 	readyDone  bool
 
 	provisioned bool
+	metrics     metrics.Website
 
 	instanceCtx  context.Context
 	instanceCtxC context.CancelFunc

--- a/protocols/substrate/components/http/website/types.go
+++ b/protocols/substrate/components/http/website/types.go
@@ -5,13 +5,9 @@ import (
 
 	"github.com/spf13/afero"
 	commonIface "github.com/taubyte/go-interfaces/services/substrate/components"
-	iface "github.com/taubyte/go-interfaces/services/substrate/components/http"
 	structureSpec "github.com/taubyte/go-specs/structure"
 	"github.com/taubyte/tau/protocols/substrate/components/http/common"
 )
-
-var _ commonIface.Serviceable = &Website{}
-var _ iface.Serviceable = &Website{}
 
 type Website struct {
 	srv commonIface.ServiceComponent
@@ -28,18 +24,13 @@ type Website struct {
 
 	assetId string
 
-	ctx  context.Context
-	ctxC context.CancelFunc
-
 	readyCtx   context.Context
 	readyCtxC  context.CancelFunc
 	readyError error
 	readyDone  bool
 
+	provisioned bool
+
 	instanceCtx  context.Context
 	instanceCtxC context.CancelFunc
-}
-
-func (w *Website) Close() {
-	w.instanceCtxC()
 }

--- a/protocols/substrate/components/http/website/website.go
+++ b/protocols/substrate/components/http/website/website.go
@@ -17,6 +17,7 @@ import (
 	matcherSpec "github.com/taubyte/go-specs/matcher"
 	http "github.com/taubyte/http"
 	"github.com/taubyte/tau/protocols/substrate/components/http/common"
+	"github.com/taubyte/tau/protocols/substrate/components/metrics"
 	"go4.org/readerutil"
 )
 
@@ -39,7 +40,6 @@ func (w *Website) Provision() (web httpComp.Serviceable, err error) {
 		if ok {
 			return _w, nil
 		}
-
 		// TODO: Debug Logger if this case is met
 	}
 
@@ -47,8 +47,14 @@ func (w *Website) Provision() (web httpComp.Serviceable, err error) {
 		return nil, fmt.Errorf("getting website `%s`assets failed with: %w", w.config.Name, err)
 	}
 
+	w.metrics.Cached = 1
 	w.provisioned = true
+
 	return w, nil
+}
+
+func (w *Website) Metrics() *metrics.Website {
+	return &w.metrics
 }
 
 func (w *Website) Handle(_w goHttp.ResponseWriter, r *goHttp.Request, matcher components.MatchDefinition) (t time.Time, err error) {

--- a/protocols/substrate/components/metrics/function.go
+++ b/protocols/substrate/components/metrics/function.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 )
 
-func (m *Function) Less(comp Metric) bool {
+func (m *Function) Less(comp Iface) bool {
 	switch n := comp.(type) {
 	case *Function:
 		return (m.Memory < 1 && n.Memory >= 1) || (m.Cached < n.Cached) || (m.ColdStart < n.ColdStart) || (m.AvgRunTime > n.AvgRunTime) || (m.Memory < n.Memory)

--- a/protocols/substrate/components/metrics/function.go
+++ b/protocols/substrate/components/metrics/function.go
@@ -1,0 +1,59 @@
+package metrics
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+)
+
+func (m *Function) Less(comp Metric) bool {
+	switch n := comp.(type) {
+	case *Function:
+		return (m.Memory < 1 && n.Memory >= 1) || (m.Cached < n.Cached) || (m.ColdStart < n.ColdStart) || (m.AvgRunTime > n.AvgRunTime) || (m.Memory < n.Memory)
+
+	default:
+		return false
+	}
+}
+
+func (m *Function) Encode() []byte {
+	var buf bytes.Buffer
+	binary.Write(&buf, binary.LittleEndian, EncodingVersion)
+	binary.Write(&buf, binary.LittleEndian, m.Cached)
+	binary.Write(&buf, binary.LittleEndian, m.ColdStart)
+	binary.Write(&buf, binary.LittleEndian, m.Memory)
+	binary.Write(&buf, binary.LittleEndian, m.AvgRunTime)
+	return buf.Bytes()
+}
+
+func (m *Function) Decode(b []byte) error {
+	buf := bytes.NewBuffer(b)
+
+	var encodingVersion uint8
+
+	if err := binary.Read(buf, binary.LittleEndian, &encodingVersion); err != nil {
+		return err
+	}
+
+	if encodingVersion != EncodingVersion {
+		return errors.New("version mismatch")
+	}
+
+	if err := binary.Read(buf, binary.LittleEndian, &m.Cached); err != nil {
+		return err
+	}
+
+	if err := binary.Read(buf, binary.LittleEndian, &m.ColdStart); err != nil {
+		return err
+	}
+
+	if err := binary.Read(buf, binary.LittleEndian, &m.Memory); err != nil {
+		return err
+	}
+
+	if err := binary.Read(buf, binary.LittleEndian, &m.AvgRunTime); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/protocols/substrate/components/metrics/types.go
+++ b/protocols/substrate/components/metrics/types.go
@@ -67,7 +67,7 @@ func (m Website) Decode(b []byte) error {
 func (m Function) Less(comp Iface) bool {
 	switch n := comp.(type) {
 	case Function:
-		return (m.Memory == 0 && n.Memory > 0) || (m.Cached < n.Cached) || (m.ColdStart < n.ColdStart) || (m.AvgRunTime > n.AvgRunTime) || (m.Memory < n.Memory)
+		return (m.Memory < 1 && n.Memory >= 1) || (m.Cached < n.Cached) || (m.ColdStart < n.ColdStart) || (m.AvgRunTime > n.AvgRunTime) || (m.Memory < n.Memory)
 
 	default:
 		return false

--- a/protocols/substrate/components/metrics/types.go
+++ b/protocols/substrate/components/metrics/types.go
@@ -1,10 +1,10 @@
 package metrics
 
-import (
-	"bytes"
-	"encoding/binary"
-	"errors"
-)
+/*
+****** Encoding/Decoding ******
+  - Append new metrics
+  - Don't do: Type or order change will require new EncodingVersion version
+*/
 
 type Website struct {
 	Cached float32
@@ -21,98 +21,4 @@ type Metric interface {
 	Encode() []byte
 	Decode(b []byte) error
 	Less(Metric) bool
-}
-
-// Encoding/Decoding
-//  - Append new metrics
-//  - Don't do: Type or order change will require new EncodingVersion version
-
-var EncodingVersion uint8 = 1
-
-func (m *Website) Less(comp Metric) bool {
-	switch n := comp.(type) {
-	case *Website:
-		return m.Cached < n.Cached
-	default:
-		return false
-	}
-}
-
-func (w *Website) Encode() []byte {
-	var buf bytes.Buffer
-	binary.Write(&buf, binary.LittleEndian, EncodingVersion)
-	binary.Write(&buf, binary.LittleEndian, w.Cached)
-	return buf.Bytes()
-}
-
-func (w *Website) Decode(b []byte) error {
-	buf := bytes.NewBuffer(b)
-
-	var encodingVersion uint8
-
-	if err := binary.Read(buf, binary.LittleEndian, &encodingVersion); err != nil {
-		return err
-	}
-
-	if encodingVersion != EncodingVersion {
-		return errors.New("version mismatch")
-	}
-
-	if err := binary.Read(buf, binary.LittleEndian, &w.Cached); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *Function) Less(comp Metric) bool {
-	switch n := comp.(type) {
-	case *Function:
-		return (m.Memory == 0 && n.Memory > 0) || (m.Cached < n.Cached) || (m.ColdStart < n.ColdStart) || (m.AvgRunTime > n.AvgRunTime) || (m.Memory < n.Memory)
-
-	default:
-		return false
-	}
-}
-
-func (m *Function) Encode() []byte {
-	var buf bytes.Buffer
-	binary.Write(&buf, binary.LittleEndian, EncodingVersion)
-	binary.Write(&buf, binary.LittleEndian, m.Cached)
-	binary.Write(&buf, binary.LittleEndian, m.ColdStart)
-	binary.Write(&buf, binary.LittleEndian, m.Memory)
-	binary.Write(&buf, binary.LittleEndian, m.AvgRunTime)
-	return buf.Bytes()
-}
-
-func (m *Function) Decode(b []byte) error {
-	buf := bytes.NewBuffer(b)
-
-	var encodingVersion uint8
-
-	if err := binary.Read(buf, binary.LittleEndian, &encodingVersion); err != nil {
-		return err
-	}
-
-	if encodingVersion != EncodingVersion {
-		return errors.New("version mismatch")
-	}
-
-	if err := binary.Read(buf, binary.LittleEndian, &m.Cached); err != nil {
-		return err
-	}
-
-	if err := binary.Read(buf, binary.LittleEndian, &m.ColdStart); err != nil {
-		return err
-	}
-
-	if err := binary.Read(buf, binary.LittleEndian, &m.Memory); err != nil {
-		return err
-	}
-
-	if err := binary.Read(buf, binary.LittleEndian, &m.AvgRunTime); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/protocols/substrate/components/metrics/types.go
+++ b/protocols/substrate/components/metrics/types.go
@@ -17,8 +17,8 @@ type Function struct {
 	AvgRunTime int64
 }
 
-type Metric interface {
+type Iface interface {
 	Encode() []byte
 	Decode(b []byte) error
-	Less(Metric) bool
+	Less(Iface) bool
 }

--- a/protocols/substrate/components/metrics/types.go
+++ b/protocols/substrate/components/metrics/types.go
@@ -1,0 +1,117 @@
+package metrics
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+)
+
+type Website struct {
+	Cached float32
+}
+
+type Function struct {
+	Cached     float32
+	ColdStart  int64
+	Memory     float64
+	AvgRunTime int64
+}
+
+type Iface interface {
+	Encode() []byte
+	Decode(b []byte) error
+	Less(Iface) bool
+}
+
+// Encoding/Decoding
+//  - Append new metrics
+//  - Don't do: Type or order change will require new EncodingVersion version
+
+var EncodingVersion uint8 = 1
+
+func (m Website) Less(comp Iface) bool {
+	switch n := comp.(type) {
+	case Website:
+		return m.Cached < n.Cached
+	default:
+		return false
+	}
+}
+
+func (m Website) Encode() []byte {
+	var buf bytes.Buffer
+	binary.Write(&buf, binary.LittleEndian, EncodingVersion)
+	return buf.Bytes()
+}
+
+func (m Website) Decode(b []byte) error {
+	buf := bytes.NewBuffer(b)
+
+	var encodingVersion uint8
+
+	if err := binary.Read(buf, binary.LittleEndian, &encodingVersion); err != nil {
+		return err
+	}
+
+	if encodingVersion != EncodingVersion {
+		return errors.New("version mismatch")
+	}
+
+	if err := binary.Read(buf, binary.LittleEndian, &m.Cached); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m Function) Less(comp Iface) bool {
+	switch n := comp.(type) {
+	case Function:
+		return (m.Memory == 0 && n.Memory > 0) || (m.Cached < n.Cached) || (m.ColdStart < n.ColdStart) || (m.AvgRunTime > n.AvgRunTime) || (m.Memory < n.Memory)
+
+	default:
+		return false
+	}
+}
+
+func (m Function) Encode() []byte {
+	var buf bytes.Buffer
+	binary.Write(&buf, binary.LittleEndian, EncodingVersion)
+	binary.Write(&buf, binary.LittleEndian, m.Cached)
+	binary.Write(&buf, binary.LittleEndian, m.ColdStart)
+	binary.Write(&buf, binary.LittleEndian, m.Memory)
+	binary.Write(&buf, binary.LittleEndian, m.AvgRunTime)
+	return buf.Bytes()
+}
+
+func (m Function) Decode(b []byte) error {
+	buf := bytes.NewBuffer(b)
+
+	var encodingVersion uint8
+
+	if err := binary.Read(buf, binary.LittleEndian, &encodingVersion); err != nil {
+		return err
+	}
+
+	if encodingVersion != EncodingVersion {
+		return errors.New("version mismatch")
+	}
+
+	if err := binary.Read(buf, binary.LittleEndian, &m.Cached); err != nil {
+		return err
+	}
+
+	if err := binary.Read(buf, binary.LittleEndian, &m.ColdStart); err != nil {
+		return err
+	}
+
+	if err := binary.Read(buf, binary.LittleEndian, &m.Memory); err != nil {
+		return err
+	}
+
+	if err := binary.Read(buf, binary.LittleEndian, &m.AvgRunTime); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/protocols/substrate/components/metrics/types.go
+++ b/protocols/substrate/components/metrics/types.go
@@ -17,10 +17,10 @@ type Function struct {
 	AvgRunTime int64
 }
 
-type Iface interface {
+type Metric interface {
 	Encode() []byte
 	Decode(b []byte) error
-	Less(Iface) bool
+	Less(Metric) bool
 }
 
 // Encoding/Decoding
@@ -29,22 +29,23 @@ type Iface interface {
 
 var EncodingVersion uint8 = 1
 
-func (m Website) Less(comp Iface) bool {
+func (m *Website) Less(comp Metric) bool {
 	switch n := comp.(type) {
-	case Website:
+	case *Website:
 		return m.Cached < n.Cached
 	default:
 		return false
 	}
 }
 
-func (m Website) Encode() []byte {
+func (w *Website) Encode() []byte {
 	var buf bytes.Buffer
 	binary.Write(&buf, binary.LittleEndian, EncodingVersion)
+	binary.Write(&buf, binary.LittleEndian, w.Cached)
 	return buf.Bytes()
 }
 
-func (m Website) Decode(b []byte) error {
+func (w *Website) Decode(b []byte) error {
 	buf := bytes.NewBuffer(b)
 
 	var encodingVersion uint8
@@ -57,24 +58,24 @@ func (m Website) Decode(b []byte) error {
 		return errors.New("version mismatch")
 	}
 
-	if err := binary.Read(buf, binary.LittleEndian, &m.Cached); err != nil {
+	if err := binary.Read(buf, binary.LittleEndian, &w.Cached); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (m Function) Less(comp Iface) bool {
+func (m *Function) Less(comp Metric) bool {
 	switch n := comp.(type) {
-	case Function:
-		return (m.Memory < 1 && n.Memory >= 1) || (m.Cached < n.Cached) || (m.ColdStart < n.ColdStart) || (m.AvgRunTime > n.AvgRunTime) || (m.Memory < n.Memory)
+	case *Function:
+		return (m.Memory == 0 && n.Memory > 0) || (m.Cached < n.Cached) || (m.ColdStart < n.ColdStart) || (m.AvgRunTime > n.AvgRunTime) || (m.Memory < n.Memory)
 
 	default:
 		return false
 	}
 }
 
-func (m Function) Encode() []byte {
+func (m *Function) Encode() []byte {
 	var buf bytes.Buffer
 	binary.Write(&buf, binary.LittleEndian, EncodingVersion)
 	binary.Write(&buf, binary.LittleEndian, m.Cached)
@@ -84,7 +85,7 @@ func (m Function) Encode() []byte {
 	return buf.Bytes()
 }
 
-func (m Function) Decode(b []byte) error {
+func (m *Function) Decode(b []byte) error {
 	buf := bytes.NewBuffer(b)
 
 	var encodingVersion uint8

--- a/protocols/substrate/components/metrics/vars.go
+++ b/protocols/substrate/components/metrics/vars.go
@@ -1,0 +1,3 @@
+package metrics
+
+var EncodingVersion uint8 = 1

--- a/protocols/substrate/components/metrics/website.go
+++ b/protocols/substrate/components/metrics/website.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 )
 
-func (m *Website) Less(comp Metric) bool {
+func (m *Website) Less(comp Iface) bool {
 	switch n := comp.(type) {
 	case *Website:
 		return m.Cached < n.Cached

--- a/protocols/substrate/components/metrics/website.go
+++ b/protocols/substrate/components/metrics/website.go
@@ -1,0 +1,43 @@
+package metrics
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+)
+
+func (m *Website) Less(comp Metric) bool {
+	switch n := comp.(type) {
+	case *Website:
+		return m.Cached < n.Cached
+	default:
+		return false
+	}
+}
+
+func (w *Website) Encode() []byte {
+	var buf bytes.Buffer
+	binary.Write(&buf, binary.LittleEndian, EncodingVersion)
+	binary.Write(&buf, binary.LittleEndian, w.Cached)
+	return buf.Bytes()
+}
+
+func (w *Website) Decode(b []byte) error {
+	buf := bytes.NewBuffer(b)
+
+	var encodingVersion uint8
+
+	if err := binary.Read(buf, binary.LittleEndian, &encodingVersion); err != nil {
+		return err
+	}
+
+	if encodingVersion != EncodingVersion {
+		return errors.New("version mismatch")
+	}
+
+	if err := binary.Read(buf, binary.LittleEndian, &w.Cached); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/protocols/substrate/dreamland.go
+++ b/protocols/substrate/dreamland.go
@@ -46,7 +46,7 @@ func createNodeService(ctx context.Context, config *iface.ServiceConfig) (iface.
 		return nil, err
 	}
 
-	service.nodeCounters = counters.New(service)
+	service.components.counters = counters.New(service)
 
 	return service, nil
 }

--- a/protocols/substrate/methods.go
+++ b/protocols/substrate/methods.go
@@ -21,15 +21,16 @@ func (srv *Service) Close() error {
 	}
 
 	srv.tns.Close()
+	components := srv.components
 
-	srv.nodeHttp.Close()
-	srv.nodePubSub.Close()
-	srv.nodeIpfs.Close()
-	srv.nodeDatabase.Close()
-	srv.nodeStorage.Close()
-	srv.nodeP2P.Close()
-	srv.nodeCounters.Close()
-	srv.nodeSmartOps.Close()
+	components.http.Close()
+	components.pubsub.Close()
+	components.ipfs.Close()
+	components.database.Close()
+	components.storage.Close()
+	components.p2p.Close()
+	components.counters.Close()
+	components.smartops.Close()
 
 	srv.vm.Close()
 

--- a/protocols/substrate/new.go
+++ b/protocols/substrate/new.go
@@ -6,29 +6,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path"
 
 	"github.com/ipfs/go-log/v2"
-	"github.com/taubyte/go-interfaces/services/substrate/components"
 	"github.com/taubyte/go-interfaces/vm"
 	"github.com/taubyte/go-seer"
-	"github.com/taubyte/tau/clients/p2p/substrate"
 	tnsClient "github.com/taubyte/tau/clients/p2p/tns"
 	tauConfig "github.com/taubyte/tau/config"
 	"github.com/taubyte/tau/pkgs/kvdb"
-	"github.com/taubyte/tau/vm/helpers"
-	"github.com/taubyte/utils/maps"
 	orbit "github.com/taubyte/vm-orbit/plugin/vm"
 
-	con "github.com/taubyte/p2p/streams"
-	"github.com/taubyte/p2p/streams/command"
-	"github.com/taubyte/p2p/streams/command/response"
-	streams "github.com/taubyte/p2p/streams/service"
-	httptun "github.com/taubyte/p2p/streams/tunnels/http"
 	protocolCommon "github.com/taubyte/tau/protocols/common"
-	http "github.com/taubyte/tau/protocols/substrate/components/http/common"
 	smartopsPlugins "github.com/taubyte/vm-core-plugins/smartops"
 	tbPlugins "github.com/taubyte/vm-core-plugins/taubyte"
 )
@@ -157,54 +146,4 @@ func New(ctx context.Context, config *tauConfig.Node) (*Service, error) {
 	}
 
 	return srv, nil
-}
-
-func (s *Service) startStream() (err error) {
-	if s.stream, err = streams.New(s.node, protocolCommon.Substrate, protocolCommon.SubstrateProtocol); err != nil {
-		return fmt.Errorf("new stream failed with: %w", err)
-	}
-
-	if err := s.stream.DefineStream(substrate.CommandHTTP, s.proxyHttp, s.tunnelHttp); err != nil {
-		return fmt.Errorf("defining command `%s` failed with: %w", substrate.CommandHTTP, err)
-	}
-
-	return
-}
-
-func (s *Service) tunnelHttp(ctx context.Context, rw io.ReadWriter) {
-	w, r, err := httptun.Backend(rw)
-	if err != nil {
-		fmt.Fprintf(rw, "Status: %d\nerror: %s", 500, err.Error())
-		return
-	}
-
-	s.nodeHttp.Handler(w, r)
-}
-
-func (s *Service) proxyHttp(ctx context.Context, con con.Connection, body command.Body) (response.Response, error) {
-	host, err := maps.String(body, substrate.BodyHost)
-	if err != nil {
-		return nil, err
-	}
-
-	path, err := maps.String(body, substrate.BodyPath)
-	if err != nil {
-		return nil, err
-	}
-
-	method, err := maps.String(body, substrate.BodyMethod)
-	if err != nil {
-		return nil, err
-	}
-
-	response := make(map[string]interface{})
-	response[substrate.ResponseCached] = false
-
-	matcher := http.New(helpers.ExtractHost(host), path, method)
-	servs, err := s.nodeHttp.Cache().Get(matcher, components.GetOptions{Validation: true})
-	if err == nil && len(servs) > 0 {
-		response[substrate.ResponseCached] = true
-	}
-
-	return response, nil
 }

--- a/protocols/substrate/nodes.go
+++ b/protocols/substrate/nodes.go
@@ -64,12 +64,12 @@ func (srv *Service) attachNodes(config *config.Node) (err error) {
 }
 
 func (srv *Service) attachNodeHttp(config *config.Node) (err error) {
-	srv.nodeHttp, err = http.New(srv, http.DvKey(config.DomainValidation.PublicKey))
+	srv.components.http, err = http.New(srv, http.DvKey(config.DomainValidation.PublicKey))
 	return
 }
 
 func (srv *Service) attachNodePubSub() (err error) {
-	srv.nodePubSub, err = pubSub.New(srv)
+	srv.components.pubsub, err = pubSub.New(srv)
 	return
 }
 
@@ -81,31 +81,31 @@ func (srv *Service) attachNodeIpfs(config *config.Node) (err error) {
 
 	}
 
-	srv.nodeIpfs, err = ipfs.New(srv.node.Context(), ipfs.Public(), ipfs.Listen([]string{fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", ipfsPort)}))
+	srv.components.ipfs, err = ipfs.New(srv.node.Context(), ipfs.Public(), ipfs.Listen([]string{fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", ipfsPort)}))
 	return
 }
 
 func (srv *Service) attachNodeDatabase() (err error) {
-	srv.nodeDatabase, err = database.New(srv, srv.databases)
+	srv.components.database, err = database.New(srv, srv.databases)
 	return
 }
 
 func (srv *Service) attachNodeStorage() (err error) {
-	srv.nodeStorage, err = storage.New(srv, srv.databases)
+	srv.components.storage, err = storage.New(srv, srv.databases)
 	return
 }
 
 func (srv *Service) attachNodeP2P() (err error) {
-	srv.nodeP2P, err = p2p.New(srv)
+	srv.components.p2p, err = p2p.New(srv)
 	return
 }
 
 func (srv *Service) attachNodeCounters() (err error) {
-	srv.nodeCounters, err = counters.New(srv)
+	srv.components.counters, err = counters.New(srv)
 	return
 }
 
 func (srv *Service) attachNodeSmartOps() (err error) {
-	srv.nodeSmartOps, err = smartOps.New(srv)
+	srv.components.smartops, err = smartOps.New(srv)
 	return
 }

--- a/protocols/substrate/stream.go
+++ b/protocols/substrate/stream.go
@@ -81,19 +81,21 @@ func (s *Service) proxyHttp(ctx context.Context, con con.Connection, body comman
 		case *function.Function:
 			//serviceable := servs[0].(*function.Function)
 			cnf := serviceable.Config()
-
-			_mem := cnf.Memory
 			shadows := serviceable.Shadows()
-			if maxMem := uint64(shadows.MemoryMax()); maxMem < cnf.Memory {
-				_mem = maxMem
-			}
-			response["mem"] = float64(mem.Free) / float64(_mem)
 
 			if serviceable.Shadows().Count() > 1 {
 				response["cold-start"] = 0
 			} else {
 				response["cold-start"] = shadows.ColdStartAverage()
+				response["cold-start-mem"] = shadows
 			}
+
+			_mem := cnf.Memory
+
+			if maxMem := uint64(shadows.MemoryMax()); maxMem < cnf.Memory {
+				_mem = maxMem
+			}
+			response["mem"] = float64(mem.Free) / float64(_mem)
 
 			response["cpu-usage"] = 0.5                             // os cpu usage
 			response["average-run"] = serviceable.CallTimeAverage() // how long it takes to run on average

--- a/protocols/substrate/stream.go
+++ b/protocols/substrate/stream.go
@@ -83,15 +83,16 @@ func (s *Service) proxyHttp(ctx context.Context, con con.Connection, body comman
 			cnf := serviceable.Config()
 
 			_mem := cnf.Memory
-			if serviceable.MemoryMax() < cnf.Memory {
-				_mem = serviceable.MemoryMax()
+			shadows := serviceable.Shadows()
+			if maxMem := uint64(shadows.MemoryMax()); maxMem < cnf.Memory {
+				_mem = maxMem
 			}
 			response["mem"] = float64(mem.Free) / float64(_mem)
 
 			if serviceable.Shadows().Count() > 1 {
 				response["cold-start"] = 0
 			} else {
-				response["cold-start"] = serviceable.ColdStartAverage()
+				response["cold-start"] = shadows.ColdStartAverage()
 			}
 
 			response["cpu-usage"] = 0.5                             // os cpu usage

--- a/protocols/substrate/stream.go
+++ b/protocols/substrate/stream.go
@@ -1,0 +1,118 @@
+package substrate
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/taubyte/go-interfaces/services/substrate/components"
+	con "github.com/taubyte/p2p/streams"
+	"github.com/taubyte/p2p/streams/command"
+	"github.com/taubyte/p2p/streams/command/response"
+	streams "github.com/taubyte/p2p/streams/service"
+	httptun "github.com/taubyte/p2p/streams/tunnels/http"
+	"github.com/taubyte/tau/clients/p2p/seer/usage"
+	"github.com/taubyte/tau/clients/p2p/substrate"
+	protocolCommon "github.com/taubyte/tau/protocols/common"
+	http "github.com/taubyte/tau/protocols/substrate/components/http/common"
+	"github.com/taubyte/tau/protocols/substrate/components/http/function"
+	"github.com/taubyte/tau/protocols/substrate/components/http/website"
+	"github.com/taubyte/tau/vm/helpers"
+	"github.com/taubyte/utils/maps"
+)
+
+func (s *Service) startStream() (err error) {
+	if s.stream, err = streams.New(s.node, protocolCommon.Substrate, protocolCommon.SubstrateProtocol); err != nil {
+		return fmt.Errorf("new stream failed with: %w", err)
+	}
+
+	if err := s.stream.DefineStream(substrate.CommandHTTP, s.proxyHttp, s.tunnelHttp); err != nil {
+		return fmt.Errorf("defining command `%s` failed with: %w", substrate.CommandHTTP, err)
+	}
+
+	return
+}
+
+func (s *Service) tunnelHttp(ctx context.Context, rw io.ReadWriter) {
+	w, r, err := httptun.Backend(rw)
+	if err != nil {
+		fmt.Fprintf(rw, "Status: %d\nerror: %s", 500, err.Error())
+		return
+	}
+
+	s.nodeHttp.Handler(w, r)
+}
+
+func (s *Service) proxyHttp(ctx context.Context, con con.Connection, body command.Body) (response.Response, error) {
+	host, err := maps.String(body, substrate.BodyHost)
+	if err != nil {
+		return nil, err
+	}
+
+	path, err := maps.String(body, substrate.BodyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	method, err := maps.String(body, substrate.BodyMethod)
+	if err != nil {
+		return nil, err
+	}
+
+	mem, err := usage.GetMemoryUsage()
+	if err != nil {
+		return nil, fmt.Errorf("getting memory usage failed with: %w", err)
+	}
+
+	response := map[string]interface{}{substrate.ResponseCached: false}
+
+	matcher := http.New(helpers.ExtractHost(host), path, method)
+	servs, _ := s.nodeHttp.Cache().Get(matcher, components.GetOptions{Validation: true})
+	// ignoring error as the only way we get an error if is we have no servisable
+	if len(servs) == 0 {
+		// not cached
+		// ---> look up with tns and get config
+		response["cold-start"] = -1
+		response["average-run"] = -1
+	} else {
+		// cached
+		// note: in http there's only one possible servisable so we pick [0]
+		switch servisable := servs[0].(type) {
+		case *function.Function:
+			//servisable := servs[0].(*function.Function)
+			cnf := servisable.Config()
+
+			_mem := cnf.Memory
+			if servisable.MemoryMax() < cnf.Memory {
+				_mem = servisable.MemoryMax()
+			}
+			response["mem"] = float64(mem.Free) / float64(_mem)
+
+			if servisable.Shadows().Count() > 1 {
+				response["cold-start"] = 0
+			} else {
+				response["cold-start"] = servisable.ColdStartAverage()
+			}
+
+			response["cpu-usage"] = 0.5                            // os cpu usage
+			response["average-run"] = servisable.CallTimeAverage() // how long it takes to run on average
+		case *website.Website:
+			// TODO
+		}
+
+	}
+	// if err == nil && len(servs) == 1 {
+	// 	response[substrate.ResponseCached] = true
+	// 	if fServ, ok := servs[0].(*function.Function); ok {
+	// 		response["required"] = fServ.Config().Memory
+	// 	} else {
+	// 		// figure out memory required for website
+	// 	}
+	// }
+
+	// response["used"] = mem.Used
+	// response["total"] = mem.Total
+	// response["free"] = mem.Free
+
+	return response, nil
+}

--- a/protocols/substrate/stream.go
+++ b/protocols/substrate/stream.go
@@ -6,6 +6,8 @@ import (
 	"io"
 
 	compIface "github.com/taubyte/go-interfaces/services/substrate/components"
+	functionSpec "github.com/taubyte/go-specs/function"
+	websiteSpec "github.com/taubyte/go-specs/website"
 	con "github.com/taubyte/p2p/streams"
 	"github.com/taubyte/p2p/streams/command"
 	"github.com/taubyte/p2p/streams/command/response"
@@ -90,9 +92,9 @@ func (s *Service) proxyHttp(ctx context.Context, con con.Connection, body comman
 
 	switch serviceable := pick.(type) {
 	case *function.Function:
-		response["function"] = serviceable.Metrics().Encode()
+		response[functionSpec.PathVariable.String()] = serviceable.Metrics().Encode()
 	case *website.Website:
-		response["website"] = serviceable.Metrics().Encode()
+		response[websiteSpec.PathVariable.String()] = serviceable.Metrics().Encode()
 	default:
 		return nil, fmt.Errorf("unknown serviceable type")
 	}

--- a/protocols/substrate/stream.go
+++ b/protocols/substrate/stream.go
@@ -16,6 +16,7 @@ import (
 	http "github.com/taubyte/tau/protocols/substrate/components/http/common"
 	"github.com/taubyte/tau/protocols/substrate/components/http/function"
 	"github.com/taubyte/tau/protocols/substrate/components/http/website"
+	"github.com/taubyte/tau/protocols/substrate/components/metrics"
 	"github.com/taubyte/utils/maps"
 )
 
@@ -93,9 +94,10 @@ func (s *Service) proxyHttp(ctx context.Context, con con.Connection, body comman
 
 	switch serviceable := pick.(type) {
 	case *function.Function:
-		response["metrics"], err = serviceable.Metrics()
+		response["function"] = serviceable.Metrics().Encode()
 	case *website.Website:
-		response["metrics"], err = serviceable.Metrics()
+		// TODO
+		response["website"] = metrics.Website{}.Encode()
 	default:
 		return nil, fmt.Errorf("unknown serviceable type")
 	}

--- a/protocols/substrate/stream.go
+++ b/protocols/substrate/stream.go
@@ -68,7 +68,7 @@ func (s *Service) proxyHttp(ctx context.Context, con con.Connection, body comman
 
 	matcher := http.New(helpers.ExtractHost(host), path, method)
 	servs, _ := s.nodeHttp.Cache().Get(matcher, components.GetOptions{Validation: true})
-	// ignoring error as the only way we get an error if is we have no servisable
+	// ignoring error as the only way we get an error if is we have no serviceable
 	if len(servs) == 0 {
 		// not cached
 		// ---> look up with tns and get config
@@ -77,25 +77,25 @@ func (s *Service) proxyHttp(ctx context.Context, con con.Connection, body comman
 	} else {
 		// cached
 		// note: in http there's only one possible servisable so we pick [0]
-		switch servisable := servs[0].(type) {
+		switch serviceable := servs[0].(type) {
 		case *function.Function:
-			//servisable := servs[0].(*function.Function)
-			cnf := servisable.Config()
+			//serviceable := servs[0].(*function.Function)
+			cnf := serviceable.Config()
 
 			_mem := cnf.Memory
-			if servisable.MemoryMax() < cnf.Memory {
-				_mem = servisable.MemoryMax()
+			if serviceable.MemoryMax() < cnf.Memory {
+				_mem = serviceable.MemoryMax()
 			}
 			response["mem"] = float64(mem.Free) / float64(_mem)
 
-			if servisable.Shadows().Count() > 1 {
+			if serviceable.Shadows().Count() > 1 {
 				response["cold-start"] = 0
 			} else {
-				response["cold-start"] = servisable.ColdStartAverage()
+				response["cold-start"] = serviceable.ColdStartAverage()
 			}
 
-			response["cpu-usage"] = 0.5                            // os cpu usage
-			response["average-run"] = servisable.CallTimeAverage() // how long it takes to run on average
+			response["cpu-usage"] = 0.5                             // os cpu usage
+			response["average-run"] = serviceable.CallTimeAverage() // how long it takes to run on average
 		case *website.Website:
 			// TODO
 		}

--- a/protocols/substrate/stream.go
+++ b/protocols/substrate/stream.go
@@ -16,7 +16,6 @@ import (
 	http "github.com/taubyte/tau/protocols/substrate/components/http/common"
 	"github.com/taubyte/tau/protocols/substrate/components/http/function"
 	"github.com/taubyte/tau/protocols/substrate/components/http/website"
-	"github.com/taubyte/tau/protocols/substrate/components/metrics"
 	"github.com/taubyte/utils/maps"
 )
 
@@ -89,15 +88,11 @@ func (s *Service) proxyHttp(ctx context.Context, con con.Connection, body comman
 		pick = serviceables[0]
 	}
 
-	// response[substrate.ResponseCpuCount] = s.cpuCount
-	// response[substrate.ResponseAverageCpu] = s.cpuAverage
-
 	switch serviceable := pick.(type) {
 	case *function.Function:
 		response["function"] = serviceable.Metrics().Encode()
 	case *website.Website:
-		// TODO
-		response["website"] = metrics.Website{}.Encode()
+		response["website"] = serviceable.Metrics().Encode()
 	default:
 		return nil, fmt.Errorf("unknown serviceable type")
 	}

--- a/protocols/substrate/stream.go
+++ b/protocols/substrate/stream.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ipfs/go-cid"
 	compIface "github.com/taubyte/go-interfaces/services/substrate/components"
 	httpComp "github.com/taubyte/go-interfaces/services/substrate/components/http"
 	con "github.com/taubyte/p2p/streams"
@@ -13,12 +12,10 @@ import (
 	"github.com/taubyte/p2p/streams/command/response"
 	streams "github.com/taubyte/p2p/streams/service"
 	httptun "github.com/taubyte/p2p/streams/tunnels/http"
-	"github.com/taubyte/tau/clients/p2p/seer/usage"
 	"github.com/taubyte/tau/clients/p2p/substrate"
 	protocolCommon "github.com/taubyte/tau/protocols/common"
 	http "github.com/taubyte/tau/protocols/substrate/components/http/common"
 	"github.com/taubyte/tau/protocols/substrate/components/http/function"
-	"github.com/taubyte/tau/protocols/substrate/components/http/website"
 	"github.com/taubyte/utils/maps"
 )
 
@@ -73,18 +70,18 @@ func (s *Service) proxyHttp(ctx context.Context, con con.Connection, body comman
 		return nil, fmt.Errorf("parsing matcher failed with: %w", err)
 	}
 
-	mem, err := usage.GetMemoryUsage()
-	if err != nil {
-		return nil, fmt.Errorf("getting memory usage failed with: %w", err)
-	}
+	// mem, err := usage.GetMemoryUsage()
+	// if err != nil {
+	// 	return nil, fmt.Errorf("getting memory usage failed with: %w", err)
+	// }
 
 	response := make(map[string]interface{})
-	var (
-		cached    float64 // 0-1
-		coldStart int64   // nanoseconds
-		runTime   int64   // nanosecond
-		maxMemory int64   //retrieved from cached serviceable or config
-	)
+	// var (
+	// 	cached    float64 // 0-1
+	// 	coldStart int64   // nanoseconds
+	// 	runTime   int64   // nanosecond
+	// 	maxMemory int64   //retrieved from cached serviceable or config
+	// )
 
 	httpComponent := s.components.http
 	serviceables, _ := httpComponent.Cache().Get(
@@ -92,56 +89,76 @@ func (s *Service) proxyHttp(ctx context.Context, con con.Connection, body comman
 		compIface.GetOptions{Validation: true},
 	)
 
-	switch len(serviceables) {
-	case http.NoMatch: // serviceable not cached
-		coldStart = -1
-		runTime = -1
-		match, err := s.components.http.Lookup(&http.MatchDefinition{Request: request})
+	var pick httpComp.Serviceable
+
+	if len(serviceables) == 0 {
+		pick, err = s.components.http.Lookup(&http.MatchDefinition{Request: request})
 		if err != nil {
 			return nil, fmt.Errorf("lookup failed with: %w", err)
 		}
-
-		switch serviceable := match.(type) {
-		case httpComp.Function:
-			maxMemory = int64(serviceable.Config().Memory)
-		case httpComp.Website:
-		default:
-			return nil, fmt.Errorf("unknown serviceable type")
-		}
-
-		assetCid, _ := cid.Decode(match.AssetId())
-		if exists, _ := s.node.DAG().HasBlock(s.ctx, assetCid); exists {
-			cached += 0.3
-		}
-
-		// TODO: look up dht
-
-	case http.ValidMatch: // serviceable is cached
-		cached = 1
-		switch serviceable := serviceables[0].(type) {
-		case *function.Function:
-			struct{cs,ct,mem} := serviceable.Metrics()
-			// // ShadowCount()
-			// if serviceable.Shadows().Count() < 1 {
-			// 	coldStart = serviceable.ColdStart().Nanoseconds()
-			// }
-			// cached = 1
-			// maxMemory = serviceable.MemoryMax()
-			// runTime = serviceable.CallTime().Nanoseconds()
-		case *website.Website:
-			// TODO
-		}
-
-	default: // internal error
-		return nil, fmt.Errorf("invalid # of matches: %d", len(serviceables))
+	} else {
+		pick = serviceables[0]
 	}
 
-	response[substrate.ResponseCached] = cached
-	response[substrate.ResponseAverageRun] = runTime
-	response[substrate.ResponseColdStart] = coldStart
+	// case http.NoMatch: // serviceable not cached
+	// 	coldStart = -1
+	// 	runTime = -1
+	// 	match, err := s.components.http.Lookup(&http.MatchDefinition{Request: request})
+	// 	if err != nil {
+	// 		return nil, fmt.Errorf("lookup failed with: %w", err)
+	// 	}
+
+	// 	switch serviceable := match.(type) {
+	// 	case *function.Function:
+	// 		maxMemory = int64(serviceable.Config().Memory)
+	// 	case httpComp.Website:
+	// 	default:
+	// 		return nil, fmt.Errorf("unknown serviceable type")
+	// 	}
+
+	// 	assetCid, _ := cid.Decode(match.AssetId())
+	// 	if exists, _ := s.node.DAG().HasBlock(s.ctx, assetCid); exists {
+	// 		cached += 0.3
+	// 	}
+
+	// 	// TODO: look up dht
+
+	// case http.ValidMatch: // serviceable is cached
+	// 	cached = 1
+	// 	switch serviceable := serviceables[0].(type) {
+	// 	case *function.Function:
+	// 		struct{cs,ct,mem} := serviceable.Metrics()
+	// 		// // ShadowCount()
+	// 		// if serviceable.Shadows().Count() < 1 {
+	// 		// 	coldStart = serviceable.ColdStart().Nanoseconds()
+	// 		// }
+	// 		// cached = 1
+	// 		// maxMemory = serviceable.MemoryMax()
+	// 		// runTime = serviceable.CallTime().Nanoseconds()
+	// 	case *website.Website:
+	// 		// TODO
+	// 	}
+
+	// default: // internal error
+	// 	return nil, fmt.Errorf("invalid # of matches: %d", len(serviceables))
+	// }
+
+	// response[substrate.ResponseCached] = cached
+	// response[substrate.ResponseAverageRun] = runTime
+	// response[substrate.ResponseColdStart] = coldStart
+	// response[substrate.ResponseMemory] = float64(mem.Free) / float64(maxMemory)
+	// response[substrate.ResponseCpuCount] = s.cpuCount
+	// response[substrate.ResponseAverageCpu] = s.cpuAverage
+
+	switch serviceable := pick.(type) {
+	case *function.Function:
+		response["metrics"] = serviceables.Metrics()
+	case httpComp.Website:
+	default:
+		return nil, fmt.Errorf("unknown serviceable type")
+	}
+
 	response[substrate.ResponseMemory] = float64(mem.Free) / float64(maxMemory)
-	response[substrate.ResponseCpuCount] = s.cpuCount
-	response[substrate.ResponseAverageCpu] = s.cpuAverage
 
 	return response, nil
 }

--- a/protocols/substrate/type.go
+++ b/protocols/substrate/type.go
@@ -26,27 +26,36 @@ type Config struct {
 	config.Node `yaml:"z,omitempty"`
 }
 
-// TODO: Node shouldn't have to have all components
+// TODO: Node shouldn't have to have all
 type Service struct {
-	ctx          context.Context
-	node         peer.Node
-	http         http.Service
-	vm           vm.Service
-	nodeHttp     *httpIface.Service
-	nodePubSub   pubSubIface.Service
-	nodeIpfs     ipfsIface.Service
-	nodeDatabase databaseIface.Service
-	nodeStorage  storageIface.Service
-	nodeP2P      p2pIface.Service
-	nodeCounters iface.CounterService
-	nodeSmartOps iface.SmartOpsService
-	dev          bool
-	verbose      bool
-	databases    kvdb.Factory
-	stream       *streams.CommandService
+	ctx        context.Context
+	node       peer.Node
+	http       http.Service
+	vm         vm.Service
+	components components
+
+	dev       bool
+	verbose   bool
+	databases kvdb.Factory
+	stream    *streams.CommandService
 
 	tns      tns.Client
 	orbitals []vm.Plugin
+
+	cpuCount   int
+	cpuAverage float64
+}
+
+// TODO: All of these components interfaces can be removed
+type components struct {
+	http     *httpIface.Service
+	pubsub   pubSubIface.Service
+	ipfs     ipfsIface.Service
+	database databaseIface.Service
+	storage  storageIface.Service
+	p2p      p2pIface.Service
+	counters iface.CounterService
+	smartops iface.SmartOpsService
 }
 
 func (n *Service) Context() context.Context {
@@ -66,11 +75,11 @@ func (s *Service) Http() http.Service {
 }
 
 func (s *Service) Counter() iface.CounterService {
-	return s.nodeCounters
+	return s.components.counters
 }
 
 func (s *Service) SmartOps() iface.SmartOpsService {
-	return s.nodeSmartOps
+	return s.components.smartops
 }
 
 func (s *Service) Tns() tns.Client {
@@ -78,5 +87,5 @@ func (s *Service) Tns() tns.Client {
 }
 
 func (s *Service) P2P() p2pIface.Service {
-	return s.nodeP2P
+	return s.components.p2p
 }

--- a/vm/cache/helpers.go
+++ b/vm/cache/helpers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/taubyte/go-specs/methods"
 )
 
+// TODO: This should return a cid.Cid
 func ResolveAssetCid(serviceable iface.Serviceable, branch string) (string, error) {
 	assetPath, err := methods.GetTNSAssetPath(serviceable.Project(), serviceable.Id(), branch)
 	if err != nil {

--- a/vm/call.go
+++ b/vm/call.go
@@ -40,7 +40,7 @@ func (f *Function) Call(runtime vm.Runtime, id uint32) (err error) {
 	if f.serviceable.Service().Verbose() {
 		defer f.printRuntimeStack(runtime, err)
 	}
-	if mem := int64(module.Memory().Size()); mem > f.maxMemory.Load() {
+	if mem := uint64(module.Memory().Size()); mem > f.maxMemory.Load() {
 		f.maxMemory.Store(mem)
 	}
 	if err != nil {

--- a/vm/call.go
+++ b/vm/call.go
@@ -14,7 +14,7 @@ func (f *Function) Call(runtime vm.Runtime, id uint32) (err error) {
 	defer func() {
 		if dur, maxAlloc := metric.stop(); err == nil {
 			f.shadows.calls.totalCount.Add(1)
-			f.shadows.calls.maxMemory.Swap(maxAlloc)
+			f.shadows.calls.maxMemory.Store(maxAlloc)
 			f.shadows.calls.totalTime.Add(int64(dur))
 		}
 	}()

--- a/vm/instantiate.go
+++ b/vm/instantiate.go
@@ -30,7 +30,7 @@ func (f *Function) instantiate() (runtime vm.Runtime, pluginApi interface{}, err
 	defer func() {
 		if dur, maxAlloc := metric.stop(); err == nil {
 			f.shadows.coldStart.totalCount.Add(1)
-			f.shadows.coldStart.maxMemory.Swap(maxAlloc)
+			f.shadows.coldStart.maxMemory.Store(maxAlloc)
 			f.shadows.coldStart.totalTime.Add(int64(dur))
 		}
 	}()

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -1,0 +1,26 @@
+package vm
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+func (f *Function) averageDuration(duration *atomic.Int64, count *atomic.Int64) time.Duration {
+	if n := count.Load(); n > 0 {
+		return time.Duration(duration.Load() / n)
+	}
+
+	return 0
+}
+
+func (f *Function) ColdStart() time.Duration {
+	return f.averageDuration(f.totalColdStart, f.coldStarts)
+}
+
+func (f *Function) MemoryMax() int64 {
+	return f.maxMemory.Load()
+}
+
+func (f *Function) CallTime() time.Duration {
+	return f.averageDuration(f.totalCallTime, f.calls)
+}

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -5,9 +5,9 @@ import (
 	"time"
 )
 
-func (f *Function) averageDuration(duration *atomic.Int64, count *atomic.Int64) time.Duration {
+func (f *Function) averageDuration(duration *atomic.Int64, count *atomic.Uint64) time.Duration {
 	if n := count.Load(); n > 0 {
-		return time.Duration(duration.Load() / n)
+		return time.Duration(duration.Load() / int64(n))
 	}
 
 	return 0
@@ -17,8 +17,9 @@ func (f *Function) ColdStart() time.Duration {
 	return f.averageDuration(f.totalColdStart, f.coldStarts)
 }
 
-func (f *Function) MemoryMax() int64 {
-	return f.maxMemory.Load()
+func (f *Function) MemoryMax() uint64 {
+
+	return uint64(f.maxMemory.Load())
 }
 
 func (f *Function) CallTime() time.Duration {

--- a/vm/new.go
+++ b/vm/new.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ipfs/go-log/v2"
 	components "github.com/taubyte/go-interfaces/services/substrate/components"
 )
+
+var logger = log.Logger("substrate.service.vm")
 
 func New(ctx context.Context, serviceable components.FunctionServiceable, branch, commit string) (*Function, error) {
 	if config := serviceable.Config(); config != nil {

--- a/vm/new.go
+++ b/vm/new.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/ipfs/go-log/v2"
 	components "github.com/taubyte/go-interfaces/services/substrate/components"
@@ -13,11 +14,16 @@ var logger = log.Logger("substrate.service.vm")
 func New(ctx context.Context, serviceable components.FunctionServiceable, branch, commit string) (*Function, error) {
 	if config := serviceable.Config(); config != nil {
 		dFunc := &Function{
-			serviceable: serviceable,
-			ctx:         ctx,
-			config:      config,
-			branch:      branch,
-			commit:      commit,
+			serviceable:    serviceable,
+			ctx:            ctx,
+			config:         config,
+			branch:         branch,
+			commit:         commit,
+			coldStarts:     new(atomic.Int64),
+			totalColdStart: new(atomic.Int64),
+			calls:          new(atomic.Int64),
+			totalCallTime:  new(atomic.Int64),
+			maxMemory:      new(atomic.Int64),
 		}
 
 		dFunc.initShadow()

--- a/vm/new.go
+++ b/vm/new.go
@@ -19,12 +19,14 @@ func New(ctx context.Context, serviceable components.FunctionServiceable, branch
 			config:         config,
 			branch:         branch,
 			commit:         commit,
-			coldStarts:     new(atomic.Int64),
+			coldStarts:     new(atomic.Uint64),
 			totalColdStart: new(atomic.Int64),
-			calls:          new(atomic.Int64),
+			calls:          new(atomic.Uint64),
 			totalCallTime:  new(atomic.Int64),
-			maxMemory:      new(atomic.Int64),
+			maxMemory:      new(atomic.Uint64),
 		}
+
+		dFunc.maxMemory.Store(uint64(serviceable.Config().Memory))
 
 		dFunc.initShadow()
 

--- a/vm/shadow.go
+++ b/vm/shadow.go
@@ -36,7 +36,7 @@ func (f *Function) initShadow() {
 			select {
 			case <-coolDown.C:
 				if errCount := f.shadows.errors.Load(); errCount > 0 {
-					f.shadows.errors.Swap(errCount / 2)
+					f.shadows.errors.Store(errCount / 2)
 				}
 			case <-ticker.C:
 				f.shadows.gc()
@@ -92,7 +92,7 @@ func (s *Shadows) gc() {
 	now := time.Now()
 	shadowInstances := make([]*shadowInstance, 0, InstanceMaxRequests)
 	defer func() {
-		s.available.Swap(0)
+		s.available.Store(0)
 		for _, instance := range shadowInstances {
 			s.instances <- instance
 			s.available.Add(1)
@@ -195,4 +195,8 @@ func (m *Metrics) DurationAverage() time.Duration {
 
 func (m *Metrics) MemoryMax() int64 {
 	return m.maxMemory.Load()
+}
+
+func (s *Shadows) Errors() int64 {
+	return s.errors.Load()
 }

--- a/vm/shadow.go
+++ b/vm/shadow.go
@@ -4,19 +4,20 @@ import (
 	"context"
 	"sync"
 	"time"
-
-	"github.com/ipfs/go-log/v2"
 )
 
-var logger = log.Logger("substrate.service.vm")
+func (f *Function) Shadows() *Shadows {
+	return f.shadows
+}
 
 func (f *Function) initShadow() {
-	f.shadows = shadows{
+	f.shadows = &Shadows{
 		instances: make(chan *shadowInstance, InstanceMaxRequests),
 		more:      make(chan struct{}, 1),
 		parent:    f,
 	}
 	f.shadows.ctx, f.shadows.ctxC = context.WithCancel(f.ctx)
+
 	ticker := time.NewTicker(ShadowCleanInterval)
 	coolDown := time.NewTicker(InstanceErrorCoolDown)
 	go func() {
@@ -27,6 +28,7 @@ func (f *Function) initShadow() {
 
 			f.serviceable.Service().Cache().Remove(f.serviceable)
 		}()
+
 		var errCount int
 		for {
 			select {
@@ -55,6 +57,7 @@ func (f *Function) initShadow() {
 							case <-f.shadows.ctx.Done():
 								return
 							case f.shadows.instances <- shadow:
+								f.shadows.count.Add(1)
 							}
 						}
 					}()
@@ -68,10 +71,11 @@ func (f *Function) initShadow() {
 	}()
 }
 
-func (s *shadows) get() (*shadowInstance, error) {
+func (s *Shadows) get() (*shadowInstance, error) {
 	select {
 	case next := <-s.instances:
 		defer s.keep()
+		s.count.Add(-1)
 		return next, nil
 	default:
 		i, err := s.newInstance()
@@ -82,12 +86,14 @@ func (s *shadows) get() (*shadowInstance, error) {
 	}
 }
 
-func (s *shadows) gc() {
+func (s *Shadows) gc() {
 	now := time.Now()
 	shadowInstances := make([]*shadowInstance, 0, InstanceMaxRequests)
 	defer func() {
+		s.count.Swap(0)
 		for _, instance := range shadowInstances {
 			s.instances <- instance
+			s.count.Add(1)
 		}
 	}()
 
@@ -103,14 +109,14 @@ func (s *shadows) gc() {
 	}
 }
 
-func (s *shadows) keep() {
+func (s *Shadows) keep() {
 	select {
 	case s.more <- struct{}{}: // Send if not blocking
 	default:
 	}
 }
 
-func (s *shadows) newInstance() (*shadowInstance, error) {
+func (s *Shadows) newInstance() (*shadowInstance, error) {
 	runtime, pluginApi, err := s.parent.instantiate()
 	if err != nil {
 		return nil, err
@@ -121,4 +127,8 @@ func (s *shadows) newInstance() (*shadowInstance, error) {
 		runtime:   runtime,
 		pluginApi: pluginApi,
 	}, nil
+}
+
+func (s *Shadows) Count() int64 {
+	return s.count.Load()
 }

--- a/vm/shadows_test.go
+++ b/vm/shadows_test.go
@@ -274,7 +274,7 @@ func TestMetrics(t *testing.T) {
 	assert.NilError(t, err)
 
 	assert.Equal(t, vmModule.ColdStart(), time.Duration(0))
-	assert.Equal(t, vmModule.MemoryMax(), int64(0))
+	assert.Equal(t, vmModule.MemoryMax(), uint64(0))
 
 	_, _, err = vmModule.Instantiate()
 	assert.NilError(t, err)
@@ -287,5 +287,5 @@ func TestMetrics(t *testing.T) {
 	// average cold start should be at least as long as delay
 	assert.Assert(t, vmModule.ColdStart() >= runtimeCreationDelay)
 	// # of cold starts should be equal to shadowBuff(shadows created) +1 (instantiate request)
-	assert.Equal(t, vmModule.coldStarts.Load(), int64(ShadowBuff)+1)
+	assert.Equal(t, vmModule.coldStarts.Load(), uint64(ShadowBuff)+1)
 }

--- a/vm/types.go
+++ b/vm/types.go
@@ -32,12 +32,12 @@ type Function struct {
 	errorCount atomic.Int64
 
 	// gateway metrics
-	coldStarts     *atomic.Int64
+	coldStarts     *atomic.Uint64
 	totalColdStart *atomic.Int64
 
-	calls         *atomic.Int64
+	calls         *atomic.Uint64
 	totalCallTime *atomic.Int64
-	maxMemory     *atomic.Int64
+	maxMemory     *atomic.Uint64
 }
 
 type shadowInstance struct {

--- a/vm/types.go
+++ b/vm/types.go
@@ -31,7 +31,7 @@ type Function struct {
 	shadows    *Shadows
 	errorCount atomic.Int64
 
-	// gateway metrics
+	// metrics
 	coldStarts     *atomic.Uint64
 	totalColdStart *atomic.Int64
 

--- a/vm/types.go
+++ b/vm/types.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	commonIface "github.com/taubyte/go-interfaces/services/substrate/components"
@@ -9,12 +10,12 @@ import (
 	structureSpec "github.com/taubyte/go-specs/structure"
 )
 
-type shadows struct {
+type Shadows struct {
 	ctx       context.Context
 	ctxC      context.CancelFunc
 	parent    *Function
 	instances chan *shadowInstance
-	//gcLock    sync.RWMutex
+	count     atomic.Int64
 
 	more chan struct{}
 }
@@ -28,7 +29,7 @@ type Function struct {
 	vmConfig    *vm.Config
 	vmContext   vm.Context
 
-	shadows shadows
+	shadows *Shadows
 }
 
 type shadowInstance struct {

--- a/vm/types.go
+++ b/vm/types.go
@@ -15,9 +15,18 @@ type Shadows struct {
 	ctxC      context.CancelFunc
 	parent    *Function
 	instances chan *shadowInstance
-	count     atomic.Int64
+	more      chan struct{}
+	errors    atomic.Int64
+	available atomic.Int64
 
-	more chan struct{}
+	coldStart *Metrics
+	calls     *Metrics
+}
+
+type Metrics struct {
+	totalCount atomic.Int64
+	maxMemory  atomic.Int64
+	totalTime  atomic.Int64
 }
 
 type Function struct {

--- a/vm/types.go
+++ b/vm/types.go
@@ -16,17 +16,7 @@ type Shadows struct {
 	parent    *Function
 	instances chan *shadowInstance
 	more      chan struct{}
-	errors    atomic.Int64
 	available atomic.Int64
-
-	coldStart *Metrics
-	calls     *Metrics
-}
-
-type Metrics struct {
-	totalCount atomic.Int64
-	maxMemory  atomic.Int64
-	totalTime  atomic.Int64
 }
 
 type Function struct {
@@ -38,7 +28,16 @@ type Function struct {
 	vmConfig    *vm.Config
 	vmContext   vm.Context
 
-	shadows *Shadows
+	shadows    *Shadows
+	errorCount atomic.Int64
+
+	// gateway metrics
+	coldStarts     *atomic.Int64
+	totalColdStart *atomic.Int64
+
+	calls         *atomic.Int64
+	totalCallTime *atomic.Int64
+	maxMemory     *atomic.Int64
 }
 
 type shadowInstance struct {

--- a/vm/utils_test.go
+++ b/vm/utils_test.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"errors"
+	"time"
 
 	"github.com/taubyte/go-interfaces/services/substrate/components"
 	"github.com/taubyte/go-interfaces/vm"
@@ -40,6 +41,7 @@ func newMockVm() *mockVm {
 type mockVm struct {
 	vm.Service
 	failInstance bool
+	runtimeDelay time.Duration
 }
 
 type mockInstance struct {
@@ -71,6 +73,9 @@ func (*mockCache) Remove(components.Serviceable) {}
 var errorTest = errors.New("test fail")
 
 func (m *mockVm) New(context vm.Context, config vm.Config) (vm.Instance, error) {
+	if m.runtimeDelay > 0 {
+		<-time.After(m.runtimeDelay)
+	}
 	if m.failInstance {
 		return nil, errorTest
 	}

--- a/vm/vars.go
+++ b/vm/vars.go
@@ -4,7 +4,7 @@ import "time"
 
 var (
 	InstanceMaxRequests   int           = 1024 * 64
-	InstanceMaxError      int           = 10
+	InstanceMaxError      int64         = 10
 	InstanceErrorCoolDown time.Duration = 30 * time.Minute
 
 	ShadowBuff                        = 10


### PR DESCRIPTION
<H1>Create a robust scoring system that Substrate nodes use to score their handling of serviceables</H1>
Linked Issue: #113 

**Features:**
- Structure to build and assess substrate node metrics, for gateway load balancing
- HTTP Serviceable scoring Based on:
  - Cpu usage
  - Serviceable assets cached in DAG
  - Serviceable runtime shadows created 
  - Serviceable memory allocation required to call vs available memory
  - Serviceable call history
 - Optimizations with http serviceable creation 
  -  Separate serviceable creation and provisioning serviceable execution requirements to minimize unnecessary operations

**Tests** 
 - [Gateway Dreamland Tests](https://asciinema.org/a/dTrINnrsmiTxOrklEHoUclBxx)
 - [VM Shadows  Unit-Tests](https://asciinema.org/a/9ZMfpOu8EY9ieZBoUzQOJd6cz)