### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/vm-low-orbit/event/event.go
+++ b/pkg/vm-low-orbit/event/event.go
@@ -30,12 +30,12 @@ func (f *Factory) CreatePubsubEvent(msg *pubsub.Message) *Event {
 
 func (f *Factory) CreateHttpEvent(w http.ResponseWriter, r *http.Request) *Event {
 	q := r.URL.Query()
-	qKeys := make([]string, len(q))
+	qKeys := make([]string, 0, len(q))
 	for k := range q {
 		qKeys = append(qKeys, k)
 	}
 
-	hKeys := make([]string, len(r.Header))
+	hKeys := make([]string, 0, len(r.Header))
 	for k := range r.Header {
 		hKeys = append(hKeys, k)
 	}

--- a/pkg/vm/service/wazero/module_instance.go
+++ b/pkg/vm/service/wazero/module_instance.go
@@ -28,7 +28,7 @@ func (m *moduleInstance) Memory() vm.Memory {
 
 func (m *moduleInstance) Functions() []vm.FunctionDefinition {
 	defMap := m.module.ExportedFunctionDefinitions()
-	defs := make([]vm.FunctionDefinition, len(defMap))
+	defs := make([]vm.FunctionDefinition, 0, len(defMap))
 	for _, def := range defMap {
 		defs = append(defs, def)
 	}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of length rather than initializing the length of this slice. 

The only demo: https://go.dev/play/p/q1BcVCmvidW