### PR TITLE
Refactor KVDB, Update P2P Mock, and Streamline Tests and Hoarder Streaming

### DIFF
--- a/cli/app/start_cmd.go
+++ b/cli/app/start_cmd.go
@@ -37,20 +37,20 @@ func startCommand() *cli.Command {
 				return fmt.Errorf("parsing config failed with: %s", err)
 			}
 
-			// Migration Start
+			// Migration Start (from odo to tau)
+			// TODO: Delete this after a few releases
 			if _, err := os.Stat(fmt.Sprintf("/tb/storage/databases/%s", shape)); !os.IsNotExist(err) {
 				err = migrateDatabase(ctx.Context, shape, len(protocolConfig.Protocols) == 0)
 				if err != nil {
 					return fmt.Errorf("migrating shape %s failed with: %w", shape, err)
 				}
+
+				cmd := exec.Command("sudo", "systemctl", "stop", fmt.Sprintf("odo@%s.service", shape))
+				cmd.CombinedOutput()
+
+				cmd = exec.Command("sudo", "systemctl", "disable", fmt.Sprintf("odo@%s.service", shape))
+				cmd.CombinedOutput()
 			}
-
-			cmd := exec.Command("sudo", "systemctl", "stop", fmt.Sprintf("odo@%s.service", shape))
-			cmd.CombinedOutput()
-
-			cmd = exec.Command("sudo", "systemctl", "disable", fmt.Sprintf("odo@%s.service", shape))
-			cmd.CombinedOutput()
-			// Migration End
 
 			setNetworkDomains(sourceConfig)
 			return node.Start(ctx.Context, protocolConfig)

