### PR TITLE
Deployment issue: systemd-resolve not stopped and init issue with seer #292

### DIFF
--- a/pkg/http-auto/types.go
+++ b/pkg/http-auto/types.go
@@ -3,6 +3,9 @@ package auto
 import (
 	"crypto/tls"
 
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
 	basicHttp "github.com/taubyte/http/basic"
 	"github.com/taubyte/tau/config"
 	auth "github.com/taubyte/tau/core/services/auth"
@@ -18,4 +21,12 @@ type Service struct {
 	tnsClient           ifaceTns.Client
 	config              *config.Node
 	customDomainChecker func(hello *tls.ClientHelloInfo) bool
+
+	positiveCache *ttlcache.Cache[string, bool]
+	negativeCache *ttlcache.Cache[string, bool]
 }
+
+var (
+	PositiveTTL = 1 * time.Hour
+	NegativeTTL = 1 * time.Minute
+)

--- a/pkg/spore-drive/clients/js/src/Service.test.ts
+++ b/pkg/spore-drive/clients/js/src/Service.test.ts
@@ -5,7 +5,7 @@ describe("Service", () => {
 
   beforeAll(() => {
     service = new Service();
-    service["packageVersion"] = "0.1.0"; // override to a published version
+    service["packageVersion"] = "0.1.3"; // override to a published version
   });
 
   afterAll(async () => {
@@ -13,13 +13,14 @@ describe("Service", () => {
   });
 
   it("should return null when service is not running", async () => {
+    await service.kill();
     const port = await service.getPort();
     expect(port).toBe(null);
   });
 
   // TODO: re-enable once we release a spore-drive binary that supports healthcheck
   // Need to set the right version in line 8
-  it.skip("should run the full workflow", async () => {
+  it("should run the full workflow", async () => {
     console.log("Running the full workflow...");
 
     await service.run();

--- a/pkg/spore-drive/clients/js/src/Service.ts
+++ b/pkg/spore-drive/clients/js/src/Service.ts
@@ -114,8 +114,10 @@ export class Service {
     try {
       const hc = new Health(transport);
       await hc.ping();
+      console.log("Service is up on port", port);
       return true;
     } catch (e) {
+      console.log("Service is not up on port", port, e);
       return false;
     }
   }

--- a/pkg/vm/service/wazero/types.go
+++ b/pkg/vm/service/wazero/types.go
@@ -65,8 +65,7 @@ type runtime struct {
 	instance *instance
 	runtime  wazero.Runtime
 
-	wasiStartError error
-	wasiStartDone  chan bool
+	wasiStartDone chan bool
 }
 
 /*************** Service ***************/

--- a/services/auth/api_acme.go
+++ b/services/auth/api_acme.go
@@ -73,8 +73,8 @@ func (srv *AuthService) getACMECertificate(ctx context.Context, fqdn string) ([]
 }
 
 func (srv *AuthService) getACMEStaticCertificate(ctx context.Context, fqdn string) ([]byte, error) {
-	logger.Debugf("Get certificate for `%s`", fqdn)
-	defer logger.Debugf("Get certificate for `%s` done", fqdn)
+	logger.Debugf("Get static certificate for `%s`", fqdn)
+	defer logger.Debugf("Get static certificate for `%s` done", fqdn)
 
 	key := "/static/" + base64.StdEncoding.EncodeToString([]byte(fqdn)) + "/certificate/pem"
 	certificate, err := srv.db.Get(ctx, key)
@@ -95,7 +95,7 @@ func (srv *AuthService) getACMEStaticCertificate(ctx context.Context, fqdn strin
 		return nil, autocert.ErrCacheMiss
 	}
 
-	logger.Debugf("Get certificate for `%s`: %v", fqdn, certificate)
+	logger.Debugf("Get static certificate for `%s`: %v", fqdn, certificate)
 
 	return certificate, nil
 }

--- a/services/seer/pubsub.go
+++ b/services/seer/pubsub.go
@@ -48,7 +48,7 @@ func (srv *Service) pubsubMsgHandler(msg *pubsub.Message) {
 			}
 		}
 		if node.Geo != nil {
-			srv.geo.setNode(srv.node.Context(), node.Cid, node.Geo.Location)
+			_, err = srv.geo.setNode(srv.node.Context(), node.Cid, node.Geo.Location)
 			if err != nil {
 				logger.Error("Failed inserting node geo with: %s", err.Error())
 			}

--- a/services/substrate/runtime/shadow.go
+++ b/services/substrate/runtime/shadow.go
@@ -110,7 +110,9 @@ func (s *Shadows) gc() {
 
 func (s *Shadows) keep() {
 	select {
-	case s.more <- struct{}{}: // Send if not blocking
+	case <-s.ctx.Done():
+		return
+	case s.more <- struct{}{}:
 	default:
 	}
 }


### PR DESCRIPTION
- fixed panic issue with seer, which was caused by init order.
- fixed logic for detecting systemd resolv with spore-drive.

Plus, as I was testing:
- optimized acme certificate handling.
- cleared _ready race.
- fixed shadow panic on closed channel.