### PR TITLE
fixed generated domain issue with seer

### DIFF
--- a/protocols/seer/dns.go
+++ b/protocols/seer/dns.go
@@ -138,7 +138,7 @@ func (h *dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		}
 	}
 
-	if domainSpecs.TaubyteServiceDomain.MatchString(name) || h.seer.protocolRecordBypass.MatchString(name) {
+	if h.seer.protocolRecordBypass.MatchString(name) {
 		h.tauDnsResolve(name, w, r, errMsg, msg)
 		return
 	}

--- a/protocols/seer/service.go
+++ b/protocols/seer/service.go
@@ -46,7 +46,7 @@ func New(ctx context.Context, config *tauConfig.Node, opts ...Options) (*Service
 
 	srv.dnsResolver = net.DefaultResolver
 	srv.generatedDomain = config.GeneratedDomain
-	srv.protocolRecordBypass = regexp.MustCompile(fmt.Sprintf("tau.%s", config.NetworkFqdn))
+	srv.protocolRecordBypass = regexp.MustCompile(fmt.Sprintf(`^[^.]+\.tau\.%s$`, regexp.QuoteMeta(config.NetworkFqdn)))
 
 	for _, op := range opts {
 		err = op(srv)

--- a/protocols/seer/tests/dns_test.go
+++ b/protocols/seer/tests/dns_test.go
@@ -7,6 +7,7 @@ import (
 
 	commonIface "github.com/taubyte/go-interfaces/common"
 	dreamland "github.com/taubyte/tau/libdream"
+
 	"gotest.tools/v3/assert"
 
 	dns "github.com/miekg/dns"


### PR DESCRIPTION
Seer was looking for gateways nodes only. Some clouds might not have these, or they could just not be available, seer should be able to return substrate nodes. Later, we need a smarter way to deal with it so a TODO was added.
Also, the ways generated domains was iffy with a string compiles to regex. Fixed now. 