--- a/go.mod
+++ b/go.mod
@@ -45,9 +45,9 @@ require (
 	github.com/taubyte/go-simple-git v0.2.5
 	github.com/taubyte/go-specs v0.10.8-0.20230912140105-e8d804edc77c
 	github.com/taubyte/http v0.10.5
-	github.com/taubyte/p2p v0.10.1-0.20230919152907-f26fd82a39d3
+	github.com/taubyte/p2p v0.11.0
 	github.com/taubyte/utils v0.1.7
-	github.com/taubyte/vm v1.0.3
+	github.com/taubyte/vm v1.0.4
 	github.com/taubyte/vm-core-plugins v0.3.4
 	github.com/taubyte/vm-orbit v1.0.0
 	github.com/urfave/cli/v2 v2.25.7

--- a/go.sum
+++ b/go.sum
@@ -906,12 +906,12 @@ github.com/taubyte/go-specs v0.10.8-0.20230912140105-e8d804edc77c/go.mod h1:lhCi
 github.com/taubyte/http v0.10.5 h1:0dpSYi1XvryxO7U1Df5cgh+6LWKtaMypILQjgfJdExw=
 github.com/taubyte/http v0.10.5/go.mod h1:hSJYC7/yqRkrsZYe1Q0c194GKkVD0KGWDzw0sC+SAiU=
 github.com/taubyte/odo v0.0.0-20230726203810-bdae9f37e8f8 h1:+r57pU7UW1DZkBgOUsBh0zmRSg77sz+bJ3DaybLR3z0=
-github.com/taubyte/p2p v0.10.1-0.20230919152907-f26fd82a39d3 h1:NbgrtVT1D0IOnIidXWIA8JN7SykD5QRT20Ak+YTFflc=
-github.com/taubyte/p2p v0.10.1-0.20230919152907-f26fd82a39d3/go.mod h1:Uo464wZDiMeuP7GDHvjUjwGbnm72ByuGofk2O2m58yI=
+github.com/taubyte/p2p v0.11.0 h1:gtrCZk6/AqIB62UuRO3iz1mcqmqUc0/AoOmISGHyrB8=
+github.com/taubyte/p2p v0.11.0/go.mod h1:Uo464wZDiMeuP7GDHvjUjwGbnm72ByuGofk2O2m58yI=
 github.com/taubyte/utils v0.1.7 h1:iFMOxhBNJKdUrD+Z1UjP9W5559LlQN8178V54uLngdk=
 github.com/taubyte/utils v0.1.7/go.mod h1:MWO21qZu7AcBwJkJLsltwb3zWyN84xSexLCU28JC4gM=
-github.com/taubyte/vm v1.0.3 h1:Z9IYHdHiWVh0/v1+dvWblGe6Ny+ni3t4yr8GIgfhavg=
-github.com/taubyte/vm v1.0.3/go.mod h1:5pRQKirHakEXSdhCPtkbom1VA2z64JO01ce1F4JibBM=
+github.com/taubyte/vm v1.0.4 h1:yHM61nU1GYwt+gfqXMvu+AkmA9tr7CuPYja4TJKeY7E=
+github.com/taubyte/vm v1.0.4/go.mod h1:WXBnk6d4WaOvT5g05Co66LDXe+gt8SFfO9nEq1srdQo=
 github.com/taubyte/vm-core-plugins v0.3.4 h1:NPYZfcL6JTS+YsQ5TYn/fO657L0Sqqk8vte7GBEtlqA=
 github.com/taubyte/vm-core-plugins v0.3.4/go.mod h1:jQBHrYYVvHjNP0fy0Sx3KsFQ4JMh8f0cmbSE6OXr+j8=
 github.com/taubyte/vm-orbit v1.0.0 h1:oSzlnGUTJWItGoz9WTS6nW68sh0zcllOOQkLtbc0LkU=

--- a/pkgs/kvdb/broadcaster.go
+++ b/pkgs/kvdb/broadcaster.go
@@ -1,0 +1,143 @@
+package kvdb
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	crdt "github.com/ipfs/go-ds-crdt"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+)
+
+// PubSubBroadcaster implements a Broadcaster using libp2p PubSub.
+type PubSubBroadcaster struct {
+	lock  sync.Mutex
+	ctx   context.Context
+	psub  *pubsub.PubSub
+	topic *pubsub.Topic
+	subs  *pubsub.Subscription
+}
+
+var (
+	broadcasters     = make(map[string]*PubSubBroadcaster)
+	broadcastersLock sync.Mutex
+)
+
+func registerTopic(topic string, b *PubSubBroadcaster) {
+	broadcastersLock.Lock()
+	defer broadcastersLock.Unlock()
+	broadcasters[topic] = b
+}
+
+func unregisterTopic(topic string) {
+	broadcastersLock.Lock()
+	defer broadcastersLock.Unlock()
+	delete(broadcasters, topic)
+}
+
+func getTopic(topic string) *PubSubBroadcaster {
+	broadcastersLock.Lock()
+	defer broadcastersLock.Unlock()
+	return broadcasters[topic]
+}
+
+// NewPubSubBroadcaster returns a new broadcaster using the given PubSub and
+// a topic to subscribe/broadcast to. The given context can be used to cancel
+// the broadcaster.
+// Please register any topic validators before creating the Broadcaster.
+//
+// The broadcaster can be shut down by cancelling the given context.
+// This must be done before Closing the crdt.Datastore, otherwise things
+// may hang.
+func NewPubSubBroadcaster(ctx context.Context, psub *pubsub.PubSub, topic string) (b *PubSubBroadcaster, err error) {
+	if b = getTopic(topic); b != nil {
+		return b, nil
+	}
+
+	b = &PubSubBroadcaster{
+		ctx:  ctx,
+		psub: psub,
+	}
+
+	b.topic, err = psub.Join(topic)
+	if err != nil {
+		return nil, err
+	}
+
+	registerTopic(topic, b)
+
+	if err = b.ensureSubscribed(); err != nil {
+		return nil, err
+	}
+
+	go func() {
+		<-b.ctx.Done()
+		b.lock.Lock()
+		defer b.lock.Unlock()
+		if b.subs != nil {
+			b.subs.Cancel()
+		}
+		b.topic.Close()
+		unregisterTopic(topic)
+	}()
+
+	return
+}
+
+func (pbc *PubSubBroadcaster) ensureSubscribed() (err error) {
+	pbc.lock.Lock()
+	defer pbc.lock.Unlock()
+	pbc.subs, err = pbc.topic.Subscribe()
+	return
+}
+
+// Broadcast publishes some data.
+func (pbc *PubSubBroadcaster) Broadcast(data []byte) error {
+	return pbc.topic.Publish(pbc.ctx, data)
+}
+
+// Next returns published data.
+func (pbc *PubSubBroadcaster) Next() ([]byte, error) {
+	for try := 3; try > 0; try-- {
+		msg, err := pbc.next()
+		if err != crdt.ErrNoMoreBroadcast {
+			return msg, err
+		}
+
+		// try again
+		if pbc.ensureSubscribed() != nil {
+			break
+		}
+	}
+
+	return nil, crdt.ErrNoMoreBroadcast
+}
+
+func (pbc *PubSubBroadcaster) next() ([]byte, error) {
+	var msg *pubsub.Message
+	var err error
+
+	select {
+	case <-pbc.ctx.Done():
+		return nil, crdt.ErrNoMoreBroadcast
+	default:
+	}
+
+	pbc.lock.Lock()
+	defer pbc.lock.Unlock()
+
+	if pbc.subs == nil {
+		return nil, crdt.ErrNoMoreBroadcast
+	}
+
+	msg, err = pbc.subs.Next(pbc.ctx)
+	if err != nil {
+		if strings.Contains(err.Error(), "subscription cancelled") ||
+			strings.Contains(err.Error(), "context") {
+			return nil, crdt.ErrNoMoreBroadcast
+		}
+		return nil, err
+	}
+
+	return msg.GetData(), nil
+}

