### PR TITLE
[accounts] invite + git-link email templates; SMTP header hardening

### DIFF
--- a/services/accounts/email/smtp.go
+++ b/services/accounts/email/smtp.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/mail"
 	"net/smtp"
+	"time"
 )
 
 // SMTPSender delivers email via a configured SMTP server. Credentials are
@@ -44,16 +46,36 @@ func NewSMTPSender(host string, port int, user, pass, from string) (*SMTPSender,
 	}, nil
 }
 
-// Send delivers a plain-text message. v1 ships text-only; HTML / MIME comes
-// when we have richer templates.
+// Send delivers a plain-text message with the full transactional-email
+// header set gmail/microsoft expect before they stop classifying as bulk:
+// MIME-Version + Content-Type so the body isn't sniffed, Date so the message
+// isn't "no temporal reference", and a friendly From if the operator gave
+// one. We parse s.From with net/mail so display-name forms like
+// `tau <noreply@ac.dz>` set the header correctly while the SMTP envelope
+// still uses just the address — sending the display form on MAIL FROM
+// would 501 every relay on the path.
 func (s *SMTPSender) Send(ctx context.Context, to, subject, body string) error {
-	addr := fmt.Sprintf("%s:%d", s.Host, s.Port)
-	msg := []byte(fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\n\r\n%s\r\n", s.From, to, subject, body))
+	from, err := mail.ParseAddress(s.From)
+	if err != nil {
+		return fmt.Errorf("email: parse From %q: %w", s.From, err)
+	}
+	msg := []byte(
+		"From: " + from.String() + "\r\n" +
+			"To: " + to + "\r\n" +
+			"Subject: " + subject + "\r\n" +
+			"Date: " + time.Now().UTC().Format(time.RFC1123Z) + "\r\n" +
+			"MIME-Version: 1.0\r\n" +
+			"Content-Type: text/plain; charset=UTF-8\r\n" +
+			"Content-Transfer-Encoding: 8bit\r\n" +
+			"\r\n" +
+			body + "\r\n",
+	)
 	var auth smtp.Auth
 	if s.User != "" {
 		auth = smtp.PlainAuth("", s.User, s.Pass, s.Host)
 	}
-	if err := s.dialer(addr, auth, s.From, []string{to}, msg); err != nil {
+	addr := fmt.Sprintf("%s:%d", s.Host, s.Port)
+	if err := s.dialer(addr, auth, from.Address, []string{to}, msg); err != nil {
 		return fmt.Errorf("email: SMTP send to %s: %w", to, err)
 	}
 	return nil

--- a/services/accounts/email/templates.go
+++ b/services/accounts/email/templates.go
@@ -65,3 +65,137 @@ func RenderMagicLink(d MagicLinkTemplateData) (subject, body string, err error) 
 	}
 	return magicLinkSubject, buf.String(), nil
 }
+
+// Variables passed to MagicInviteTemplate:
+//   - InviterDisplay: name/email of the admin who issued the invite (best-effort)
+//   - AccountName: target account display name
+//   - Role: cluster-side Member role (owner/admin/viewer/billing)
+//   - URL: full invite landing URL (PublicURL + /invite?token=...)
+//   - TTLHours: integer hours from issue to expiry
+
+const magicInviteBody = `Hi,
+
+{{.InviterDisplay}} has invited you to join {{.AccountName}} as
+{{.Role}} on tau.
+
+Open this link to accept or decline:
+
+    {{.URL}}
+
+This invitation expires in {{.TTLHours}} hours. If you weren't
+expecting it, you can safely ignore — declining is one click.
+
+— tau
+`
+
+const magicInviteSubjectTpl = `You've been invited to {{.AccountName}}`
+
+// MagicInviteTemplateData is the variable bag for the member-invite email.
+type MagicInviteTemplateData struct {
+	InviterDisplay string
+	AccountName    string
+	Role           string
+	URL            string
+	TTLHours       int
+}
+
+// Variables passed to MagicGitLinkTemplate:
+//   - InviterDisplay: admin display string ("name (email)" or bare email)
+//   - AccountName: target account display name
+//   - Provider: human-facing provider name (e.g. "GitHub")
+//   - RequiredLogin: optional pinned provider handle ("alice-dev") — empty when no constraint
+//   - RequiredOrganization: optional pinned provider org / group — empty when no constraint
+//   - URL: full landing URL (PublicURL + /git-link?token=...)
+//   - TTLHours: integer hours from issue to expiry
+
+const magicGitLinkBody = `Hi,
+
+{{.InviterDisplay}} has invited you to link your {{.Provider}} account
+to {{.AccountName}} on tau.{{if .RequiredLogin}}
+
+Please sign in as {{.RequiredLogin}} — the admin pinned this invite to
+that specific {{.Provider}} handle.{{end}}{{if .RequiredOrganization}}
+
+Your {{.Provider}} account must be a member of {{.RequiredOrganization}}.{{end}}
+
+Open this link and sign in with {{.Provider}} to complete the link:
+
+    {{.URL}}
+
+This link expires in {{.TTLHours}} hours. If you weren't expecting it,
+you can safely ignore — declining is one click.
+
+— tau
+`
+
+const magicGitLinkSubjectTpl = `Link your {{.Provider}} to {{.AccountName}}`
+
+// MagicGitLinkTemplateData is the variable bag for the git-link email.
+type MagicGitLinkTemplateData struct {
+	InviterDisplay       string
+	AccountName          string
+	Provider             string
+	RequiredLogin        string
+	RequiredOrganization string
+	URL                  string
+	TTLHours             int
+}
+
+// RenderMagicGitLink renders the git-link invitation email. Subject and
+// body both templated so the recipient's inbox preview names the account +
+// provider before they open.
+func RenderMagicGitLink(d MagicGitLinkTemplateData) (subject, body string, err error) {
+	if d.URL == "" {
+		return "", "", errors.New("email: git-link URL required")
+	}
+	if d.AccountName == "" {
+		return "", "", errors.New("email: git-link AccountName required")
+	}
+	if d.Provider == "" {
+		return "", "", errors.New("email: git-link Provider required")
+	}
+	bodyTpl, err := template.New("magic-gitlink-body").Parse(magicGitLinkBody)
+	if err != nil {
+		return "", "", fmt.Errorf("email: parse magic-gitlink body template: %w", err)
+	}
+	subjTpl, err := template.New("magic-gitlink-subject").Parse(magicGitLinkSubjectTpl)
+	if err != nil {
+		return "", "", fmt.Errorf("email: parse magic-gitlink subject template: %w", err)
+	}
+	var bodyBuf, subjBuf bytes.Buffer
+	if err := bodyTpl.Execute(&bodyBuf, d); err != nil {
+		return "", "", fmt.Errorf("email: render magic-gitlink body: %w", err)
+	}
+	if err := subjTpl.Execute(&subjBuf, d); err != nil {
+		return "", "", fmt.Errorf("email: render magic-gitlink subject: %w", err)
+	}
+	return subjBuf.String(), bodyBuf.String(), nil
+}
+
+// RenderMagicInvite renders the member-invite email. Both subject and body
+// are templated (subject substitutes AccountName so the recipient sees what
+// they're being invited to before opening the message).
+func RenderMagicInvite(d MagicInviteTemplateData) (subject, body string, err error) {
+	if d.URL == "" {
+		return "", "", errors.New("email: invite URL required")
+	}
+	if d.AccountName == "" {
+		return "", "", errors.New("email: invite AccountName required")
+	}
+	bodyTpl, err := template.New("magic-invite-body").Parse(magicInviteBody)
+	if err != nil {
+		return "", "", fmt.Errorf("email: parse magic-invite body template: %w", err)
+	}
+	subjTpl, err := template.New("magic-invite-subject").Parse(magicInviteSubjectTpl)
+	if err != nil {
+		return "", "", fmt.Errorf("email: parse magic-invite subject template: %w", err)
+	}
+	var bodyBuf, subjBuf bytes.Buffer
+	if err := bodyTpl.Execute(&bodyBuf, d); err != nil {
+		return "", "", fmt.Errorf("email: render magic-invite body: %w", err)
+	}
+	if err := subjTpl.Execute(&subjBuf, d); err != nil {
+		return "", "", fmt.Errorf("email: render magic-invite subject: %w", err)
+	}
+	return subjBuf.String(), bodyBuf.String(), nil
+}

--- a/services/accounts/email/templates_test.go
+++ b/services/accounts/email/templates_test.go
@@ -55,3 +55,103 @@ func TestRenderMagicLink_RequiresCode(t *testing.T) {
 		t.Fatalf("expected error for empty code")
 	}
 }
