### PR TITLE
libdream fixtures do not get universe

### DIFF
--- a/libdream/common/config.go
+++ b/libdream/common/config.go
@@ -9,7 +9,7 @@ import (
 	"github.com/taubyte/tau/libdream"
 )
 
-func NewDreamlandConfig(config *iface.ServiceConfig) *tauConfig.Node {
+func NewDreamlandConfig(u *libdream.Universe, config *iface.ServiceConfig) *tauConfig.Node {
 	serviceConfig := &tauConfig.Node{}
 
 	serviceConfig.Ports = make(map[string]int)

--- a/libdream/types.go
+++ b/libdream/types.go
@@ -36,7 +36,7 @@ type handlers struct {
 	client  ClientCreate
 }
 
-type ServiceCreate func(context.Context, *commonIface.ServiceConfig) (commonIface.Service, error)
+type ServiceCreate func(*Universe, *commonIface.ServiceConfig) (commonIface.Service, error)
 type ClientCreate func(peer.Node, *commonIface.ClientConfig) (commonIface.Client, error)
 
 var Registry *handlerRegistry

--- a/libdream/universe.go
+++ b/libdream/universe.go
@@ -140,12 +140,20 @@ func (u *Universe) StartAll(simples ...string) error {
 	)
 }
 
-func (u *Universe) GetPortHttp(node peer.Node) (int, error) {
+func (u *Universe) GetInfo(node peer.Node) (*NodeInfo, error) {
 	u.lock.RLock()
+	defer u.lock.RUnlock()
 	info, ok := u.lookups[node.ID().String()]
-	u.lock.RUnlock()
 	if !ok {
-		return 0, errors.New("node does not exist")
+		return nil, errors.New("node does not exist")
+	}
+	return info, nil
+}
+
+func (u *Universe) GetPortHttp(node peer.Node) (int, error) {
+	info, err := u.GetInfo(node)
+	if err != nil {
+		return 0, err
 	}
 
 	port, ok := info.Ports["http"]

--- a/libdream/universeHelpers.go
+++ b/libdream/universeHelpers.go
@@ -98,7 +98,7 @@ func (u *Universe) startService(protocol string, config *commonIface.ServiceConf
 		return nil, err
 	}
 
-	service, err := creationMethod(u.ctx, config)
+	service, err := creationMethod(u, config)
 	if err != nil {
 		return nil, err
 	}

--- a/libdream/universeMethods.go
+++ b/libdream/universeMethods.go
@@ -51,7 +51,7 @@ func (u *Universe) Mesh(newNodes ...peer.Node) {
 
 	u.lock.RLock()
 	var wg sync.WaitGroup
-	for _, n0 := range newNodes {
+	for _, n0 := range append(u.all, newNodes...) {
 		for _, n1 := range u.all {
 			if n0 != n1 {
 				wg.Add(1)

--- a/libdream/vars.go
+++ b/libdream/vars.go
@@ -27,8 +27,8 @@ var (
 	DefaultP2PListenFormat  string = "/ip4/" + DefaultHost + "/tcp/%d"
 	DefaultHTTPListenFormat string = "%s://" + DefaultHost + ":%d"
 
-	BaseAfterStartDelay = 100 // Millisecond
-	MaxAfterStartDelay  = 500 // Millisecond
+	BaseAfterStartDelay = 500  // Millisecond
+	MaxAfterStartDelay  = 1000 // Millisecond
 	MeshTimeout         = 5 * time.Second
 
 	startAllDefaultSimple = "client"

--- a/protocols/auth/dreamland.go
+++ b/protocols/auth/dreamland.go
@@ -1,8 +1,6 @@
 package auth
 
 import (
-	"context"
-
 	iface "github.com/taubyte/go-interfaces/common"
 	commonSpecs "github.com/taubyte/go-specs/common"
 	"github.com/taubyte/tau/libdream"
@@ -15,6 +13,6 @@ func init() {
 	}
 }
 
-func createAuthService(ctx context.Context, config *iface.ServiceConfig) (iface.Service, error) {
-	return New(ctx, common.NewDreamlandConfig(config))
+func createAuthService(u *libdream.Universe, config *iface.ServiceConfig) (iface.Service, error) {
+	return New(u.Context(), common.NewDreamlandConfig(u, config))
 }

--- a/protocols/auth/service.go
+++ b/protocols/auth/service.go
@@ -62,7 +62,6 @@ func New(ctx context.Context, config *tauConfig.Node) (*AuthService, error) {
 	srv.dvPrivateKey = config.DomainValidation.PrivateKey
 	srv.dvPublicKey = config.DomainValidation.PublicKey
 
-	// For Odo
 	clientNode := srv.node
 	if config.ClientNode != nil {
 		clientNode = config.ClientNode

--- a/protocols/gateway/dreamland.go
+++ b/protocols/gateway/dreamland.go
@@ -1,8 +1,6 @@
 package gateway
 
 import (
-	"context"
-
 	iface "github.com/taubyte/go-interfaces/common"
 	commonSpecs "github.com/taubyte/go-specs/common"
 	"github.com/taubyte/tau/libdream"
@@ -15,6 +13,6 @@ func init() {
 	}
 }
 
-func createGateway(ctx context.Context, config *iface.ServiceConfig) (iface.Service, error) {
-	return New(ctx, common.NewDreamlandConfig(config))
+func createGateway(u *libdream.Universe, config *iface.ServiceConfig) (iface.Service, error) {
+	return New(u.Context(), common.NewDreamlandConfig(u, config))
 }

--- a/protocols/hoarder/dreamland.go
+++ b/protocols/hoarder/dreamland.go
@@ -1,8 +1,6 @@
 package hoarder
 
 import (
-	"context"
-
 	iface "github.com/taubyte/go-interfaces/common"
 	commonSpecs "github.com/taubyte/go-specs/common"
 	"github.com/taubyte/tau/libdream"
@@ -15,6 +13,6 @@ func init() {
 	}
 }
 
-func createService(ctx context.Context, config *iface.ServiceConfig) (iface.Service, error) {
-	return New(ctx, common.NewDreamlandConfig(config))
+func createService(u *libdream.Universe, config *iface.ServiceConfig) (iface.Service, error) {
+	return New(u.Context(), common.NewDreamlandConfig(u, config))
 }

--- a/protocols/hoarder/service.go
+++ b/protocols/hoarder/service.go
@@ -53,7 +53,6 @@ func New(ctx context.Context, config *tauConfig.Node) (service hoarderIface.Serv
 		s.node = config.Node
 	}
 
-	// For Odo
 	clientNode := s.node
 	if config.ClientNode != nil {
 		clientNode = config.ClientNode

--- a/protocols/monkey/dreamland.go
+++ b/protocols/monkey/dreamland.go
@@ -1,8 +1,6 @@
 package monkey
 
 import (
-	"context"
-
 	iface "github.com/taubyte/go-interfaces/common"
 	commonSpecs "github.com/taubyte/go-specs/common"
 	"github.com/taubyte/tau/libdream"
@@ -15,6 +13,6 @@ func init() {
 	}
 }
 
-func createService(ctx context.Context, config *iface.ServiceConfig) (iface.Service, error) {
-	return New(ctx, common.NewDreamlandConfig(config))
+func createService(u *libdream.Universe, config *iface.ServiceConfig) (iface.Service, error) {
+	return New(u.Context(), common.NewDreamlandConfig(u, config))
 }

--- a/protocols/monkey/service.go
+++ b/protocols/monkey/service.go
@@ -71,11 +71,9 @@ func New(ctx context.Context, config *tauConfig.Node) (*Service, error) {
 		srv.dvPublicKey = config.DomainValidation.PublicKey
 	}
 
-	// For Odo
+	srv.clientNode = srv.node
 	if config.ClientNode != nil {
 		srv.clientNode = config.ClientNode
-	} else {
-		srv.clientNode = srv.node
 	}
 
 	// should end if any of the two contexts ends

--- a/protocols/patrick/dreamland.go
+++ b/protocols/patrick/dreamland.go
@@ -1,8 +1,6 @@
 package service
 
 import (
-	"context"
-
 	iface "github.com/taubyte/go-interfaces/common"
 	commonSpecs "github.com/taubyte/go-specs/common"
 	"github.com/taubyte/tau/libdream"
@@ -16,7 +14,7 @@ func init() {
 	}
 }
 
-func createPatrickService(ctx context.Context, config *iface.ServiceConfig) (iface.Service, error) {
+func createPatrickService(u *libdream.Universe, config *iface.ServiceConfig) (iface.Service, error) {
 	// Used to test cancel job on go-patrick-http
 	if result, ok := config.Others["delay"]; ok {
 		if result == 1 {
@@ -31,5 +29,5 @@ func createPatrickService(ctx context.Context, config *iface.ServiceConfig) (ifa
 		}
 	}
 
-	return New(ctx, common.NewDreamlandConfig(config))
+	return New(u.Context(), common.NewDreamlandConfig(u, config))
 }

--- a/protocols/patrick/dreamland_fixture_push.go
+++ b/protocols/patrick/dreamland_fixture_push.go
@@ -140,7 +140,7 @@ func pushSpecific(u *libdream.Universe, params ...interface{}) error {
 	if len(projectId) == 0 {
 		_repo, err := auth.Repositories().Github().Get(intRepoId)
 		if err != nil {
-			return fmt.Errorf("failed Making Repo: %v", err)
+			return fmt.Errorf("failed to fetch Repo: %v", err)
 		}
 		projectId = _repo.Project()
 	}

--- a/protocols/patrick/dreamland_fixture_two_jobs.go
+++ b/protocols/patrick/dreamland_fixture_two_jobs.go
@@ -81,11 +81,8 @@ func fixture(u *libdream.Universe, params ...interface{}) error {
 			return fmt.Errorf("unable to get tns client after 50 attempts")
 		}
 
-		tnsClient, err = simple.TNS()
+		tnsClient, _ = simple.TNS()
 		attempts++
-	}
-	if err != nil {
-		return fmt.Errorf("getting tns client failed with: %w", err)
 	}
 
 	attempts = 0

--- a/protocols/patrick/service.go
+++ b/protocols/patrick/service.go
@@ -55,7 +55,6 @@ func New(ctx context.Context, config *tauConfig.Node) (*PatrickService, error) {
 		srv.dbFactory = kvdb.New(srv.node)
 	}
 
-	// For odo
 	clientNode := srv.node
 	if config.ClientNode != nil {
 		clientNode = config.ClientNode

--- a/protocols/seer/dreamland.go
+++ b/protocols/seer/dreamland.go
@@ -1,7 +1,6 @@
 package seer
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/foxcpp/go-mockdns"
@@ -18,7 +17,7 @@ func init() {
 	}
 }
 
-func createService(ctx context.Context, config *iface.ServiceConfig) (iface.Service, error) {
+func createService(u *libdream.Universe, config *iface.ServiceConfig) (iface.Service, error) {
 
 	var mockResolver seer.Resolver
 	if config.Others["mock"] == 1 {
@@ -36,5 +35,5 @@ func createService(ctx context.Context, config *iface.ServiceConfig) (iface.Serv
 		mockResolver = mockServer.Resolver()
 	}
 
-	return New(ctx, common.NewDreamlandConfig(config), Resolver(mockResolver))
+	return New(u.Context(), common.NewDreamlandConfig(u, config), Resolver(mockResolver))
 }

--- a/protocols/seer/service.go
+++ b/protocols/seer/service.go
@@ -67,7 +67,6 @@ func New(ctx context.Context, config *tauConfig.Node, opts ...Options) (*Service
 		srv.dbFactory = kvdb.New(srv.node)
 	}
 
-	// For odo
 	clientNode := srv.node
 	if config.ClientNode != nil {
 		clientNode = config.ClientNode

--- a/protocols/substrate/dreamland.go
+++ b/protocols/substrate/dreamland.go
@@ -1,8 +1,6 @@
 package substrate
 
 import (
-	"context"
-
 	iface "github.com/taubyte/go-interfaces/common"
 	commonSpecs "github.com/taubyte/go-specs/common"
 	"github.com/taubyte/tau/libdream"
@@ -16,8 +14,8 @@ func init() {
 	}
 }
 
-func createNodeService(ctx context.Context, config *iface.ServiceConfig) (iface.Service, error) {
-	service, err := New(ctx, common.NewDreamlandConfig(config))
+func createNodeService(u *libdream.Universe, config *iface.ServiceConfig) (iface.Service, error) {
+	service, err := New(u.Context(), common.NewDreamlandConfig(u, config))
 	if err != nil {
 		return nil, err
 	}

--- a/protocols/tns/dreamland.go
+++ b/protocols/tns/dreamland.go
@@ -1,13 +1,10 @@
 package tns
 
 import (
-	"context"
-	"fmt"
-
 	iface "github.com/taubyte/go-interfaces/common"
 	commonSpecs "github.com/taubyte/go-specs/common"
-	tauConfig "github.com/taubyte/tau/config"
 	"github.com/taubyte/tau/libdream"
+	"github.com/taubyte/tau/libdream/common"
 )
 
 func init() {
@@ -16,13 +13,6 @@ func init() {
 	}
 }
 
-func createTNSService(ctx context.Context, config *iface.ServiceConfig) (iface.Service, error) {
-	return New(ctx, &tauConfig.Node{
-		Root:        config.Root,
-		P2PListen:   []string{fmt.Sprintf(libdream.DefaultP2PListenFormat, config.Port)},
-		P2PAnnounce: []string{fmt.Sprintf(libdream.DefaultP2PListenFormat, config.Port)},
-		DevMode:     true,
-		SwarmKey:    config.SwarmKey,
-		Databases:   config.Databases,
-	})
+func createTNSService(u *libdream.Universe, config *iface.ServiceConfig) (iface.Service, error) {
+	return New(u.Context(), common.NewDreamlandConfig(u, config))
 }


### PR DESCRIPTION
Fixtures only get context. Some need access to universe.

example:
```go
func createAuthService(ctx context.Context, config *iface.ServiceConfig) (iface.Service, error)
```
should be
```go
func createAuthService(u *libdream.Universe, config *iface.ServiceConfig) (iface.Service, error)
```

Also some odd behavior of auth under dream/dev  was fixed