--- a/pkgs/kvdb/broadcaster_test.go
+++ b/pkgs/kvdb/broadcaster_test.go
@@ -1,0 +1,201 @@
+package kvdb
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	crdt "github.com/ipfs/go-ds-crdt"
+	"github.com/taubyte/p2p/peer"
+)
+
+// TestNewPubSubBroadcaster tests the creation of a new PubSubBroadcaster.
+func TestNewPubSubBroadcaster(t *testing.T) {
+	ctx := context.Background()
+	mockNode := peer.MockNode(ctx)
+	psub := mockNode.Messaging()
+
+	// Test successful creation
+	broadcaster, err := NewPubSubBroadcaster(ctx, psub, "test-topic")
+	if err != nil {
+		t.Fatalf("Failed to create new broadcaster: %v", err)
+	}
+	if broadcaster == nil {
+		t.Fatal("Expected non-nil broadcaster, got nil")
+	}
+
+	// Test creation with existing topic
+	_, err = NewPubSubBroadcaster(ctx, psub, "test-topic")
+	if err != nil {
+		t.Fatalf("Failed to create broadcaster with existing topic: %v", err)
+	}
+
+	// Cleanup
+	broadcaster.topic.Close()
+}
+
+// TestPubSubBroadcaster_Broadcast tests the broadcast functionality.
+func TestPubSubBroadcaster_Broadcast(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mockNode := peer.MockNode(ctx)
+	psub := mockNode.Messaging()
+
+	broadcaster, _ := NewPubSubBroadcaster(ctx, psub, "test-topic")
+	defer broadcaster.topic.Close()
+
+	// Test broadcasting a message
+	err := broadcaster.Broadcast([]byte("test message"))
+	if err != nil {
+		t.Fatalf("Failed to broadcast message: %v", err)
+	}
+}
+
+// TestPubSubBroadcaster_Next tests the receiving of messages.
+func TestPubSubBroadcaster_Next(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mockNode := peer.MockNode(ctx)
+	psub := mockNode.Messaging()
+
+	broadcaster, _ := NewPubSubBroadcaster(ctx, psub, "test-topic")
+	defer broadcaster.topic.Close()
+
+	// Start a goroutine to broadcast a message after a delay
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		broadcaster.Broadcast([]byte("test message"))
+	}()
+
+	// Test receiving a message
+	msg, err := broadcaster.Next()
+	if err != nil {
+		t.Fatalf("Failed to receive message: %v", err)
+	}
+	if string(msg) != "test message" {
+		t.Fatalf("Expected 'test message', got '%s'", msg)
+	}
+}
+
+// TestPubSubBroadcaster_ContextCancellation tests the behavior when the context is cancelled.
+func TestPubSubBroadcaster_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	mockNode := peer.MockNode(ctx)
+	psub := mockNode.Messaging()
+
+	broadcaster, _ := NewPubSubBroadcaster(ctx, psub, "test-topic-2")
+	defer broadcaster.topic.Close()
+
+	// Cancel the context
+	cancel()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Test that Next returns an error after context cancellation
+	_, err := broadcaster.Next()
+	if !errors.Is(err, crdt.ErrNoMoreBroadcast) {
+		t.Fatalf("Expected ErrNoMoreBroadcast after context cancellation, got %v", err)
+	}
+}
+
+// TestPubSubBroadcaster_ConcurrentOperations tests concurrent broadcasting and receiving.
+func TestPubSubBroadcaster_ConcurrentOperations(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mockNode := peer.MockNode(ctx)
+	psub := mockNode.Messaging()
+
+	broadcaster, _ := NewPubSubBroadcaster(ctx, psub, "test-topic")
+	defer broadcaster.topic.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Start a goroutine to receive a message
+	go func() {
+		defer wg.Done()
+		msg, err := broadcaster.Next()
+		if err != nil {
+			t.Errorf("Failed to receive message: %v", err)
+		}
+		if string(msg) != "test message" {
+			t.Errorf("Expected 'test message', got '%s'", msg)
+		}
+	}()
+
+	// Broadcast a message
+	err := broadcaster.Broadcast([]byte("test message"))
+	if err != nil {
+		t.Fatalf("Failed to broadcast message: %v", err)
+	}
+
+	wg.Wait()
+}
+
+func TestPubSubBroadcaster_BroadcastAndReceive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mockNode := peer.MockNode(ctx)
+	psub := mockNode.Messaging()
+
+	topic := "testTopic"
+	broadcaster, err := NewPubSubBroadcaster(ctx, psub, topic)
+	if err != nil {
+		t.Fatalf("Failed to create new PubSubBroadcaster: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		data, err := broadcaster.Next()
+		if err != nil {
+			t.Errorf("Failed to receive broadcast: %v", err)
+			return
+		}
+		if string(data) != "testMessage" {
+			t.Errorf("Expected message 'testMessage', got '%s'", data)
+		}
+	}()
+
+	err = broadcaster.Broadcast([]byte("testMessage"))
+	if err != nil {
+		t.Fatalf("Failed to broadcast message: %v", err)
+	}
+
+	wg.Wait()
+}
+
+func TestPubSubBroadcaster_TopicRegistrationAndUnregistration(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mockNode := peer.MockNode(ctx)
+	psub := mockNode.Messaging()
+
+	topic := "testTopicRegistration"
+	_, err := NewPubSubBroadcaster(ctx, psub, topic)
+	if err != nil {
+		t.Fatalf("Failed to create new PubSubBroadcaster: %v", err)
+	}
+
+	if getTopic(topic) == nil {
+		t.Errorf("Expected topic '%s' to be registered", topic)
+	}
+
+	cancel() // This should unregister the topic
+
+	time.Sleep(100 * time.Millisecond) // Give some time for the goroutine to unregister the topic
+
+	if getTopic(topic) != nil {
+		t.Errorf("Expected topic '%s' to be unregistered after context cancellation", topic)
+	}
+}