+
+func TestRenderMagicInvite_RendersAllFields(t *testing.T) {
+	subject, body, err := RenderMagicInvite(MagicInviteTemplateData{
+		InviterDisplay: "Alice (alice@example.com)",
+		AccountName:    "Acme Corp",
+		Role:           "admin",
+		URL:            "https://accounts.example.com/invite?token=abc",
+		TTLHours:       168,
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	// Subject names the account so the inbox preview is meaningful.
+	if !strings.Contains(subject, "Acme Corp") {
+		t.Fatalf("subject must name account: %s", subject)
+	}
+	// Body surfaces the human-readable inviter, role, URL, TTL.
+	for _, want := range []string{
+		"Alice (alice@example.com)",
+		"Acme Corp",
+		"as\nadmin",
+		"https://accounts.example.com/invite?token=abc",
+		"168 hours",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q: %s", want, body)
+		}
+	}
+}
+
+func TestRenderMagicInvite_RequiresURLAndAccountName(t *testing.T) {
+	if _, _, err := RenderMagicInvite(MagicInviteTemplateData{AccountName: "Acme"}); err == nil {
+		t.Fatalf("expected error for empty URL")
+	}
+	if _, _, err := RenderMagicInvite(MagicInviteTemplateData{URL: "u"}); err == nil {
+		t.Fatalf("expected error for empty AccountName")
+	}
+}
+
+func TestRenderMagicGitLink_Default_NoConstraints(t *testing.T) {
+	subject, body, err := RenderMagicGitLink(MagicGitLinkTemplateData{
+		InviterDisplay: "Alice (alice@example.com)",
+		AccountName:    "Acme Corp",
+		Provider:       "GitHub",
+		URL:            "https://accounts.example.com/git-link?token=abc",
+		TTLHours:       168,
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(subject, "GitHub") || !strings.Contains(subject, "Acme Corp") {
+		t.Fatalf("subject must name provider + account: %s", subject)
+	}
+	for _, want := range []string{
+		"Alice (alice@example.com)", "Acme Corp", "GitHub",
+		"https://accounts.example.com/git-link?token=abc",
+		"168 hours",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q: %s", want, body)
+		}
+	}
+	// Constraint lines must NOT show when both constraints are empty.
+	if strings.Contains(body, "pinned this invite") {
+		t.Fatalf("body should not mention login constraint when none set")
+	}
+	if strings.Contains(body, "must be a member") {
+		t.Fatalf("body should not mention org constraint when none set")
+	}
+}
+
+func TestRenderMagicGitLink_WithConstraints(t *testing.T) {
+	_, body, err := RenderMagicGitLink(MagicGitLinkTemplateData{
+		InviterDisplay:       "Admin",
+		AccountName:          "Acme",
+		Provider:             "GitHub",
+		RequiredLogin:        "alice-dev",
+		RequiredOrganization: "taubyte",
+		URL:                  "u",
+		TTLHours:             24,
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(body, "alice-dev") || !strings.Contains(body, "taubyte") {
+		t.Fatalf("body must surface pinned constraints: %s", body)
+	}
+}
+
+func TestRenderMagicGitLink_RequiresURLAccountAndProvider(t *testing.T) {
+	if _, _, err := RenderMagicGitLink(MagicGitLinkTemplateData{AccountName: "Acme", Provider: "GitHub"}); err == nil {
+		t.Fatalf("expected error for empty URL")
+	}
+	if _, _, err := RenderMagicGitLink(MagicGitLinkTemplateData{URL: "u", Provider: "GitHub"}); err == nil {
+		t.Fatalf("expected error for empty AccountName")
+	}
+	if _, _, err := RenderMagicGitLink(MagicGitLinkTemplateData{URL: "u", AccountName: "Acme"}); err == nil {
+		t.Fatalf("expected error for empty Provider")
+	}
+}


### PR DESCRIPTION
## What

### New transactional email templates (`services/accounts/email`)
- `RenderMagicInvite` — account-member invitation (magic link to accept/decline)
- `RenderMagicGitLink` — git-account link request, with optional pinned-login / pinned-org constraint lines

Both validate required fields and have full test coverage.

### SMTP sender hardening
- Emits the full transactional header set (`Date`, `MIME-Version`, `Content-Type`, `Content-Transfer-Encoding`) so Gmail/Microsoft don't classify the mail as bulk
- Parses `From` with `net/mail`, so display-name forms (`Ops <ops@x.y>`) work in the header while the SMTP envelope uses the bare address

## Why

The tam accounts service (ee) gains member-invite and GitHub account-link flows; these are the emails those flows send. Deliverability fixes come from testing against real Gmail/Outlook recipients.

## Testing
`go test ./services/accounts/email/` green (isolated from the rest of the working tree before push). Purely additive — no callers change in this PR.