### PR TITLE
chore: Remove unused modernc.org/sqlite dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools v2.2.0+incompatible
 	gotest.tools/v3 v3.5.1
-	modernc.org/sqlite v1.23.1
 )
 
 require (

--- a/protocols/seer/service.go
+++ b/protocols/seer/service.go
@@ -20,7 +20,6 @@ import (
 	"github.com/taubyte/tau/pkgs/kvdb"
 	protocolsCommon "github.com/taubyte/tau/protocols/common"
 
-	_ "modernc.org/sqlite"
 )
 
 var (


### PR DESCRIPTION
Hi i am working on [seer] forgotten _ import of sqlite #164.

1. delete import.

2.update go.mod.
(Manually instead of running go mod tidy.)