--- a/pkgs/kvdb/methods.go
+++ b/pkgs/kvdb/methods.go
@@ -2,6 +2,7 @@ package kvdb
 
 import (
 	"context"
+	"errors"
 
 	ds "github.com/ipfs/go-datastore"
 	query "github.com/ipfs/go-datastore/query"
@@ -14,6 +15,10 @@ func (kvd *kvDatabase) Get(ctx context.Context, key string) ([]byte, error) {
 }
 
 func (kvd *kvDatabase) Put(ctx context.Context, key string, v []byte) error {
+	if key == "" {
+		return errors.New("key cannot be empty")
+	}
+
 	k := ds.NewKey(key)
 	return kvd.datastore.Put(ctx, k, v)
 }

--- a/pkgs/kvdb/methods_test.go
+++ b/pkgs/kvdb/methods_test.go
@@ -1,0 +1,209 @@
+package kvdb
+
+import (
+	"context"
+	"testing"
+
+	ds "github.com/ipfs/go-datastore"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/taubyte/p2p/peer"
+)
+
+func TestKVDatabase_PutAndGet(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+	db, _ := f.New(logger, "testpath", 10)
+
+	// Test putting a value
+	key := "testkey"
+	value := []byte("testvalue")
+	err := db.Put(context.Background(), key, value)
+	if err != nil {
+		t.Fatalf("Failed to put value: %v", err)
+	}
+
+	// Test getting the value back
+	retrievedValue, err := db.Get(context.Background(), key)
+	if err != nil {
+		t.Fatalf("Failed to get value: %v", err)
+	}
+
+	// Assert that the retrieved value is equal to the original value
+	if string(retrievedValue) != string(value) {
+		t.Fatalf("Expected retrieved value to be '%s', got '%s'", value, retrievedValue)
+	}
+
+	// Cleanup
+	db.Close()
+}
+
+func TestKVDatabase_Delete(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+	db, _ := f.New(logger, "testpath", 10)
+
+	// Put a value and then delete it
+	key := "testkey"
+	value := []byte("testvalue")
+	db.Put(context.Background(), key, value)
+	err := db.Delete(context.Background(), key)
+	if err != nil {
+		t.Fatalf("Failed to delete value: %v", err)
+	}
+
+	// Try to get the deleted value
+	_, err = db.Get(context.Background(), key)
+	if err != ds.ErrNotFound {
+		t.Fatalf("Expected ErrNotFound for deleted key, got %v", err)
+	}
+
+	// Cleanup
+	db.Close()
+}
+
+func TestKVDatabase_List(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+	db, _ := f.New(logger, "testpath", 10)
+
+	// Put some values
+	keys := []string{"key1", "key2", "key3"}
+	for _, key := range keys {
+		err := db.Put(context.Background(), key, []byte("value"))
+		if err != nil {
+			t.Fatalf("Failed to put value for key '%s': %v", key, err)
+		}
+	}
+
+	// List keys
+	listedKeys, err := db.List(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Failed to list keys: %v", err)
+	}
+
+	// Assert that all keys are listed
+	if len(listedKeys) != len(keys) {
+		t.Fatalf("Expected %d keys, got %d", len(keys), len(listedKeys))
+	}
+
+	// Cleanup
+	db.Close()
+}
+
+func TestKVDatabase_Batch(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+	db, _ := f.New(logger, "testpath", 10)
+
+	// Start a batch
+	batch, err := db.Batch(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to start batch: %v", err)
+	}
+
+	// Put some values in the batch
+	keys := []string{"batchkey1", "batchkey2"}
+	for _, key := range keys {
+		err := batch.Put(key, []byte("batchvalue"))
+		if err != nil {
+			t.Fatalf("Failed to put value in batch for key '%s': %v", key, err)
+		}
+	}
+
+	// Commit the batch
+	err = batch.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit batch: %v", err)
+	}
+
+	// Assert that the values are stored
+	for _, key := range keys {
+		_, err := db.Get(context.Background(), key)
+		if err != nil {
+			t.Fatalf("Failed to get value for key '%s' after batch commit: %v", key, err)
+		}
+	}
+
+	// Cleanup
+	db.Close()
+}
+
+func TestKVDatabase_Get_NonExistentKey(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+	db, _ := f.New(logger, "testpath", 10)
+
+	// Test getting a non-existent key
+	_, err := db.Get(context.Background(), "nonexistentkey")
+	if err != ds.ErrNotFound {
+		t.Fatalf("Expected ErrNotFound for non-existent key, got %v", err)
+	}
+
+	// Cleanup
+	db.Close()
+}
+
+func TestKVDatabase_Put_EmptyKeyOrValue(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+	db, _ := f.New(logger, "testpath", 10)
+
+	// Test putting an empty key
+	err := db.Put(context.Background(), "", []byte("value"))
+	if err == nil {
+		t.Fatalf("Expected error when putting empty key")
+	}
+
+	// Test putting an empty value
+	err = db.Put(context.Background(), "testkey", []byte(""))
+	if err != nil {
+		t.Fatalf("Failed to put empty value: %v", err)
+	}
+
+	// Cleanup
+	db.Close()
+}
+
+func TestKVDatabase_List_SpecificPrefix(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+	db, _ := f.New(logger, "testpath", 10)
+
+	// Put some values with specific prefix
+	prefix := "myprefix/"
+	keysWithPrefix := []string{prefix + "key1", prefix + "key2"}
+	for _, key := range keysWithPrefix {
+		err := db.Put(context.Background(), key, []byte("value"))
+		if err != nil {
+			t.Fatalf("Failed to put value for key '%s': %v", key, err)
+		}
+	}
+
+	// List keys with specific prefix
+	listedKeys, err := db.List(context.Background(), prefix)
+	if err != nil {
+		t.Fatalf("Failed to list keys with prefix '%s': %v", prefix, err)
+	}
+
+	// Assert that only keys with the specific prefix are listed
+	if len(listedKeys) != len(keysWithPrefix) {
+		t.Fatalf("Expected %d keys with prefix '%s', got %d", len(keysWithPrefix), prefix, len(listedKeys))
+	}
+
+	// Cleanup
+	db.Close()
+}

