### PR TITLE
[bug] Improve error handling in raft healing wipe operations

### DIFF
--- a/pkg/raft/healing.go
+++ b/pkg/raft/healing.go
@@ -573,19 +573,30 @@ func (h *healer) wipeRaftState(ctx context.Context) {
 			KeysOnly: true,
 		})
 		if err != nil {
+			healLogger.Warnf("[%s] failed to query %s keys during wipe: %v",
+				h.cluster.node.ID().ShortString(), sub, err)
 			continue
 		}
 		for result := range results.Next() {
 			if result.Error != nil {
+				healLogger.Warnf("[%s] error iterating %s keys during wipe: %v",
+					h.cluster.node.ID().ShortString(), sub, result.Error)
 				break
 			}
-			store.Delete(ctx, ds.NewKey(result.Key))
+			if err := store.Delete(ctx, ds.NewKey(result.Key)); err != nil {
+				healLogger.Warnf("[%s] failed to delete key %s during wipe: %v",
+					h.cluster.node.ID().ShortString(), result.Key, err)
+			}
 		}
 		results.Close()
 	}
 }
 
 func (f *fileSnapshotStore) wipeAll() {
-	os.RemoveAll(f.dir)
-	os.MkdirAll(f.dir, 0755)
+	if err := os.RemoveAll(f.dir); err != nil {
+		healLogger.Warnf("failed to remove snapshot dir %s: %v", f.dir, err)
+	}
+	if err := os.MkdirAll(f.dir, 0755); err != nil {
+		healLogger.Errorf("failed to recreate snapshot dir %s: %v", f.dir, err)
+	}
 }


### PR DESCRIPTION
Closes #442

## Summary

This PR improves error handling during raft healing cleanup operations by checking and logging errors that were previously ignored.

## Changes

### `wipeRaftState`

Added error handling and logging for:

- `store.Query`
- `results.Next()` iteration
- `store.Delete`

### `wipeAll`

Added error handling and logging for:

- `os.RemoveAll`
- `os.MkdirAll`

All cleanup failures are now logged using `healLogger`, making it easier to diagnose issues during split-brain recovery.

## Why

Before this change, cleanup operations could fail silently, potentially leaving partial raft state behind without any indication in the logs. This makes troubleshooting difficult and increases the risk of inconsistent raft state after healing.

With this PR:

- Errors are no longer silently ignored.
- Cleanup failures become visible through logs.
- Observability and reliability of raft healing are improved while preserving the existing behavior.

## Testing

- Verified the project builds successfully.
- Confirmed the new error handling paths compile correctly.
- Existing cleanup behavior is preserved with additional logging.