--- a/pkgs/kvdb/service_test.go
+++ b/pkgs/kvdb/service_test.go
@@ -1,0 +1,328 @@
+package kvdb
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	ds "github.com/ipfs/go-datastore"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/taubyte/p2p/peer"
+)
+
+func TestFactory_New(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+
+	// Test creating a new database
+	db, err := f.New(logger, "testpath", 10)
+	if err != nil {
+		t.Fatalf("Failed to create new database: %v", err)
+	}
+
+	// Assert that db is not nil
+	if db == nil {
+		t.Fatal("Expected non-nil db, got nil")
+	}
+
+	// Cleanup
+	db.Close()
+}
+
+func TestFactory_getDB(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+	db, _ := f.New(logger, "testpath", 10)
+
+	// Test retrieving an existing database
+	retrievedDB := f.(*factory).getDB("testpath")
+
+	// Assert that retrievedDB is not nil and is equal to the original db
+	if retrievedDB == nil {
+		t.Fatal("Expected non-nil retrievedDB, got nil")
+	}
+	if retrievedDB != db {
+		t.Fatal("Expected retrievedDB to be equal to original db")
+	}
+
+	// Cleanup
+	db.Close()
+}
+
+func TestFactory_deleteDB(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+	db, _ := f.New(logger, "testpath", 10)
+
+	// Test deleting a database
+	f.(*factory).deleteDB("testpath")
+
+	// Assert that the database is no longer retrievable
+	deletedDB := f.(*factory).getDB("testpath")
+	if deletedDB != nil {
+		t.Fatal("Expected deletedDB to be nil")
+	}
+
+	// Cleanup
+	db.Close()
+}
+
+func TestKVDatabase_Close(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	factory := New(mockNode)
+	db, _ := factory.New(logger, "testpath", 10)
+
+	// Test closing the database
+	db.Close()
+
+	// Assert that the database is closed
+	// You would need to add a method or a way to check if the database is closed.
+	// For example, you could add a `IsClosed() bool` method to the kvDatabase type.
+	if !db.(*kvDatabase).closed {
+		t.Fatal("Expected database to be closed")
+	}
+}
+
+func TestFactory_NewDatabaseExists(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+
+	// Test creating a new database
+	db1, err := f.New(logger, "testpath", 10)
+	if err != nil {
+		t.Fatalf("Failed to create new database: %v", err)
+	}
+
+	// Test creating the same database again should retrieve the existing one
+	db2, err := f.New(logger, "testpath", 10)
+	if err != nil {
+		t.Fatalf("Failed to create new database: %v", err)
+	}
+
+	// Assert that db2 is not nil and is equal to db1
+	if db2 == nil {
+		t.Fatal("Expected non-nil db2, got nil")
+	}
+	if db1 != db2 {
+		t.Fatal("Expected db2 to be equal to db1")
+	}
+
+	// Cleanup
+	db1.Close()
+}
+
+func TestFactory_ConcurrentAccess(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+
+	// Test concurrent creation of databases
+	var wg sync.WaitGroup
+	createDB := func(path string) {
+		defer wg.Done()
+		if _, err := f.New(logger, path, 10); err != nil {
+			t.Errorf("Failed to create new database: %v", err)
+		}
+	}
+
+	wg.Add(2)
+	go createDB("testpath1")
+	go createDB("testpath2")
+	wg.Wait()
+
+	// Assert that both databases are created and retrievable
+	if db1 := f.(*factory).getDB("testpath1"); db1 == nil {
+		t.Fatal("Expected non-nil db1, got nil")
+	}
+	if db2 := f.(*factory).getDB("testpath2"); db2 == nil {
+		t.Fatal("Expected non-nil db2, got nil")
+	}
+
+	// Cleanup
+	f.(*factory).getDB("testpath1").Close()
+	f.(*factory).getDB("testpath2").Close()
+}
+
+func TestFactory_CloseAll(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+
+	// Create multiple databases
+	f.New(logger, "testpath1", 10)
+	f.New(logger, "testpath2", 10)
+
+	// Test closing all databases
+	f.Close()
+
+	// Assert that all databases are closed
+	if db1 := f.(*factory).getDB("testpath1"); db1 != nil && !db1.closed {
+		t.Fatal("Expected db1 to be closed")
+	}
+	if db2 := f.(*factory).getDB("testpath2"); db2 != nil && !db2.closed {
+		t.Fatal("Expected db2 to be closed")
+	}
+}
+
+func TestKVDatabase_ReopenClosedDatabase(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+
+	// Create a database and close it
+	db, _ := f.New(logger, "testpath", 10)
+	db.Close()
+
+	// Test reopening the closed database
+	reopenedDB, err := f.New(logger, "testpath", 10)
+	if err != nil {
+		t.Fatalf("Failed to reopen closed database: %v", err)
+	}
+
+	// Assert that reopenedDB is not nil and is a new instance
+	if reopenedDB == nil {
+		t.Fatal("Expected non-nil reopenedDB, got nil")
+	}
+	if reopenedDB == db {
+		t.Fatal("Expected reopenedDB to be a new instance")
+	}
+
+	// Cleanup
+	reopenedDB.Close()
+}
+
+func TestKVDatabase_ListAsync(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+	db, _ := f.New(logger, "testpath", 10)
+
+	// Put some values
+	keys := []string{"async1", "async2", "async3"}
+	for _, key := range keys {
+		err := db.Put(context.Background(), key, []byte("value"))
+		if err != nil {
+			t.Fatalf("Failed to put value for key '%s': %v", key, err)
+		}
+	}
+
+	// Test ListAsync
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // Ensure the context is canceled to prevent leaks
+
+	keyChan, err := db.ListAsync(ctx, "")
+	if err != nil {
+		t.Fatalf("Failed to list keys asynchronously: %v", err)
+	}
+
+	receivedKeys := make([]string, 0, len(keys))
+	for key := range keyChan {
+		receivedKeys = append(receivedKeys, key)
+	}
+
+	// Assert that all keys are received
+	if len(receivedKeys) != len(keys) {
+		t.Fatalf("Expected %d keys, got %d", len(keys), len(receivedKeys))
+	}
+
+	// Cleanup
+	db.Close()
+}
+
+func TestKVDatabase_Batch_MixedOperations(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+	db, _ := f.New(logger, "testpath", 10)
+
+	// Create a batch
+	batch, err := db.Batch(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to create batch: %v", err)
+	}
+
+	// Perform some operations
+	err = batch.Put("batchkey1", []byte("value1"))
+	if err != nil {
+		t.Fatalf("Failed to put in batch: %v", err)
+	}
+	err = batch.Delete("batchkey1")
+	if err != nil {
+		t.Fatalf("Failed to delete in batch: %v", err)
+	}
+	err = batch.Put("batchkey2", []byte("value2"))
+	if err != nil {
+		t.Fatalf("Failed to put in batch: %v", err)
+	}
+
+	// Commit the batch
+	err = batch.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit batch: %v", err)
+	}
+
+	// Assert that "batchkey1" was deleted and "batchkey2" exists
+	_, err = db.Get(context.Background(), "batchkey1")
+	if err != ds.ErrNotFound {
+		t.Fatalf("Expected 'batchkey1' to be deleted")
+	}
+
+	value, err := db.Get(context.Background(), "batchkey2")
+	if err != nil {
+		t.Fatalf("Failed to get 'batchkey2': %v", err)
+	}
+	if string(value) != "value2" {
+		t.Fatalf("Expected 'batchkey2' to have value 'value2', got '%s'", value)
+	}
+
+	// Cleanup
+	db.Close()
+}
+
+func TestKVDatabase_Sync(t *testing.T) {
+	// Setup
+	logger := logging.Logger("test")
+	mockNode := peer.MockNode(context.Background())
+	f := New(mockNode)
+	db, _ := f.New(logger, "testpath", 10)
+
+	// Put a value
+	key := "syncKey"
+	err := db.Put(context.Background(), key, []byte("syncValue"))
+	if err != nil {
+		t.Fatalf("Failed to put value: %v", err)
+	}
+
+	// Sync the key
+	err = db.Sync(context.Background(), key)
+	if err != nil {
+		t.Fatalf("Failed to sync: %v", err)
+	}
+
+	// Assert that the key is still there after sync
+	value, err := db.Get(context.Background(), key)
+	if err != nil {
+		t.Fatalf("Failed to get key after sync: %v", err)
+	}
+	if string(value) != "syncValue" {
+		t.Fatalf("Expected value 'syncValue', got '%s'", value)
+	}
+
+	// Cleanup
+	db.Close()
+}

--- a/pkgs/kvdb/types.go
+++ b/pkgs/kvdb/types.go
@@ -10,7 +10,7 @@ type kvDatabase struct {
 	closeCtx    context.Context
 	closeCtxC   context.CancelFunc
 	factory     *factory
-	broadcaster *(crdt.PubSubBroadcaster)
+	broadcaster *(PubSubBroadcaster)
 	datastore   *(crdt.Datastore)
 	closed      bool
 	path        string

--- a/protocols/auth/stream.go
+++ b/protocols/auth/stream.go
@@ -13,7 +13,6 @@ func (srv *AuthService) setupStreamRoutes() {
 	srv.stream.Define("ping", func(context.Context, streams.Connection, command.Body) (cr.Response, error) {
 		return cr.Response{"time": int(time.Now().Unix())}, nil
 	})
-
 	srv.stream.Define("acme", srv.acmeServiceHandler)
 	srv.stream.Define("hooks", srv.apiHookServiceHandler)
 	srv.stream.Define("repositories", srv.apiGitRepositoryServiceHandler)

--- a/protocols/hoarder/service.go
+++ b/protocols/hoarder/service.go
@@ -72,9 +72,7 @@ func New(ctx context.Context, config *tauConfig.Node) (service hoarderIface.Serv
 		return nil, fmt.Errorf("creating database failed with: %w", err)
 	}
 
-	if err = s.setupStreamRoutes(); err != nil {
-		return nil, fmt.Errorf("setting up stream routes failed with: %w", err)
-	}
+	s.setupStreamRoutes()
 
 	if err = s.subscribe(ctx); err != nil {
 		return nil, fmt.Errorf("pubsub subscribe failed with: %w", err)

--- a/protocols/hoarder/stream.go
+++ b/protocols/hoarder/stream.go
@@ -15,16 +15,11 @@ import (
 	"github.com/taubyte/utils/maps"
 )
 
-func (s *Service) setupStreamRoutes() error {
-	if err := s.stream.Define("ping", s.ping); err != nil {
-		return fmt.Errorf("defining `ping` command failed with: %w", err)
-	}
-
-	if err := s.stream.Define("hoarder", s.ServiceHandler); err != nil {
-		return fmt.Errorf("defining `hoarder` command failed with: %w", err)
-	}
-
-	return nil
+func (srv *Service) setupStreamRoutes() {
+	srv.stream.Define("ping", func(context.Context, streams.Connection, command.Body) (cr.Response, error) {
+		return cr.Response{"time": int(time.Now().Unix())}, nil
+	})
+	srv.stream.Define("hoarder", srv.ServiceHandler)
 }
 
 // TODO: This can be made generic

--- a/protocols/monkey/fixtures/compile/function_zw_test.go
+++ b/protocols/monkey/fixtures/compile/function_zw_test.go
@@ -32,7 +32,8 @@ func TestZWasmFunction(t *testing.T) {
 		Simples: map[string]dreamland.SimpleConfig{
 			"client": {
 				Clients: dreamland.SimpleConfigClients{
-					TNS: &commonIface.ClientConfig{},
+					TNS:     &commonIface.ClientConfig{},
+					Hoarder: &commonIface.ClientConfig{},
 				}.Compat(),
 			},
 		},

--- a/protocols/monkey/fixtures/compile/website_test.go
+++ b/protocols/monkey/fixtures/compile/website_test.go
@@ -33,7 +33,8 @@ func TestWebsite(t *testing.T) {
 		Simples: map[string]dreamland.SimpleConfig{
 			"client": {
 				Clients: dreamland.SimpleConfigClients{
-					TNS: &commonIface.ClientConfig{},
+					TNS:     &commonIface.ClientConfig{},
+					Hoarder: &commonIface.ClientConfig{},
 				}.Compat(),
 			},
 		},

--- a/protocols/monkey/fixtures/compile/website_z_test.go
+++ b/protocols/monkey/fixtures/compile/website_z_test.go
@@ -33,7 +33,8 @@ func TestZipWebsite(t *testing.T) {
 		Simples: map[string]dreamland.SimpleConfig{
 			"client": {
 				Clients: dreamland.SimpleConfigClients{
-					TNS: &commonIface.ClientConfig{},
+					TNS:     &commonIface.ClientConfig{},
+					Hoarder: &commonIface.ClientConfig{},
 				}.Compat(),
 			},
 		},

--- a/protocols/patrick/stream.go
+++ b/protocols/patrick/stream.go
@@ -1,5 +1,17 @@
 package service
 
-func (h *PatrickService) setupStreamRoutes() {
-	h.stream.Define("patrick", h.requestServiceHandler)
+import (
+	"context"
+	"time"
+
+	"github.com/taubyte/p2p/streams"
+	"github.com/taubyte/p2p/streams/command"
+	cr "github.com/taubyte/p2p/streams/command/response"
+)
+
+func (srv *PatrickService) setupStreamRoutes() {
+	srv.stream.Define("ping", func(context.Context, streams.Connection, command.Body) (cr.Response, error) {
+		return cr.Response{"time": int(time.Now().Unix())}, nil
+	})
+	srv.stream.Define("patrick", srv.requestServiceHandler)
 }

--- a/protocols/seer/stream.go
+++ b/protocols/seer/stream.go
@@ -13,7 +13,6 @@ func (srv *Service) setupStreamRoutes() {
 	srv.stream.Define("ping", func(context.Context, streams.Connection, command.Body) (cr.Response, error) {
 		return cr.Response{"time": int(time.Now().Unix())}, nil
 	})
-
 	srv.stream.Define("geo", srv.geo.locationServiceHandler)
 	srv.stream.Define("heartbeat", srv.oracle.heartbeatServiceHandler)
 	srv.stream.Define("announce", srv.oracle.announceServiceHandler)

--- a/protocols/tns/stream.go
+++ b/protocols/tns/stream.go
@@ -1,19 +1,6 @@
 package tns
 
-import (
-	"context"
-	"time"
-
-	"github.com/taubyte/p2p/streams"
-	"github.com/taubyte/p2p/streams/command"
-	cr "github.com/taubyte/p2p/streams/command/response"
-)
-
 func (srv *Service) setupStreamRoutes() {
-	srv.stream.Define("ping", func(context.Context, streams.Connection, command.Body) (cr.Response, error) {
-		return cr.Response{"time": int(time.Now().Unix())}, nil
-	})
-
 	// TODO: requires secret + maybe a handshare using project PSK
 	srv.stream.Define("push", srv.pushHandler)
 	srv.stream.Define("fetch", srv.fetchHandler)

--- a/vm/counter/tests/counters_test.go
+++ b/vm/counter/tests/counters_test.go
@@ -61,7 +61,8 @@ func TestCounters(t *testing.T) {
 		Simples: map[string]dreamland.SimpleConfig{
 			"client": {
 				Clients: dreamland.SimpleConfigClients{
-					TNS: &commonIface.ClientConfig{},
+					TNS:     &commonIface.ClientConfig{},
+					Hoarder: &commonIface.ClientConfig{},
 				}.Compat(),
 			},
 		},


### PR DESCRIPTION
This PR introduces a significant refactor of the KVDB package, implements a new P2P mock, and addresses various issues in tests and hoarder streaming routes. The changes include:

- A new PubSubBroadcaster structure that utilizes libp2p PubSub for broadcasting.
- A mechanism for registering and unregistering topics within the PubSub system.
- Enhanced synchronization with the addition of mutex locks to prevent race conditions.
- Improved error handling and subscription logic to ensure reliable message broadcasting and reception.
- These updates aim to optimize the underlying data distribution mechanisms, improve the robustness of the testing framework, and ensure that streaming routes are defined more consistently.