### PR TITLE
[accounts] PRefs: global plans + account-scoped plan references

### DIFF
--- a/clients/http/accounts/management.go
+++ b/clients/http/accounts/management.go
@@ -127,14 +127,14 @@ func (c *Client) RemoveUser(accountID, userID string) error {
 	}, "", nil)
 }
 
-func (c *Client) GrantPlan(accountID, userID, planID string) error {
-	if accountID == "" || userID == "" || planID == "" {
-		return errors.New("GrantPlan: account_id, user_id, plan_id required")
+func (c *Client) GrantPRef(accountID, userID, prefName string) error {
+	if accountID == "" || userID == "" || prefName == "" {
+		return errors.New("GrantPRef: account_id, user_id, pref_name required")
 	}
 	return c.sendMgmt("/users", map[string]any{
 		"action":     "grant",
 		"account_id": accountID,
 		"id":         userID,
-		"plan_id":    planID,
+		"pref_name":  prefName,
 	}, "", nil)
 }

--- a/clients/p2p/accounts/accounts.go
+++ b/clients/p2p/accounts/accounts.go
@@ -14,12 +14,11 @@ type accountsImpl struct {
 
 func (i *accountsImpl) Create(ctx context.Context, in accountsIface.CreateAccountInput) (*accountsIface.Account, error) {
 	body := command.Body{
-		"action":        "create",
-		"slug":          in.Slug,
-		"name":          in.Name,
-		"kind":          string(in.Kind),
-		"auth_mode":     string(in.AuthMode),
-		"plan_template": in.PlanTemplate,
+		"action":    "create",
+		"slug":      in.Slug,
+		"name":      in.Name,
+		"kind":      string(in.Kind),
+		"auth_mode": string(in.AuthMode),
 	}
 	if in.AuthConfig != nil {
 		body["auth_config"] = in.AuthConfig
@@ -81,9 +80,6 @@ func (i *accountsImpl) Update(ctx context.Context, accountID string, in accounts
 	}
 	if in.AuthMode != nil {
 		body["auth_mode"] = string(*in.AuthMode)
-	}
-	if in.PlanTemplate != nil {
-		body["plan_template"] = *in.PlanTemplate
 	}
 	if in.Status != nil {
 		body["status"] = string(*in.Status)

--- a/clients/p2p/accounts/client.go
+++ b/clients/p2p/accounts/client.go
@@ -16,10 +16,8 @@ import (
 
 var logger = log.Logger("tau.accounts.client")
 
-// Client is the P2P client for the Accounts service. Wraps a stream client
-// against the protocol registered by services/accounts; per-entity wire
-// methods live in accounts.go / members.go / users.go / plans.go /
-// tokens.go / login.go.
+// Client is the P2P client for the Accounts service. Per-entity wire methods
+// live in accounts.go / members.go / users.go / plans.go / prefs.go / login.go.
 type Client struct {
 	client *streamClient.Client
 	node   peer.Node
@@ -28,7 +26,6 @@ type Client struct {
 
 var _ accountsIface.Client = (*Client)(nil)
 
-// New constructs a P2P accounts client over the given node.
 func New(ctx context.Context, node peer.Node) (accountsIface.Client, error) {
 	var (
 		c   Client
@@ -43,22 +40,16 @@ func New(ctx context.Context, node peer.Node) (accountsIface.Client, error) {
 	return &c, nil
 }
 
-// Close releases the underlying P2P stream client.
 func (c *Client) Close() {
 	c.client.Close()
 }
 
-// Peers narrows subsequent calls to a specific peer subset.
 func (c *Client) Peers(peers ...peerCore.ID) accountsIface.Client {
 	cp := *c
 	cp.peers = peers
 	return &cp
 }
 
-// --- Integration surface (verify + plan-resolve) ----------------
-
-// Verify asks an accounts service node whether a (provider, external_id) git
-// account is linked to ≥1 Account.
 func (c *Client) Verify(ctx context.Context, provider, externalID string) (*accountsIface.VerifyResponse, error) {
 	resp, err := c.client.Send(verbVerify, command.Body{
 		"provider":    provider,
@@ -70,23 +61,41 @@ func (c *Client) Verify(ctx context.Context, provider, externalID string) (*acco
 	return decodeVerifyResponse(resp)
 }
 
-// ResolvePlan asks an accounts service node whether (account_slug,
-// plan_slug) names an active Plan the (provider, external_id) git user
-// has a grant on.
-func (c *Client) ResolvePlan(ctx context.Context, accountSlug, planSlug, provider, externalID string) (*accountsIface.ResolveResponse, error) {
+func (c *Client) LookupAccountsByEmail(ctx context.Context, email string) ([]string, error) {
+	resp, err := c.client.Send(verbLookupAccountsByEmail, command.Body{
+		"email": email,
+	}, c.peers...)
+	if err != nil {
+		return nil, fmt.Errorf("accounts.LookupAccountsByEmail: %w", err)
+	}
+	var ids []string
+	if v, ok := resp["account_ids"]; ok {
+		raw, err := cbor.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("accounts.LookupAccountsByEmail: re-encode: %w", err)
+		}
+		if err := cbor.Unmarshal(raw, &ids); err != nil {
+			return nil, fmt.Errorf("accounts.LookupAccountsByEmail: decode: %w", err)
+		}
+	}
+	if ids == nil {
+		ids = []string{}
+	}
+	return ids, nil
+}
+
+func (c *Client) ResolvePRef(ctx context.Context, accountSlug, prefName, provider, externalID string) (*accountsIface.ResolveResponse, error) {
 	resp, err := c.client.Send(verbResolve, command.Body{
 		"account_slug": accountSlug,
-		"plan_slug":    planSlug,
+		"pref_name":    prefName,
 		"provider":     provider,
 		"external_id":  externalID,
 	}, c.peers...)
 	if err != nil {
-		return nil, fmt.Errorf("accounts.ResolvePlan: %w", err)
+		return nil, fmt.Errorf("accounts.ResolvePRef: %w", err)
 	}
 	return decodeResolveResponse(resp)
 }
-
-// --- Management surface --------------------------------------------
 
 func (c *Client) Accounts() accountsIface.Accounts { return &accountsImpl{c: c} }
 func (c *Client) Members(accountID string) accountsIface.Members {
@@ -95,16 +104,18 @@ func (c *Client) Members(accountID string) accountsIface.Members {
 func (c *Client) Users(accountID string) accountsIface.Users {
 	return &usersImpl{c: c, accountID: accountID}
 }
-func (c *Client) Plans(accountID string) accountsIface.Plans {
-	return &plansImpl{c: c, accountID: accountID}
+func (c *Client) Plans() accountsIface.Plans {
+	return &plansImpl{c: c}
+}
+func (c *Client) PRefs(accountID string) accountsIface.PRefs {
+	return &prefsImpl{c: c, accountID: accountID}
 }
 func (c *Client) Login() accountsIface.Login { return &loginImpl{c: c} }
 
-// --- Verify / Resolve verb constants and decoding ----------------
-
 const (
-	verbVerify  = "verify"
-	verbResolve = "resolve"
+	verbVerify                = "verify"
+	verbResolve               = "resolve"
+	verbLookupAccountsByEmail = "lookup_accounts_by_email"
 )
 
 func decodeVerifyResponse(resp map[string]any) (*accountsIface.VerifyResponse, error) {
@@ -128,16 +139,27 @@ func decodeResolveResponse(resp map[string]any) (*accountsIface.ResolveResponse,
 		Valid:  tryBool(resp, "valid"),
 		Reason: tryString(resp, "reason"),
 	}
+	if v, ok := resp["pref"]; ok {
+		raw, err := cbor.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("accounts.ResolvePRef: re-encode pref: %w", err)
+		}
+		var pref accountsIface.PRef
+		if err := cbor.Unmarshal(raw, &pref); err != nil {
+			return nil, fmt.Errorf("accounts.ResolvePRef: decode pref: %w", err)
+		}
+		out.PRef = &pref
+	}
 	if v, ok := resp["plan"]; ok {
 		raw, err := cbor.Marshal(v)
 		if err != nil {
-			return nil, fmt.Errorf("accounts.ResolvePlan: re-encode plan: %w", err)
+			return nil, fmt.Errorf("accounts.ResolvePRef: re-encode plan: %w", err)
 		}
-		var b accountsIface.Plan
-		if err := cbor.Unmarshal(raw, &b); err != nil {
-			return nil, fmt.Errorf("accounts.ResolvePlan: decode plan: %w", err)
+		var p accountsIface.Plan
+		if err := cbor.Unmarshal(raw, &p); err != nil {
+			return nil, fmt.Errorf("accounts.ResolvePRef: decode plan: %w", err)
 		}
-		out.Plan = &b
+		out.Plan = &p
 	}
 	return out, nil
 }

--- a/clients/p2p/accounts/plans.go
+++ b/clients/p2p/accounts/plans.go
@@ -8,22 +8,21 @@ import (
 	"github.com/taubyte/tau/p2p/streams/command"
 )
 
+// plansImpl is the P2P client for the global Plan catalogue. Plans are not
+// scoped to an account; the only operations are Create (operator-only), Get,
+// and List.
 type plansImpl struct {
-	c         *Client
-	accountID string
+	c *Client
 }
 
 func (i *plansImpl) Create(ctx context.Context, in accountsIface.CreatePlanInput) (*accountsIface.Plan, error) {
 	body := command.Body{
-		"action":     "create",
-		"account_id": i.accountID,
-		"slug":       in.Slug,
-		"name":       in.Name,
-		"mode":       string(in.Mode),
-		"period":     in.Period,
+		"action":       "create",
+		"name":         in.Name,
+		"display_name": in.DisplayName,
 	}
-	if in.Dimensions != nil {
-		body["dimensions"] = in.Dimensions
+	if in.Data != nil {
+		body["data"] = in.Data
 	}
 	resp, err := i.c.client.Send(verbPlan, body, i.c.peers...)
 	if err != nil {
@@ -38,7 +37,7 @@ func (i *plansImpl) Create(ctx context.Context, in accountsIface.CreatePlanInput
 
 func (i *plansImpl) Get(ctx context.Context, planID string) (*accountsIface.Plan, error) {
 	resp, err := i.c.client.Send(verbPlan, command.Body{
-		"action": "get", "account_id": i.accountID, "id": planID,
+		"action": "get", "id": planID,
 	}, i.c.peers...)
 	if err != nil {
 		return nil, fmt.Errorf("plans.Get: %w", err)
@@ -50,23 +49,9 @@ func (i *plansImpl) Get(ctx context.Context, planID string) (*accountsIface.Plan
 	return &p, nil
 }
 
-func (i *plansImpl) GetBySlug(ctx context.Context, slug string) (*accountsIface.Plan, error) {
-	resp, err := i.c.client.Send(verbPlan, command.Body{
-		"action": "get-by-slug", "account_id": i.accountID, "slug": slug,
-	}, i.c.peers...)
-	if err != nil {
-		return nil, fmt.Errorf("plans.GetBySlug: %w", err)
-	}
-	var p accountsIface.Plan
-	if err := readField(resp, "plan", &p); err != nil {
-		return nil, err
-	}
-	return &p, nil
-}
-
 func (i *plansImpl) List(ctx context.Context) ([]string, error) {
 	resp, err := i.c.client.Send(verbPlan, command.Body{
-		"action": "list", "account_id": i.accountID,
+		"action": "list",
 	}, i.c.peers...)
 	if err != nil {
 		return nil, fmt.Errorf("plans.List: %w", err)
@@ -76,46 +61,4 @@ func (i *plansImpl) List(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 	return ids, nil
-}
-
-func (i *plansImpl) Update(ctx context.Context, planID string, in accountsIface.UpdatePlanInput) (*accountsIface.Plan, error) {
-	body := command.Body{
-		"action":     "update",
-		"account_id": i.accountID,
-		"id":         planID,
-	}
-	if in.Name != nil {
-		body["name"] = *in.Name
-	}
-	if in.Mode != nil {
-		body["mode"] = string(*in.Mode)
-	}
-	if in.Period != nil {
-		body["period"] = *in.Period
-	}
-	if in.Status != nil {
-		body["status"] = string(*in.Status)
-	}
-	if in.Dimensions != nil {
-		body["dimensions"] = in.Dimensions
-	}
-	resp, err := i.c.client.Send(verbPlan, body, i.c.peers...)
-	if err != nil {
-		return nil, fmt.Errorf("plans.Update: %w", err)
-	}
-	var p accountsIface.Plan
-	if err := readField(resp, "plan", &p); err != nil {
-		return nil, err
-	}
-	return &p, nil
-}
-
-func (i *plansImpl) Delete(ctx context.Context, planID string) error {
-	resp, err := i.c.client.Send(verbPlan, command.Body{
-		"action": "delete", "account_id": i.accountID, "id": planID,
-	}, i.c.peers...)
-	if err != nil {
-		return fmt.Errorf("plans.Delete: %w", err)
-	}
-	return expectOK(resp, "plans.Delete")
 }

--- a/clients/p2p/accounts/prefs.go
+++ b/clients/p2p/accounts/prefs.go
@@ -1,0 +1,171 @@
+package accounts
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	accountsIface "github.com/taubyte/tau/core/services/accounts"
+	"github.com/taubyte/tau/p2p/streams/command"
+)
+
+// prefsImpl is the P2P client for one Account's PRef surface.
+type prefsImpl struct {
+	c         *Client
+	accountID string
+}
+
+func (i *prefsImpl) Create(ctx context.Context, in accountsIface.CreatePRefInput) (*accountsIface.PRef, error) {
+	resp, err := i.c.client.Send(verbPRef, command.Body{
+		"action":       "create",
+		"account_id":   i.accountID,
+		"name":         in.Name,
+		"display_name": in.DisplayName,
+		"member_id":    in.MemberID,
+	}, i.c.peers...)
+	if err != nil {
+		return nil, fmt.Errorf("prefs.Create: %w", err)
+	}
+	var pref accountsIface.PRef
+	if err := readField(resp, "pref", &pref); err != nil {
+		return nil, err
+	}
+	return &pref, nil
+}
+
+func (i *prefsImpl) Get(ctx context.Context, name string) (*accountsIface.PRef, error) {
+	resp, err := i.c.client.Send(verbPRef, command.Body{
+		"action":     "get",
+		"account_id": i.accountID,
+		"name":       name,
+	}, i.c.peers...)
+	if err != nil {
+		return nil, fmt.Errorf("prefs.Get: %w", err)
+	}
+	var pref accountsIface.PRef
+	if err := readField(resp, "pref", &pref); err != nil {
+		return nil, err
+	}
+	return &pref, nil
+}
+
+func (i *prefsImpl) List(ctx context.Context) ([]string, error) {
+	resp, err := i.c.client.Send(verbPRef, command.Body{
+		"action":     "list",
+		"account_id": i.accountID,
+	}, i.c.peers...)
+	if err != nil {
+		return nil, fmt.Errorf("prefs.List: %w", err)
+	}
+	var names []string
+	if err := readField(resp, "names", &names); err != nil {
+		return nil, err
+	}
+	return names, nil
+}
+
+func (i *prefsImpl) SetDisplayName(ctx context.Context, name, displayName string) (*accountsIface.PRef, error) {
+	resp, err := i.c.client.Send(verbPRef, command.Body{
+		"action":       "set-display-name",
+		"account_id":   i.accountID,
+		"name":         name,
+		"display_name": displayName,
+	}, i.c.peers...)
+	if err != nil {
+		return nil, fmt.Errorf("prefs.SetDisplayName: %w", err)
+	}
+	var pref accountsIface.PRef
+	if err := readField(resp, "pref", &pref); err != nil {
+		return nil, err
+	}
+	return &pref, nil
+}
+
+func (i *prefsImpl) Assign(ctx context.Context, in accountsIface.AssignPRefInput) (*accountsIface.PRefEvent, error) {
+	resp, err := i.c.client.Send(verbPRef, command.Body{
+		"action":     "assign",
+		"account_id": i.accountID,
+		"name":       in.Name,
+		"plan_id":    in.PlanID,
+		"member_id":  in.MemberID,
+		"note":       in.Note,
+	}, i.c.peers...)
+	if err != nil {
+		return nil, fmt.Errorf("prefs.Assign: %w", err)
+	}
+	var ev accountsIface.PRefEvent
+	if err := readField(resp, "event", &ev); err != nil {
+		return nil, err
+	}
+	return &ev, nil
+}
+
+func (i *prefsImpl) Disable(ctx context.Context, in accountsIface.DisablePRefInput) (*accountsIface.PRefEvent, error) {
+	resp, err := i.c.client.Send(verbPRef, command.Body{
+		"action":     "disable",
+		"account_id": i.accountID,
+		"name":       in.Name,
+		"member_id":  in.MemberID,
+		"note":       in.Note,
+	}, i.c.peers...)
+	if err != nil {
+		return nil, fmt.Errorf("prefs.Disable: %w", err)
+	}
+	var ev accountsIface.PRefEvent
+	if err := readField(resp, "event", &ev); err != nil {
+		return nil, err
+	}
+	return &ev, nil
+}
+
+func (i *prefsImpl) Enable(ctx context.Context, in accountsIface.EnablePRefInput) (*accountsIface.PRefEvent, error) {
+	resp, err := i.c.client.Send(verbPRef, command.Body{
+		"action":     "enable",
+		"account_id": i.accountID,
+		"name":       in.Name,
+		"member_id":  in.MemberID,
+		"note":       in.Note,
+	}, i.c.peers...)
+	if err != nil {
+		return nil, fmt.Errorf("prefs.Enable: %w", err)
+	}
+	var ev accountsIface.PRefEvent
+	if err := readField(resp, "event", &ev); err != nil {
+		return nil, err
+	}
+	return &ev, nil
+}
+
+func (i *prefsImpl) Events(ctx context.Context, name string, from, to time.Time) ([]accountsIface.PRefEvent, error) {
+	body := command.Body{
+		"action":     "events",
+		"account_id": i.accountID,
+		"name":       name,
+	}
+	if !from.IsZero() {
+		body["from_unixnano"] = from.UnixNano()
+	}
+	if !to.IsZero() {
+		body["to_unixnano"] = to.UnixNano()
+	}
+	resp, err := i.c.client.Send(verbPRef, body, i.c.peers...)
+	if err != nil {
+		return nil, fmt.Errorf("prefs.Events: %w", err)
+	}
+	var events []accountsIface.PRefEvent
+	if err := readField(resp, "events", &events); err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+func (i *prefsImpl) LatestEvent(ctx context.Context, name string) (*accountsIface.PRefEvent, error) {
+	events, err := i.Events(ctx, name, time.Time{}, time.Time{})
+	if err != nil {
+		return nil, err
+	}
+	if len(events) == 0 {
+		return nil, fmt.Errorf("prefs.LatestEvent: no events for %q", name)
+	}
+	return &events[len(events)-1], nil
+}

--- a/clients/p2p/accounts/users.go
+++ b/clients/p2p/accounts/users.go
@@ -84,12 +84,12 @@ func (i *usersImpl) Remove(ctx context.Context, userID string) error {
 	return expectOK(resp, "users.Remove")
 }
 
-func (i *usersImpl) Grant(ctx context.Context, userID string, in accountsIface.GrantPlanInput) error {
+func (i *usersImpl) Grant(ctx context.Context, userID string, in accountsIface.GrantPRefInput) error {
 	resp, err := i.c.client.Send(verbUser, command.Body{
 		"action":     "grant",
 		"account_id": i.accountID,
 		"id":         userID,
-		"plan_id":    in.PlanID,
+		"pref_name":  in.PRefName,
 		"is_default": in.IsDefault,
 	}, i.c.peers...)
 	if err != nil {
@@ -98,10 +98,10 @@ func (i *usersImpl) Grant(ctx context.Context, userID string, in accountsIface.G
 	return expectOK(resp, "users.Grant")
 }
 
-func (i *usersImpl) Revoke(ctx context.Context, userID, planID string) error {
+func (i *usersImpl) Revoke(ctx context.Context, userID, prefName string) error {
 	resp, err := i.c.client.Send(verbUser, command.Body{
 		"action": "revoke", "account_id": i.accountID,
-		"id": userID, "plan_id": planID,
+		"id": userID, "pref_name": prefName,
 	}, i.c.peers...)
 	if err != nil {
 		return fmt.Errorf("users.Revoke: %w", err)

--- a/clients/p2p/accounts/wire.go
+++ b/clients/p2p/accounts/wire.go
@@ -13,6 +13,7 @@ const (
 	verbMember  = "member"
 	verbUser    = "user"
 	verbPlan    = "plan"
+	verbPRef    = "pref"
 	verbLogin   = "login"
 )
 

--- a/core/services/accounts/client.go
+++ b/core/services/accounts/client.go
@@ -2,21 +2,34 @@ package accounts
 
 import (
 	"context"
+	"time"
 
 	peerCore "github.com/libp2p/go-libp2p/core/peer"
 )
 
 // Client is the consumer-side interface for the Accounts subsystem.
 type Client interface {
-	// Integration surface — the two methods the rest of tau actually calls.
+	// Integration surface — methods the rest of tau actually calls.
 	Verify(ctx context.Context, provider, externalID string) (*VerifyResponse, error)
-	ResolvePlan(ctx context.Context, accountSlug, planSlug, provider, externalID string) (*ResolveResponse, error)
+	ResolvePRef(ctx context.Context, accountSlug, prefName, provider, externalID string) (*ResolveResponse, error)
 
-	// Management surface — requires a Member session.
+	// LookupAccountsByEmail returns the IDs of every Account on the cluster
+	// that has a Member with this primary_email (case-insensitive, trimmed).
+	// Empty input → error. No matches → (empty slice, nil). Result is
+	// deduplicated and unordered. No filtering: suspended accounts and
+	// pending-claim members are included. Callers fetch details via the
+	// existing Accounts() / Members() surfaces and apply their own policy.
+	LookupAccountsByEmail(ctx context.Context, email string) ([]string, error)
+
+	// Management surface — requires a Member session (per-account ops) or
+	// operator authority (Plans).
 	Accounts() Accounts
 	Members(accountID string) Members
 	Users(accountID string) Users
-	Plans(accountID string) Plans
+	PRefs(accountID string) PRefs
+
+	// Plans is the global, immutable Plan catalogue. Not scoped to an account.
+	Plans() Plans
 
 	// Login surface — managed (passkey + magic-link); external is EE.
 	Login() Login
@@ -37,23 +50,21 @@ type Accounts interface {
 
 // CreateAccountInput is the payload for creating a new Account.
 type CreateAccountInput struct {
-	Slug         string            `cbor:"slug"`
-	Name         string            `cbor:"name"`
-	Kind         AccountKind       `cbor:"kind"`
-	AuthMode     AuthMode          `cbor:"auth_mode"`
-	AuthConfig   *AuthConfig       `cbor:"auth_config,omitempty"`
-	PlanTemplate string            `cbor:"plan_template,omitempty"`
-	Metadata     map[string]string `cbor:"metadata,omitempty"`
+	Slug       string            `cbor:"slug"`
+	Name       string            `cbor:"name"`
+	Kind       AccountKind       `cbor:"kind"`
+	AuthMode   AuthMode          `cbor:"auth_mode"`
+	AuthConfig *AuthConfig       `cbor:"auth_config,omitempty"`
+	Metadata   map[string]string `cbor:"metadata,omitempty"`
 }
 
 // UpdateAccountInput is the partial-update payload for an Account.
 type UpdateAccountInput struct {
-	Name         *string           `cbor:"name,omitempty"`
-	AuthMode     *AuthMode         `cbor:"auth_mode,omitempty"`
-	AuthConfig   *AuthConfig       `cbor:"auth_config,omitempty"`
-	PlanTemplate *string           `cbor:"plan_template,omitempty"`
-	Status       *AccountStatus    `cbor:"status,omitempty"`
-	Metadata     map[string]string `cbor:"metadata,omitempty"`
+	Name       *string           `cbor:"name,omitempty"`
+	AuthMode   *AuthMode         `cbor:"auth_mode,omitempty"`
+	AuthConfig *AuthConfig       `cbor:"auth_config,omitempty"`
+	Status     *AccountStatus    `cbor:"status,omitempty"`
+	Metadata   map[string]string `cbor:"metadata,omitempty"`
 }
 
 // Members is the Member CRUD + invite surface for one Account.
@@ -85,8 +96,8 @@ type Users interface {
 	GetByExternal(ctx context.Context, provider, externalID string) (*User, error)
 	List(ctx context.Context) ([]string, error)
 	Remove(ctx context.Context, userID string) error
-	Grant(ctx context.Context, userID string, in GrantPlanInput) error
-	Revoke(ctx context.Context, userID, planID string) error
+	Grant(ctx context.Context, userID string, in GrantPRefInput) error
+	Revoke(ctx context.Context, userID, prefName string) error
 }
 
 // AddUserInput links a git provider account to the Account.
@@ -96,38 +107,71 @@ type AddUserInput struct {
 	DisplayName string `cbor:"display_name,omitempty"`
 }
 
-// GrantPlanInput grants a Plan to a User.
-type GrantPlanInput struct {
-	PlanID    string `cbor:"plan_id"`
+// GrantPRefInput grants a PRef to a User.
+type GrantPRefInput struct {
+	PRefName  string `cbor:"pref_name"`
 	IsDefault bool   `cbor:"is_default,omitempty"`
 }
 
-// Plans is the Plan CRUD surface for one Account.
+// Plans is the global Plan catalogue. Plans are immutable and undeletable;
+// the only ops are Create, Get, and List.
 type Plans interface {
 	Create(ctx context.Context, in CreatePlanInput) (*Plan, error)
 	Get(ctx context.Context, planID string) (*Plan, error)
-	GetBySlug(ctx context.Context, slug string) (*Plan, error)
 	List(ctx context.Context) ([]string, error)
-	Update(ctx context.Context, planID string, in UpdatePlanInput) (*Plan, error)
-	Delete(ctx context.Context, planID string) error
 }
 
-// CreatePlanInput is the payload for creating a new Plan.
+// CreatePlanInput is the payload for creating a new Plan record. Name is the
+// admin-facing label; DisplayName is cosmetic (defaults to Name when empty).
+// Data is an opaque metadata blob; its schema is TBD.
 type CreatePlanInput struct {
-	Slug       string      `cbor:"slug"`
-	Name       string      `cbor:"name"`
-	Mode       PlanMode    `cbor:"mode"`
-	Dimensions []Dimension `cbor:"dimensions,omitempty"`
-	Period     string      `cbor:"period,omitempty"`
+	Name        string `cbor:"name"`
+	DisplayName string `cbor:"display_name,omitempty"`
+	Data        []byte `cbor:"data,omitempty"`
 }
 
-// UpdatePlanInput is the partial-update payload for a Plan.
-type UpdatePlanInput struct {
-	Name       *string     `cbor:"name,omitempty"`
-	Mode       *PlanMode   `cbor:"mode,omitempty"`
-	Dimensions []Dimension `cbor:"dimensions,omitempty"`
-	Period     *string     `cbor:"period,omitempty"`
-	Status     *PlanStatus `cbor:"status,omitempty"`
+// PRefs is the PRef surface for one Account. PRef names are immortal once
+// created; PRefs cannot be deleted, only disabled.
+type PRefs interface {
+	Create(ctx context.Context, in CreatePRefInput) (*PRef, error)
+	Get(ctx context.Context, name string) (*PRef, error)
+	List(ctx context.Context) ([]string, error)
+	SetDisplayName(ctx context.Context, name, displayName string) (*PRef, error)
+	Assign(ctx context.Context, in AssignPRefInput) (*PRefEvent, error)
+	Disable(ctx context.Context, in DisablePRefInput) (*PRefEvent, error)
+	Enable(ctx context.Context, in EnablePRefInput) (*PRefEvent, error)
+	Events(ctx context.Context, name string, from, to time.Time) ([]PRefEvent, error)
+	LatestEvent(ctx context.Context, name string) (*PRefEvent, error)
+}
+
+// CreatePRefInput creates a new PRef envelope. Name is immortal and must match
+// varname rules ([a-zA-Z_][a-zA-Z0-9_]*); DisplayName defaults to Name if empty.
+type CreatePRefInput struct {
+	Name        string `cbor:"name"`
+	DisplayName string `cbor:"display_name,omitempty"`
+	MemberID    string `cbor:"member_id"` // server-resolved from session; "system:<actor>" for non-human
+}
+
+// AssignPRefInput records an `assign` event on a PRef.
+type AssignPRefInput struct {
+	Name     string `cbor:"name"`
+	PlanID   string `cbor:"plan_id"`
+	MemberID string `cbor:"member_id"`
+	Note     string `cbor:"note,omitempty"`
+}
+
+// DisablePRefInput records a `disable` event on a PRef.
+type DisablePRefInput struct {
+	Name     string `cbor:"name"`
+	MemberID string `cbor:"member_id"`
+	Note     string `cbor:"note,omitempty"`
+}
+
+// EnablePRefInput records an `enable` event on a PRef.
+type EnablePRefInput struct {
+	Name     string `cbor:"name"`
+	MemberID string `cbor:"member_id"`
+	Note     string `cbor:"note,omitempty"`
 }
 
 // Login is the login dispatcher — routes to managed (passkey/magic-link) or

--- a/core/services/accounts/types.go
+++ b/core/services/accounts/types.go
@@ -47,42 +47,19 @@ const (
 	RoleBilling Role = "billing"
 )
 
-// PlanMode describes how a Plan constrains usage. v1 records but does not
-// enforce any of these; runtime enforcement is a follow-up PR.
-type PlanMode string
-
-const (
-	PlanModeQuota   PlanMode = "quota"
-	PlanModeMetered PlanMode = "metered"
-	PlanModeHybrid  PlanMode = "hybrid"
-)
-
-// PlanStatus tracks lifecycle of a Plan. Suspended/deleted causes the
-// resolve endpoint to fail compile.
-type PlanStatus string
-
-const (
-	PlanStatusActive    PlanStatus = "active"
-	PlanStatusSuspended PlanStatus = "suspended"
-	PlanStatusGrace     PlanStatus = "grace"
-)
-
-// Account is the tenancy entity. It holds plans, quotas, plans and the login
-// principal. It never holds git credentials.
-//
-// `cbor:` tags mirror `json:` tags so KV inspection matches the wire shape;
-// fxamacker/cbor/v2 needs explicit cbor tags (no json fallback).
+// Account is the tenancy entity. It holds Members (login principals), Users
+// (linked git accounts) and PRefs (account-scoped pointers to Plans).
+// Plans themselves are global, not owned by an Account.
 type Account struct {
-	ID           string            `json:"id"                       cbor:"id"`
-	Slug         string            `json:"slug"                     cbor:"slug"`
-	Name         string            `json:"name"                     cbor:"name"`
-	Kind         AccountKind       `json:"kind"                     cbor:"kind"`
-	Status       AccountStatus     `json:"status"                   cbor:"status"`
-	PlanTemplate string            `json:"plan_template,omitempty"  cbor:"plan_template,omitempty"`
-	AuthMode     AuthMode          `json:"auth_mode"                cbor:"auth_mode"`
-	AuthConfig   *AuthConfig       `json:"auth_config,omitempty"    cbor:"auth_config,omitempty"`
-	Metadata     map[string]string `json:"metadata,omitempty"       cbor:"metadata,omitempty"`
-	CreatedAt    time.Time         `json:"created_at"               cbor:"created_at"`
+	ID         string            `json:"id"                       cbor:"id"`
+	Slug       string            `json:"slug"                     cbor:"slug"`
+	Name       string            `json:"name"                     cbor:"name"`
+	Kind       AccountKind       `json:"kind"                     cbor:"kind"`
+	Status     AccountStatus     `json:"status"                   cbor:"status"`
+	AuthMode   AuthMode          `json:"auth_mode"                cbor:"auth_mode"`
+	AuthConfig *AuthConfig       `json:"auth_config,omitempty"    cbor:"auth_config,omitempty"`
+	Metadata   map[string]string `json:"metadata,omitempty"       cbor:"metadata,omitempty"`
+	CreatedAt  time.Time         `json:"created_at"               cbor:"created_at"`
 }
 
 // AuthConfig carries managed-mode magic-link sender hints or external-IdP
@@ -97,7 +74,7 @@ type AuthConfig struct {
 	ClientID     string            `json:"client_id,omitempty"         cbor:"client_id,omitempty"`
 	ClientSecret string            `json:"client_secret_ref,omitempty" cbor:"client_secret_ref,omitempty"`
 	GroupToRole  map[string]Role   `json:"group_to_role,omitempty"     cbor:"group_to_role,omitempty"`
-	GroupToPlan  map[string]string `json:"group_to_plan,omitempty"     cbor:"group_to_plan,omitempty"`
+	GroupToPRef  map[string]string `json:"group_to_pref,omitempty"     cbor:"group_to_pref,omitempty"`
 	JITProvision bool              `json:"jit_provision,omitempty"     cbor:"jit_provision,omitempty"`
 }
 
@@ -145,35 +122,68 @@ type User struct {
 	LastUsedAt      *time.Time  `json:"last_used_at,omitempty"       cbor:"last_used_at,omitempty"`
 }
 
-// PlanGrant attaches a Plan to a User. Exactly one grant per User is
-// marked IsDefault (used when project config doesn't explicitly disambiguate).
+// PlanGrant attaches a PRef to a User. Exactly one grant per User is marked
+// IsDefault (used when project config doesn't explicitly disambiguate).
+//
+// Grants are keyed by PRef name (account-scoped), not by plan ID. When the
+// PRef's pointer swaps to a new plan, the user automatically follows the
+// upgrade — no re-grant needed.
 type PlanGrant struct {
-	PlanID    string `json:"plan_id"    cbor:"plan_id"`
+	PRefName  string `json:"pref_name"  cbor:"pref_name"`
 	IsDefault bool   `json:"is_default" cbor:"is_default"`
 }
 
-// Plan is a usage capacity slot owned by an Account.
+// Plan is an immutable, undeletable, global usage-capacity record. Plans are
+// not scoped to an Account; the only link between a Plan and an Account is a
+// PRef. Modifying a Plan = creating a new immutable Plan record (versioning is
+// emergent from the PRef event log, not encoded on the record).
 type Plan struct {
-	ID         string      `json:"id"                   cbor:"id"`
-	AccountID  string      `json:"account_id"           cbor:"account_id"`
-	Slug       string      `json:"slug"                 cbor:"slug"`
-	Name       string      `json:"name"                 cbor:"name"`
-	Mode       PlanMode    `json:"mode"                 cbor:"mode"`
-	Dimensions []Dimension `json:"dimensions,omitempty" cbor:"dimensions,omitempty"`
-	Period     string      `json:"period,omitempty"     cbor:"period,omitempty"`
-	Status     PlanStatus  `json:"status"               cbor:"status"`
-	CreatedAt  time.Time   `json:"created_at"           cbor:"created_at"`
+	ID          string `json:"id"                     cbor:"id"`
+	Name        string `json:"name"                   cbor:"name"`
+	DisplayName string `json:"display_name,omitempty" cbor:"display_name,omitempty"`
+	Data        []byte `json:"data,omitempty"         cbor:"data,omitempty"` // opaque metadata blob; schema TBD
 }
 
-// Dimension is a metered axis of a Plan. v1 declares dimensions but does not
-// enforce limits; the runtime quota / metering hooks land in a follow-up PR.
-type Dimension struct {
-	Name        string  `json:"name"                   cbor:"name"`
-	HardLimit   *uint64 `json:"hard_limit,omitempty"   cbor:"hard_limit,omitempty"`
-	SoftLimit   *uint64 `json:"soft_limit,omitempty"   cbor:"soft_limit,omitempty"`
-	Meter       string  `json:"meter,omitempty"        cbor:"meter,omitempty"`
-	UnitPrice   string  `json:"unit_price,omitempty"   cbor:"unit_price,omitempty"`
-	ResetPolicy string  `json:"reset_policy,omitempty" cbor:"reset_policy,omitempty"`
+// PRefStatus tracks the lifecycle of a PRef. PRefs cannot be deleted; they go
+// `active` ↔ `disabled` via events.
+type PRefStatus string
+
+const (
+	PRefStatusActive   PRefStatus = "active"
+	PRefStatusDisabled PRefStatus = "disabled"
+)
+
+// PRef is an account-scoped named pointer to a Plan. Its Name is immortal once
+// created; its DisplayName is cosmetic and mutable; its Status is reflected
+// from the latest disable/enable event; its current plan is the PlanID of the
+// latest `assign` event.
+type PRef struct {
+	Name        string     `json:"name"                   cbor:"name"`
+	AccountID   string     `json:"account_id"             cbor:"account_id"`
+	DisplayName string     `json:"display_name,omitempty" cbor:"display_name,omitempty"`
+	Status      PRefStatus `json:"status"                 cbor:"status"`
+	CreatedAt   time.Time  `json:"created_at"             cbor:"created_at"`
+}
+
+// PRefEventKind enumerates the operations recorded in a PRef's event log.
+type PRefEventKind string
+
+const (
+	PRefEventKindAssign  PRefEventKind = "assign"
+	PRefEventKindDisable PRefEventKind = "disable"
+	PRefEventKindEnable  PRefEventKind = "enable"
+)
+
+// PRefEvent is one entry in a PRef's append-only event log. Each event carries
+// the server-stamped time, who initiated it (Member session or `system:<actor>`),
+// the kind, and an optional human-readable note. Assign events also carry the
+// PlanID newly bound to the PRef.
+type PRefEvent struct {
+	At       time.Time     `json:"at"                cbor:"at"`
+	Kind     PRefEventKind `json:"kind"              cbor:"kind"`
+	PlanID   string        `json:"plan_id,omitempty" cbor:"plan_id,omitempty"`
+	MemberID string        `json:"member_id"         cbor:"member_id"`
+	Note     string        `json:"note,omitempty"    cbor:"note,omitempty"`
 }
 
 // Session is an authenticated Member session, returned by managed or external
@@ -198,25 +208,26 @@ type VerifyResponse struct {
 }
 
 // VerifyAccountSummary is one entry in VerifyResponse.Accounts: an Account the
-// git user is linked to, plus that User's plan grants on the Account.
+// git user is linked to, plus that User's PRef grants on the Account.
 type VerifyAccountSummary struct {
 	ID    string              `json:"id"    cbor:"id"`
 	Slug  string              `json:"slug"  cbor:"slug"`
 	Name  string              `json:"name"  cbor:"name"`
-	Plans []VerifyPlanSummary `json:"plans" cbor:"plans"`
+	PRefs []VerifyPRefSummary `json:"prefs" cbor:"prefs"`
 }
 
-// VerifyPlanSummary is one plan grant in a VerifyAccountSummary.
-type VerifyPlanSummary struct {
-	ID        string `json:"id"         cbor:"id"`
-	Slug      string `json:"slug"       cbor:"slug"`
-	IsDefault bool   `json:"is_default" cbor:"is_default"`
+// VerifyPRefSummary is one PRef grant in a VerifyAccountSummary.
+type VerifyPRefSummary struct {
+	Name        string `json:"name"                   cbor:"name"`
+	DisplayName string `json:"display_name,omitempty" cbor:"display_name,omitempty"`
+	IsDefault   bool   `json:"is_default"             cbor:"is_default"`
 }
 
-// ResolveResponse is the result of resolving an account/plan pair against a
+// ResolveResponse is the result of resolving an account/pref pair against a
 // git user, called by the project compiler at compile time.
 type ResolveResponse struct {
 	Valid  bool   `json:"valid"             cbor:"valid"`
-	Reason string `json:"reason,omitempty"  cbor:"reason,omitempty"` // "plan not found" | ...
+	Reason string `json:"reason,omitempty"  cbor:"reason,omitempty"` // typed: account not active | pref not found | pref disabled | pref has no plan assigned | plan not found | git user not linked | git user has no grant
+	PRef   *PRef  `json:"pref,omitempty"    cbor:"pref,omitempty"`
 	Plan   *Plan  `json:"plan,omitempty"    cbor:"plan,omitempty"`
 }

--- a/dream/fixtures/fake_account.go
+++ b/dream/fixtures/fake_account.go
@@ -13,14 +13,14 @@ import (
 const (
 	FakeAccountSlug      = "acme"
 	FakeAccountName      = "Acme Corp"
-	FakeAccountPlan      = "prod"
+	FakeAccountPRef      = "prod"
 	FakeAccountUserProv  = "github"
 	FakeAccountUserExtID = "42"
 )
 
-// fakeAccount seeds one (account, plan, user, grant) tuple. After the fixture
-// runs, Verify and ResolvePlan succeed for the seeded identity. Tests needing
-// a different shape script CRUD inline or call `injectAccount`.
+// fakeAccount seeds one (account, plan, pref, user, grant) tuple. After the
+// fixture runs, Verify and ResolvePRef succeed for the seeded identity. Tests
+// needing a different shape script CRUD inline or call `injectAccount`.
 func fakeAccount(u *dream.Universe, params ...any) error {
 	svc := u.Accounts()
 	if svc == nil {
@@ -41,13 +41,26 @@ func fakeAccount(u *dream.Universe, params ...any) error {
 	if err != nil {
 		return fmt.Errorf("fakeAccount: create account: %w", err)
 	}
-	plan, err := cli.Plans(acc.ID).Create(ctx, accountsIface.CreatePlanInput{
-		Slug: FakeAccountPlan,
-		Name: "Production",
-		Mode: accountsIface.PlanModeQuota,
+	plan, err := cli.Plans().Create(ctx, accountsIface.CreatePlanInput{
+		Name:        "Production",
+		DisplayName: "Production",
 	})
 	if err != nil {
 		return fmt.Errorf("fakeAccount: create plan: %w", err)
+	}
+	pref, err := cli.PRefs(acc.ID).Create(ctx, accountsIface.CreatePRefInput{
+		Name:     FakeAccountPRef,
+		MemberID: "system:dream-fixture",
+	})
+	if err != nil {
+		return fmt.Errorf("fakeAccount: create pref: %w", err)
+	}
+	if _, err := cli.PRefs(acc.ID).Assign(ctx, accountsIface.AssignPRefInput{
+		Name:     pref.Name,
+		PlanID:   plan.ID,
+		MemberID: "system:dream-fixture",
+	}); err != nil {
+		return fmt.Errorf("fakeAccount: assign plan to pref: %w", err)
 	}
 	user, err := cli.Users(acc.ID).Add(ctx, accountsIface.AddUserInput{
 		Provider:    FakeAccountUserProv,
@@ -57,8 +70,8 @@ func fakeAccount(u *dream.Universe, params ...any) error {
 	if err != nil {
 		return fmt.Errorf("fakeAccount: add user: %w", err)
 	}
-	if err := cli.Users(acc.ID).Grant(ctx, user.ID, accountsIface.GrantPlanInput{PlanID: plan.ID}); err != nil {
-		return fmt.Errorf("fakeAccount: grant plan to user: %w", err)
+	if err := cli.Users(acc.ID).Grant(ctx, user.ID, accountsIface.GrantPRefInput{PRefName: pref.Name}); err != nil {
+		return fmt.Errorf("fakeAccount: grant pref to user: %w", err)
 	}
 	return nil
 }

--- a/dream/fixtures/inject_account.go
+++ b/dream/fixtures/inject_account.go
@@ -14,9 +14,8 @@ import (
 type AccountInjection struct {
 	AccountSlug string
 	AccountName string
-	PlanSlug    string
+	PRefName    string
 	PlanName    string
-	PlanMode    accountsIface.PlanMode
 	UserProv    string
 	UserExtID   string
 	UserDisplay string
@@ -47,14 +46,11 @@ func injectAccount(u *dream.Universe, params ...any) error {
 	if inj.AccountName == "" {
 		inj.AccountName = FakeAccountName
 	}
-	if inj.PlanSlug == "" {
-		inj.PlanSlug = FakeAccountPlan
+	if inj.PRefName == "" {
+		inj.PRefName = FakeAccountPRef
 	}
 	if inj.PlanName == "" {
 		inj.PlanName = "Production"
-	}
-	if inj.PlanMode == "" {
-		inj.PlanMode = accountsIface.PlanModeQuota
 	}
 	if inj.UserProv == "" {
 		inj.UserProv = FakeAccountUserProv
@@ -76,13 +72,26 @@ func injectAccount(u *dream.Universe, params ...any) error {
 	if err != nil {
 		return fmt.Errorf("injectAccount: create account %q: %w", inj.AccountSlug, err)
 	}
-	plan, err := cli.Plans(acc.ID).Create(ctx, accountsIface.CreatePlanInput{
-		Slug: inj.PlanSlug,
-		Name: inj.PlanName,
-		Mode: inj.PlanMode,
+	plan, err := cli.Plans().Create(ctx, accountsIface.CreatePlanInput{
+		Name:        inj.PlanName,
+		DisplayName: inj.PlanName,
 	})
 	if err != nil {
-		return fmt.Errorf("injectAccount: create plan %q under %q: %w", inj.PlanSlug, inj.AccountSlug, err)
+		return fmt.Errorf("injectAccount: create plan %q: %w", inj.PlanName, err)
+	}
+	pref, err := cli.PRefs(acc.ID).Create(ctx, accountsIface.CreatePRefInput{
+		Name:     inj.PRefName,
+		MemberID: "system:dream-fixture",
+	})
+	if err != nil {
+		return fmt.Errorf("injectAccount: create pref %q under %q: %w", inj.PRefName, inj.AccountSlug, err)
+	}
+	if _, err := cli.PRefs(acc.ID).Assign(ctx, accountsIface.AssignPRefInput{
+		Name:     pref.Name,
+		PlanID:   plan.ID,
+		MemberID: "system:dream-fixture",
+	}); err != nil {
+		return fmt.Errorf("injectAccount: assign plan to pref %q: %w", inj.PRefName, err)
 	}
 	user, err := cli.Users(acc.ID).Add(ctx, accountsIface.AddUserInput{
 		Provider:    inj.UserProv,
@@ -92,8 +101,8 @@ func injectAccount(u *dream.Universe, params ...any) error {
 	if err != nil {
 		return fmt.Errorf("injectAccount: add user %s/%s: %w", inj.UserProv, inj.UserExtID, err)
 	}
-	if err := cli.Users(acc.ID).Grant(ctx, user.ID, accountsIface.GrantPlanInput{PlanID: plan.ID}); err != nil {
-		return fmt.Errorf("injectAccount: grant plan %q to user %s/%s: %w", inj.PlanSlug, inj.UserProv, inj.UserExtID, err)
+	if err := cli.Users(acc.ID).Grant(ctx, user.ID, accountsIface.GrantPRefInput{PRefName: pref.Name}); err != nil {
+		return fmt.Errorf("injectAccount: grant pref %q to user %s/%s: %w", inj.PRefName, inj.UserProv, inj.UserExtID, err)
 	}
 	return nil
 }

--- a/services/accounts/account.go
+++ b/services/accounts/account.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/taubyte/tau/core/kvdb"
@@ -12,19 +11,14 @@ import (
 	protocolCommon "github.com/taubyte/tau/services/common"
 )
 
-// accountStore implements accountsIface.Accounts (the top-level Account CRUD
-// surface) over a KVDB.
 type accountStore struct {
 	db kvdb.KVDB
 }
 
 func newAccountStore(db kvdb.KVDB) *accountStore { return &accountStore{db: db} }
 
-// Compile-time check.
 var _ accountsIface.Accounts = (*accountStore)(nil)
 
-// Create persists a new Account. The slug must be unique. Defaults: managed
-// auth_mode and active status when unspecified.
 func (s *accountStore) Create(ctx context.Context, in accountsIface.CreateAccountInput) (*accountsIface.Account, error) {
 	if err := validateAccountSlug(in.Slug); err != nil {
 		return nil, err
@@ -39,37 +33,33 @@ func (s *accountStore) Create(ctx context.Context, in accountsIface.CreateAccoun
 		in.AuthMode = accountsIface.AuthModeManaged
 	}
 
-	// Slug uniqueness: lookup index.
 	if existing, _ := s.lookupIDBySlug(ctx, in.Slug); existing != "" {
 		return nil, fmt.Errorf("accounts: slug %q already in use", in.Slug)
 	}
 
 	now := time.Now().UTC()
 	acc := &accountsIface.Account{
-		ID:           protocolCommon.GetNewAccountID(in.Slug, in.Kind, now.UnixNano()),
-		Slug:         in.Slug,
-		Name:         in.Name,
-		Kind:         in.Kind,
-		Status:       accountsIface.AccountStatusActive,
-		PlanTemplate: in.PlanTemplate,
-		AuthMode:     in.AuthMode,
-		AuthConfig:   in.AuthConfig,
-		Metadata:     in.Metadata,
-		CreatedAt:    now,
+		ID:         protocolCommon.GetNewAccountID(in.Slug, in.Kind, now.UnixNano()),
+		Slug:       in.Slug,
+		Name:       in.Name,
+		Kind:       in.Kind,
+		Status:     accountsIface.AccountStatusActive,
+		AuthMode:   in.AuthMode,
+		AuthConfig: in.AuthConfig,
+		Metadata:   in.Metadata,
+		CreatedAt:  now,
 	}
 
 	if err := putKV(ctx, s.db, AccountProfilePath(acc.ID), acc); err != nil {
 		return nil, err
 	}
 	if err := s.db.Put(ctx, LookupAccountSlugPath(in.Slug), []byte(acc.ID)); err != nil {
-		// best-effort rollback of the profile write
 		_ = s.db.Delete(ctx, AccountProfilePath(acc.ID))
 		return nil, fmt.Errorf("accounts: index slug: %w", err)
 	}
 	return acc, nil
 }
 
-// Get loads an Account by ID.
 func (s *accountStore) Get(ctx context.Context, accountID string) (*accountsIface.Account, error) {
 	var acc accountsIface.Account
 	if err := getKV(ctx, s.db, AccountProfilePath(accountID), &acc); err != nil {
@@ -78,7 +68,6 @@ func (s *accountStore) Get(ctx context.Context, accountID string) (*accountsIfac
 	return &acc, nil
 }
 
-// GetBySlug resolves slug → id then loads the Account.
 func (s *accountStore) GetBySlug(ctx context.Context, slug string) (*accountsIface.Account, error) {
 	id, err := s.lookupIDBySlug(ctx, slug)
 	if err != nil {
@@ -90,12 +79,11 @@ func (s *accountStore) GetBySlug(ctx context.Context, slug string) (*accountsIfa
 	return s.Get(ctx, id)
 }
 
-// List returns the IDs of all Accounts in the store.
 func (s *accountStore) List(ctx context.Context) ([]string, error) {
 	return listChildIDs(ctx, s.db, prefixAccounts)
 }
 
-// Update applies a partial update to an Account. Slug and ID are immutable.
+// Update is partial — slug and ID are immutable.
 func (s *accountStore) Update(ctx context.Context, accountID string, in accountsIface.UpdateAccountInput) (*accountsIface.Account, error) {
 	acc, err := s.Get(ctx, accountID)
 	if err != nil {
@@ -110,15 +98,11 @@ func (s *accountStore) Update(ctx context.Context, accountID string, in accounts
 	if in.AuthConfig != nil {
 		acc.AuthConfig = in.AuthConfig
 	}
-	if in.PlanTemplate != nil {
-		acc.PlanTemplate = *in.PlanTemplate
-	}
 	if in.Status != nil {
 		acc.Status = *in.Status
 	}
 	if in.Metadata != nil {
-		// merge: caller can set keys to "" to clear (we keep them — explicit
-		// removal can be a follow-up if needed).
+		// Merge, not replace — "" values are kept; explicit removal TBD.
 		if acc.Metadata == nil {
 			acc.Metadata = map[string]string{}
 		}
@@ -132,9 +116,8 @@ func (s *accountStore) Update(ctx context.Context, accountID string, in accounts
 	return acc, nil
 }
 
-// Delete removes the Account profile and its slug index. It does NOT
-// recursively delete Members/Users/Plans/Tokens — callers should empty those
-// first. (Cascading deletion is a follow-up; explicit emptying is safer.)
+// Delete does not cascade into Members/Users/PRefs — callers must empty
+// those first. Explicit emptying is safer than implicit cascade here.
 func (s *accountStore) Delete(ctx context.Context, accountID string) error {
 	acc, err := s.Get(ctx, accountID)
 	if err != nil {
@@ -156,7 +139,7 @@ func (s *accountStore) Delete(ctx context.Context, accountID string) error {
 	return nil
 }
 
-// lookupIDBySlug returns the account_id for a slug, or "" if not present.
+// lookupIDBySlug returns "" (not ErrNotFound) when the slug is missing.
 func (s *accountStore) lookupIDBySlug(ctx context.Context, slug string) (string, error) {
 	raw, err := s.db.Get(ctx, LookupAccountSlugPath(slug))
 	if err != nil {
@@ -168,9 +151,7 @@ func (s *accountStore) lookupIDBySlug(ctx context.Context, slug string) (string,
 	return string(raw), nil
 }
 
-// validateAccountSlug enforces a small, URL-safe alphabet so slugs can appear
-// in URLs (e.g. accounts.<network>/<slug>) and in project config without
-// quoting.
+// validateAccountSlug is case-sensitive — "Pro" and "pro" are distinct.
 func validateAccountSlug(slug string) error {
 	if slug == "" {
 		return errors.New("accounts: slug required")
@@ -178,17 +159,13 @@ func validateAccountSlug(slug string) error {
 	if len(slug) > 64 {
 		return errors.New("accounts: slug too long (>64)")
 	}
-	for _, r := range slug {
-		switch {
-		case r >= 'a' && r <= 'z':
-		case r >= '0' && r <= '9':
-		case r == '-' || r == '_':
-		default:
-			return fmt.Errorf("accounts: slug must be lowercase alnum/-/_; bad char %q", string(r))
-		}
+	if !isVarnameStart(rune(slug[0])) {
+		return fmt.Errorf("accounts: slug must start with a letter or underscore (got %q)", string(slug[0]))
 	}
-	if strings.HasPrefix(slug, "-") || strings.HasSuffix(slug, "-") {
-		return errors.New("accounts: slug cannot start/end with '-'")
+	for _, r := range slug[1:] {
+		if !isVarnameRune(r) {
+			return fmt.Errorf("accounts: slug must be varname (a-zA-Z0-9_); bad char %q", string(r))
+		}
 	}
 	return nil
 }

--- a/services/accounts/api_hooks.go
+++ b/services/accounts/api_hooks.go
@@ -11,13 +11,12 @@ import (
 	"github.com/taubyte/tau/utils/maps"
 )
 
-// Verify / Resolve P2P stream verb names.
 const (
-	StreamVerbVerify  = "verify"
-	StreamVerbResolve = "resolve"
+	StreamVerbVerify                = "verify"
+	StreamVerbResolve               = "resolve"
+	StreamVerbLookupAccountsByEmail = "lookup_accounts_by_email"
 )
 
-// apiVerifyHandler — body: {provider, external_id}; response: VerifyResponse.
 func (srv *AccountsService) apiVerifyHandler(ctx context.Context, _ streams.Connection, body command.Body) (cr.Response, error) {
 	provider, err := maps.String(body, "provider")
 	if err != nil {
@@ -34,14 +33,24 @@ func (srv *AccountsService) apiVerifyHandler(ctx context.Context, _ streams.Conn
 	return verifyResponseToWire(resp), nil
 }
 
-// apiResolveHandler — body: {account_slug, plan_slug, provider, external_id};
-// response: ResolveResponse.
+func (srv *AccountsService) apiLookupAccountsByEmailHandler(ctx context.Context, _ streams.Connection, body command.Body) (cr.Response, error) {
+	email, err := maps.String(body, "email")
+	if err != nil {
+		return nil, fmt.Errorf("lookup_accounts_by_email: %w", err)
+	}
+	ids, err := srv.Client().LookupAccountsByEmail(ctx, email)
+	if err != nil {
+		return nil, err
+	}
+	return cr.Response{"account_ids": ids}, nil
+}
+
 func (srv *AccountsService) apiResolveHandler(ctx context.Context, _ streams.Connection, body command.Body) (cr.Response, error) {
 	accountSlug, err := maps.String(body, "account_slug")
 	if err != nil {
 		return nil, fmt.Errorf("resolve: %w", err)
 	}
-	planSlug, err := maps.String(body, "plan_slug")
+	prefName, err := maps.String(body, "pref_name")
 	if err != nil {
 		return nil, fmt.Errorf("resolve: %w", err)
 	}
@@ -53,18 +62,12 @@ func (srv *AccountsService) apiResolveHandler(ctx context.Context, _ streams.Con
 	if err != nil {
 		return nil, fmt.Errorf("resolve: %w", err)
 	}
-	resp, err := srv.Client().ResolvePlan(ctx, accountSlug, planSlug, provider, externalID)
+	resp, err := srv.Client().ResolvePRef(ctx, accountSlug, prefName, provider, externalID)
 	if err != nil {
 		return nil, err
 	}
 	return resolveResponseToWire(resp), nil
 }
-
-// --- wire encoders -------------------------------------------------
-//
-// Nested structured fields ride the wire natively — the P2P framer CBORs
-// the whole response, the HTTP wrapper JSONs it. The client side has its
-// own decoders in clients/p2p/accounts/client.go.
 
 func verifyResponseToWire(r *accountsIface.VerifyResponse) cr.Response {
 	if r == nil {
@@ -84,6 +87,9 @@ func resolveResponseToWire(r *accountsIface.ResolveResponse) cr.Response {
 	out := cr.Response{"valid": r.Valid}
 	if r.Reason != "" {
 		out["reason"] = r.Reason
+	}
+	if r.PRef != nil {
+		out["pref"] = r.PRef
 	}
 	if r.Plan != nil {
 		out["plan"] = r.Plan

--- a/services/accounts/api_hooks_test.go
+++ b/services/accounts/api_hooks_test.go
@@ -11,6 +11,45 @@ import (
 // Tests for the wire codec (verify/resolve response encoding + decoding) and
 // the stream-handler dispatch layer.
 
+// seedAccountUserPRef stands up an Account + Plan + PRef (assigned) + User
+// (with a grant on that PRef). Returns the IDs/names so callers can build
+// resolve/verify queries against them. Centralised so test files share one
+// setup convention.
+func seedAccountUserPRef(t *testing.T, srv *AccountsService, accountSlug, prefName, provider, externalID string) (accountID, planID string) {
+	t.Helper()
+	ctx := context.Background()
+	acc, err := newAccountStore(srv.db).Create(ctx, accountsIface.CreateAccountInput{Slug: accountSlug, Name: accountSlug})
+	if err != nil {
+		t.Fatalf("seed: create account: %v", err)
+	}
+	plan, err := newPlanStore(srv.db).Create(ctx, accountsIface.CreatePlanInput{Name: "Prod"})
+	if err != nil {
+		t.Fatalf("seed: create plan: %v", err)
+	}
+	prefs := newPRefStore(srv.db, acc.ID, newPlanStore(srv.db))
+	if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{
+		Name:     prefName,
+		MemberID: "system:test",
+	}); err != nil {
+		t.Fatalf("seed: create pref: %v", err)
+	}
+	if _, err := prefs.Assign(ctx, accountsIface.AssignPRefInput{
+		Name:     prefName,
+		PlanID:   plan.ID,
+		MemberID: "system:test",
+	}); err != nil {
+		t.Fatalf("seed: assign pref: %v", err)
+	}
+	user, err := newUserStore(srv.db, acc.ID).Add(ctx, accountsIface.AddUserInput{Provider: provider, ExternalID: externalID})
+	if err != nil {
+		t.Fatalf("seed: add user: %v", err)
+	}
+	if err := newUserStore(srv.db, acc.ID).Grant(ctx, user.ID, accountsIface.GrantPRefInput{PRefName: prefName}); err != nil {
+		t.Fatalf("seed: grant: %v", err)
+	}
+	return acc.ID, plan.ID
+}
+
 func TestVerifyResponseToWire_NilAndEmpty(t *testing.T) {
 	// Nil response → wire indicates not-linked.
 	w := verifyResponseToWire(nil)
@@ -31,8 +70,8 @@ func TestResolveResponseToWire_RejectionShapes(t *testing.T) {
 		t.Fatalf("nil should be invalid")
 	}
 	// Invalid with reason but no plan.
-	w = resolveResponseToWire(&accountsIface.ResolveResponse{Valid: false, Reason: "plan not found"})
-	if r, _ := w["reason"].(string); r != "plan not found" {
+	w = resolveResponseToWire(&accountsIface.ResolveResponse{Valid: false, Reason: "pref not found"})
+	if r, _ := w["reason"].(string); r != "pref not found" {
 		t.Fatalf("reason missing: %+v", w)
 	}
 	if _, ok := w["plan"]; ok {
@@ -44,11 +83,7 @@ func TestApiVerifyHandler_HappyAndMissingFields(t *testing.T) {
 	srv := newTestService(t)
 	ctx := context.Background()
 
-	// Seed the store so verify returns linked.
-	acc, _ := newAccountStore(srv.db).Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
-	bk, _ := newPlanStore(srv.db, acc.ID).Create(ctx, accountsIface.CreatePlanInput{Slug: "prod", Name: "Prod"})
-	user, _ := newUserStore(srv.db, acc.ID).Add(ctx, accountsIface.AddUserInput{Provider: "github", ExternalID: "1"})
-	_ = newUserStore(srv.db, acc.ID).Grant(ctx, user.ID, accountsIface.GrantPlanInput{PlanID: bk.ID})
+	seedAccountUserPRef(t, srv, "acme", "prod", "github", "1")
 
 	// Linked path.
 	resp, err := srv.apiVerifyHandler(ctx, nil, command.Body{
@@ -76,15 +111,12 @@ func TestApiResolveHandler_HappyAndMissingFields(t *testing.T) {
 	srv := newTestService(t)
 	ctx := context.Background()
 
-	acc, _ := newAccountStore(srv.db).Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
-	bk, _ := newPlanStore(srv.db, acc.ID).Create(ctx, accountsIface.CreatePlanInput{Slug: "prod", Name: "Prod"})
-	user, _ := newUserStore(srv.db, acc.ID).Add(ctx, accountsIface.AddUserInput{Provider: "github", ExternalID: "1"})
-	_ = newUserStore(srv.db, acc.ID).Grant(ctx, user.ID, accountsIface.GrantPlanInput{PlanID: bk.ID})
+	seedAccountUserPRef(t, srv, "acme", "prod", "github", "1")
 
 	// Valid path.
 	resp, err := srv.apiResolveHandler(ctx, nil, command.Body{
 		"account_slug": "acme",
-		"plan_slug":    "prod",
+		"pref_name":    "prod",
 		"provider":     "github",
 		"external_id":  "1",
 	})
@@ -96,11 +128,11 @@ func TestApiResolveHandler_HappyAndMissingFields(t *testing.T) {
 	}
 
 	// Each missing field → error.
-	missing := []string{"account_slug", "plan_slug", "provider", "external_id"}
+	missing := []string{"account_slug", "pref_name", "provider", "external_id"}
 	for _, drop := range missing {
 		body := command.Body{
 			"account_slug": "acme",
-			"plan_slug":    "prod",
+			"pref_name":    "prod",
 			"provider":     "github",
 			"external_id":  "1",
 		}

--- a/services/accounts/api_management.go
+++ b/services/accounts/api_management.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/fxamacker/cbor/v2"
 	accountsIface "github.com/taubyte/tau/core/services/accounts"
@@ -13,18 +14,17 @@ import (
 	"github.com/taubyte/tau/utils/maps"
 )
 
-// Stream verbs — one per entity, dispatched by the `action` body field.
+// Verbs dispatched by the `action` body field. Scalar inputs ride directly on
+// the body; structured inputs ride as one named entry and re-decode via
+// decodeField.
 const (
 	StreamVerbAccount = "account"
 	StreamVerbMember  = "member"
 	StreamVerbUser    = "user"
 	StreamVerbPlan    = "plan"
+	StreamVerbPRef    = "pref"
 	StreamVerbLogin   = "login"
 )
-
-// Wire shape: scalar input fields ride directly on the body (patrick-style);
-// structured fields (slices, nested structs) ride as a single named entry and
-// are landed via decodeField.
 
 func requireAccountID(body command.Body) (string, error) {
 	id, err := maps.String(body, "account_id")
@@ -54,8 +54,6 @@ func decodeField(v, into any) error {
 	return cbor.Unmarshal(raw, into)
 }
 
-// --- Account verb -------------------------------------------------
-
 func (srv *AccountsService) apiAccountHandler(ctx context.Context, _ streams.Connection, body command.Body) (cr.Response, error) {
 	action, err := maps.String(body, "action")
 	if err != nil {
@@ -65,11 +63,10 @@ func (srv *AccountsService) apiAccountHandler(ctx context.Context, _ streams.Con
 	switch action {
 	case "create":
 		in := accountsIface.CreateAccountInput{
-			Slug:         maps.TryString(body, "slug"),
-			Name:         maps.TryString(body, "name"),
-			Kind:         accountsIface.AccountKind(maps.TryString(body, "kind")),
-			AuthMode:     accountsIface.AuthMode(maps.TryString(body, "auth_mode")),
-			PlanTemplate: maps.TryString(body, "plan_template"),
+			Slug:     maps.TryString(body, "slug"),
+			Name:     maps.TryString(body, "name"),
+			Kind:     accountsIface.AccountKind(maps.TryString(body, "kind")),
+			AuthMode: accountsIface.AuthMode(maps.TryString(body, "auth_mode")),
 		}
 		if v, ok := body["auth_config"]; ok {
 			if err := decodeField(v, &in.AuthConfig); err != nil {
@@ -125,9 +122,6 @@ func (srv *AccountsService) apiAccountHandler(ctx context.Context, _ streams.Con
 			am := accountsIface.AuthMode(s)
 			in.AuthMode = &am
 		}
-		if s, ok := optString(body, "plan_template"); ok {
-			in.PlanTemplate = &s
-		}
 		if s, ok := optString(body, "status"); ok {
 			st := accountsIface.AccountStatus(s)
 			in.Status = &st
@@ -160,8 +154,6 @@ func (srv *AccountsService) apiAccountHandler(ctx context.Context, _ streams.Con
 		return nil, fmt.Errorf("account: unknown action %q", action)
 	}
 }
-
-// --- Member verb --------------------------------------------------
 
 func (srv *AccountsService) apiMemberHandler(ctx context.Context, _ streams.Connection, body command.Body) (cr.Response, error) {
 	action, err := maps.String(body, "action")
@@ -229,8 +221,6 @@ func (srv *AccountsService) apiMemberHandler(ctx context.Context, _ streams.Conn
 	}
 }
 
-// --- User verb (linked git accounts) ------------------------------
-
 func (srv *AccountsService) apiUserHandler(ctx context.Context, _ streams.Connection, body command.Body) (cr.Response, error) {
 	action, err := maps.String(body, "action")
 	if err != nil {
@@ -297,12 +287,12 @@ func (srv *AccountsService) apiUserHandler(ctx context.Context, _ streams.Connec
 		if err != nil {
 			return nil, err
 		}
-		planID, err := maps.String(body, "plan_id")
+		prefName, err := maps.String(body, "pref_name")
 		if err != nil {
 			return nil, err
 		}
 		isDefault, _ := maps.Bool(body, "is_default")
-		if err := cli.Grant(ctx, id, accountsIface.GrantPlanInput{PlanID: planID, IsDefault: isDefault}); err != nil {
+		if err := cli.Grant(ctx, id, accountsIface.GrantPRefInput{PRefName: prefName, IsDefault: isDefault}); err != nil {
 			return nil, err
 		}
 		return cr.Response{"ok": true}, nil
@@ -311,11 +301,11 @@ func (srv *AccountsService) apiUserHandler(ctx context.Context, _ streams.Connec
 		if err != nil {
 			return nil, err
 		}
-		planID, err := maps.String(body, "plan_id")
+		prefName, err := maps.String(body, "pref_name")
 		if err != nil {
 			return nil, err
 		}
-		if err := cli.Revoke(ctx, id, planID); err != nil {
+		if err := cli.Revoke(ctx, id, prefName); err != nil {
 			return nil, err
 		}
 		return cr.Response{"ok": true}, nil
@@ -324,28 +314,22 @@ func (srv *AccountsService) apiUserHandler(ctx context.Context, _ streams.Connec
 	}
 }
 
-// --- Plan verb --------------------------------------------------
-
 func (srv *AccountsService) apiPlanHandler(ctx context.Context, _ streams.Connection, body command.Body) (cr.Response, error) {
 	action, err := maps.String(body, "action")
 	if err != nil {
 		return nil, fmt.Errorf("plan: %w", err)
 	}
-	accountID, err := requireAccountID(body)
-	if err != nil {
-		return nil, err
-	}
-	cli := srv.Client().Plans(accountID)
+	cli := srv.Client().Plans()
 	switch action {
 	case "create":
 		in := accountsIface.CreatePlanInput{
-			Slug:   maps.TryString(body, "slug"),
-			Name:   maps.TryString(body, "name"),
-			Mode:   accountsIface.PlanMode(maps.TryString(body, "mode")),
-			Period: maps.TryString(body, "period"),
+			Name:        maps.TryString(body, "name"),
+			DisplayName: maps.TryString(body, "display_name"),
 		}
-		if v, ok := body["dimensions"]; ok {
-			if err := decodeField(v, &in.Dimensions); err != nil {
+		if v, ok := body["data"]; ok {
+			if b, ok := v.([]byte); ok {
+				in.Data = b
+			} else if err := decodeField(v, &in.Data); err != nil {
 				return nil, err
 			}
 		}
@@ -364,67 +348,141 @@ func (srv *AccountsService) apiPlanHandler(ctx context.Context, _ streams.Connec
 			return nil, err
 		}
 		return cr.Response{"plan": p}, nil
-	case "get-by-slug":
-		slug, err := maps.String(body, "slug")
-		if err != nil {
-			return nil, err
-		}
-		p, err := cli.GetBySlug(ctx, slug)
-		if err != nil {
-			return nil, err
-		}
-		return cr.Response{"plan": p}, nil
 	case "list":
 		ids, err := cli.List(ctx)
 		if err != nil {
 			return nil, err
 		}
 		return cr.Response{"ids": ids}, nil
-	case "update":
-		id, err := maps.String(body, "id")
-		if err != nil {
-			return nil, err
-		}
-		var in accountsIface.UpdatePlanInput
-		if s, ok := optString(body, "name"); ok {
-			in.Name = &s
-		}
-		if s, ok := optString(body, "mode"); ok {
-			m := accountsIface.PlanMode(s)
-			in.Mode = &m
-		}
-		if s, ok := optString(body, "period"); ok {
-			in.Period = &s
-		}
-		if s, ok := optString(body, "status"); ok {
-			st := accountsIface.PlanStatus(s)
-			in.Status = &st
-		}
-		if v, ok := body["dimensions"]; ok {
-			if err := decodeField(v, &in.Dimensions); err != nil {
-				return nil, err
-			}
-		}
-		p, err := cli.Update(ctx, id, in)
-		if err != nil {
-			return nil, err
-		}
-		return cr.Response{"plan": p}, nil
-	case "delete":
-		id, err := maps.String(body, "id")
-		if err != nil {
-			return nil, err
-		}
-		if err := cli.Delete(ctx, id); err != nil {
-			return nil, err
-		}
-		return cr.Response{"ok": true}, nil
 	default:
 		return nil, fmt.Errorf("plan: unknown action %q", action)
 	}
 }
 
-// --- Login verb ---------------------------------------------------
+func (srv *AccountsService) apiPRefHandler(ctx context.Context, _ streams.Connection, body command.Body) (cr.Response, error) {
+	action, err := maps.String(body, "action")
+	if err != nil {
+		return nil, fmt.Errorf("pref: %w", err)
+	}
+	accountID, err := requireAccountID(body)
+	if err != nil {
+		return nil, err
+	}
+	cli := srv.Client().PRefs(accountID)
+	switch action {
+	case "create":
+		in := accountsIface.CreatePRefInput{
+			Name:        maps.TryString(body, "name"),
+			DisplayName: maps.TryString(body, "display_name"),
+			MemberID:    maps.TryString(body, "member_id"),
+		}
+		pref, err := cli.Create(ctx, in)
+		if err != nil {
+			return nil, err
+		}
+		return cr.Response{"pref": pref}, nil
+	case "get":
+		name, err := maps.String(body, "name")
+		if err != nil {
+			return nil, err
+		}
+		pref, err := cli.Get(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		return cr.Response{"pref": pref}, nil
+	case "list":
+		names, err := cli.List(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return cr.Response{"names": names}, nil
+	case "set-display-name":
+		name, err := maps.String(body, "name")
+		if err != nil {
+			return nil, err
+		}
+		displayName := maps.TryString(body, "display_name")
+		pref, err := cli.SetDisplayName(ctx, name, displayName)
+		if err != nil {
+			return nil, err
+		}
+		return cr.Response{"pref": pref}, nil
+	case "assign":
+		in := accountsIface.AssignPRefInput{
+			Name:     maps.TryString(body, "name"),
+			PlanID:   maps.TryString(body, "plan_id"),
+			MemberID: maps.TryString(body, "member_id"),
+			Note:     maps.TryString(body, "note"),
+		}
+		ev, err := cli.Assign(ctx, in)
+		if err != nil {
+			return nil, err
+		}
+		return cr.Response{"event": ev}, nil
+	case "disable":
+		in := accountsIface.DisablePRefInput{
+			Name:     maps.TryString(body, "name"),
+			MemberID: maps.TryString(body, "member_id"),
+			Note:     maps.TryString(body, "note"),
+		}
+		ev, err := cli.Disable(ctx, in)
+		if err != nil {
+			return nil, err
+		}
+		return cr.Response{"event": ev}, nil
+	case "enable":
+		in := accountsIface.EnablePRefInput{
+			Name:     maps.TryString(body, "name"),
+			MemberID: maps.TryString(body, "member_id"),
+			Note:     maps.TryString(body, "note"),
+		}
+		ev, err := cli.Enable(ctx, in)
+		if err != nil {
+			return nil, err
+		}
+		return cr.Response{"event": ev}, nil
+	case "events":
+		name, err := maps.String(body, "name")
+		if err != nil {
+			return nil, err
+		}
+		from, _ := optInt64(body, "from_unixnano")
+		to, _ := optInt64(body, "to_unixnano")
+		var fromT, toT time.Time
+		if from != 0 {
+			fromT = time.Unix(0, from)
+		}
+		if to != 0 {
+			toT = time.Unix(0, to)
+		}
+		events, err := cli.Events(ctx, name, fromT, toT)
+		if err != nil {
+			return nil, err
+		}
+		return cr.Response{"events": events}, nil
+	default:
+		return nil, fmt.Errorf("pref: unknown action %q", action)
+	}
+}
+
+func optInt64(body command.Body, key string) (int64, bool) {
+	v, ok := body[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case int64:
+		return n, true
+	case uint64:
+		return int64(n), true
+	case int:
+		return int64(n), true
+	case float64:
+		return int64(n), true
+	}
+	return 0, false
+}
 
 func (srv *AccountsService) apiLoginHandler(ctx context.Context, _ streams.Connection, body command.Body) (cr.Response, error) {
 	action, err := maps.String(body, "action")

--- a/services/accounts/api_management_test.go
+++ b/services/accounts/api_management_test.go
@@ -156,28 +156,21 @@ func TestApiAccountHandler_BadInput(t *testing.T) {
 func TestApiPlanHandler_RoundTrip(t *testing.T) {
 	srv := dispatchTestService(t)
 	ctx := context.Background()
-	cli := newInProcessClient(srv)
 
-	acc, err := cli.Accounts().Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
-	if err != nil {
-		t.Fatalf("Create acc: %v", err)
-	}
-
+	// Plans are global; no account_id in the body.
 	body := encodeBodyPayload(t, "create",
-		accountsIface.CreatePlanInput{Slug: "prod", Name: "Prod"},
-		command.Body{"account_id": acc.ID})
+		accountsIface.CreatePlanInput{Name: "Prod"},
+		nil)
 	resp, err := srv.apiPlanHandler(ctx, nil, body)
 	if err != nil {
 		t.Fatalf("create plan: %v", err)
 	}
 	bk := decodeResponsePayload[accountsIface.Plan](t, resp)
-	if bk.Slug != "prod" {
-		t.Fatalf("create slug")
+	if bk.Name != "Prod" {
+		t.Fatalf("create name")
 	}
 
-	resp, err = srv.apiPlanHandler(ctx, nil, command.Body{
-		"action": "list", "account_id": acc.ID,
-	})
+	resp, err = srv.apiPlanHandler(ctx, nil, command.Body{"action": "list"})
 	if err != nil {
 		t.Fatalf("list plan: %v", err)
 	}
@@ -186,19 +179,13 @@ func TestApiPlanHandler_RoundTrip(t *testing.T) {
 	}
 
 	resp, err = srv.apiPlanHandler(ctx, nil, command.Body{
-		"action": "get-by-slug", "account_id": acc.ID, "slug": "prod",
+		"action": "get", "id": bk.ID,
 	})
 	if err != nil {
-		t.Fatalf("get-by-slug: %v", err)
+		t.Fatalf("get: %v", err)
 	}
 	if got := decodeResponsePayload[accountsIface.Plan](t, resp); got.ID != bk.ID {
-		t.Fatalf("get-by-slug id")
-	}
-
-	if _, err := srv.apiPlanHandler(ctx, nil, command.Body{
-		"action": "delete", "account_id": acc.ID, "id": bk.ID,
-	}); err != nil {
-		t.Fatalf("delete: %v", err)
+		t.Fatalf("get id mismatch")
 	}
 }
 
@@ -245,7 +232,16 @@ func TestApiUserHandler_RoundTrip(t *testing.T) {
 	ctx := context.Background()
 	cli := newInProcessClient(srv)
 	acc, _ := cli.Accounts().Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
-	bk, _ := cli.Plans(acc.ID).Create(ctx, accountsIface.CreatePlanInput{Slug: "prod", Name: "Prod"})
+
+	// Create a global plan + a PRef pointing at it (grant target is the PRef name).
+	plan, _ := cli.Plans().Create(ctx, accountsIface.CreatePlanInput{Name: "Prod"})
+	prefs := cli.PRefs(acc.ID)
+	if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "prod", MemberID: "system:test"}); err != nil {
+		t.Fatalf("create pref: %v", err)
+	}
+	if _, err := prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: "prod", PlanID: plan.ID, MemberID: "system:test"}); err != nil {
+		t.Fatalf("assign pref: %v", err)
+	}
 
 	body := encodeBodyPayload(t, "add",
 		accountsIface.AddUserInput{Provider: "github", ExternalID: "1"},
@@ -257,7 +253,7 @@ func TestApiUserHandler_RoundTrip(t *testing.T) {
 	u := decodeResponsePayload[accountsIface.User](t, resp)
 
 	body = encodeBodyPayload(t, "grant",
-		accountsIface.GrantPlanInput{PlanID: bk.ID},
+		accountsIface.GrantPRefInput{PRefName: "prod"},
 		command.Body{"account_id": acc.ID, "id": u.ID})
 	if _, err := srv.apiUserHandler(ctx, nil, body); err != nil {
 		t.Fatalf("grant: %v", err)
@@ -271,7 +267,7 @@ func TestApiUserHandler_RoundTrip(t *testing.T) {
 	}
 
 	if _, err := srv.apiUserHandler(ctx, nil, command.Body{
-		"action": "revoke", "account_id": acc.ID, "id": u.ID, "plan_id": bk.ID,
+		"action": "revoke", "account_id": acc.ID, "id": u.ID, "pref_name": "prod",
 	}); err != nil {
 		t.Fatalf("revoke: %v", err)
 	}
@@ -444,7 +440,7 @@ func TestManagedLoginChallenge_JSONShape(t *testing.T) {
 func TestStreamVerbConstants(t *testing.T) {
 	for name, v := range map[string]string{
 		"account": StreamVerbAccount, "member": StreamVerbMember,
-		"user": StreamVerbUser, "plan": StreamVerbPlan,
+		"user": StreamVerbUser, "plan": StreamVerbPlan, "pref": StreamVerbPRef,
 		"login":  StreamVerbLogin,
 		"verify": StreamVerbVerify, "resolve": StreamVerbResolve,
 	} {
@@ -462,7 +458,7 @@ func TestApiHandlers_AdditionalBranches(t *testing.T) {
 	ctx := context.Background()
 	cli := newInProcessClient(srv)
 	acc, _ := cli.Accounts().Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
-	bk, _ := cli.Plans(acc.ID).Create(ctx, accountsIface.CreatePlanInput{Slug: "prod", Name: "Prod"})
+	bk, _ := cli.Plans().Create(ctx, accountsIface.CreatePlanInput{Name: "Prod"})
 	u, _ := cli.Users(acc.ID).Add(ctx, accountsIface.AddUserInput{Provider: "github", ExternalID: "1"})
 	m, _ := cli.Members(acc.ID).Invite(ctx, accountsIface.InviteMemberInput{PrimaryEmail: "alice@x"})
 
@@ -480,26 +476,17 @@ func TestApiHandlers_AdditionalBranches(t *testing.T) {
 		t.Fatalf("expected error for missing id on update")
 	}
 
-	// plan: get + update + delete missing-id
+	// plan: get + list (Plans are global, no account_id; immutable so no update/delete)
 	if _, err := srv.apiPlanHandler(ctx, nil, command.Body{
-		"action": "get", "account_id": acc.ID, "id": bk.ID,
+		"action": "get", "id": bk.ID,
 	}); err != nil {
 		t.Fatalf("plan get: %v", err)
 	}
-	newName := "Production"
-	body := encodeBodyPayload(t, "update",
-		accountsIface.UpdatePlanInput{Name: &newName},
-		command.Body{"account_id": acc.ID, "id": bk.ID})
-	if _, err := srv.apiPlanHandler(ctx, nil, body); err != nil {
-		t.Fatalf("plan update: %v", err)
-	}
-	for _, action := range []string{"get", "get-by-slug", "update", "delete"} {
-		if _, err := srv.apiPlanHandler(ctx, nil, command.Body{"action": action, "account_id": acc.ID}); err == nil {
-			t.Fatalf("plan %s should require id/slug", action)
-		}
-	}
 	if _, err := srv.apiPlanHandler(ctx, nil, command.Body{"action": "get"}); err == nil {
-		t.Fatalf("plan missing account_id")
+		t.Fatalf("plan get should require id")
+	}
+	if _, err := srv.apiPlanHandler(ctx, nil, command.Body{"action": "delete", "id": bk.ID}); err == nil {
+		t.Fatalf("plan delete should be unknown action")
 	}
 
 	// member: get
@@ -537,7 +524,7 @@ func TestApiHandlers_AdditionalBranches(t *testing.T) {
 		t.Fatalf("finish-external should error in v1")
 	}
 	// finish-passkey: bad assertion bytes → ParseCredentialRequestResponseBody fails.
-	body = encodeBodyPayload(t, "finish-passkey",
+	body := encodeBodyPayload(t, "finish-passkey",
 		accountsIface.FinishPasskeyInput{SessionID: "x", Assertion: []byte("{not json")}, nil)
 	if _, err := srv.apiLoginHandler(ctx, nil, body); err == nil {
 		t.Fatalf("finish-passkey should reject invalid assertion bytes")
@@ -550,6 +537,8 @@ func TestApiHandlers_AdditionalBranches(t *testing.T) {
 	}
 
 	// account_id missing on each Account-scoped verb.
+	// Account-scoped verbs (member, user, pref) require account_id. Plan is
+	// global and explicitly does not.
 	for _, verb := range []func(context.Context, any, command.Body) (map[string]interface{}, error){
 		func(c context.Context, _ any, b command.Body) (map[string]interface{}, error) {
 			return srv.apiMemberHandler(c, nil, b)
@@ -558,7 +547,7 @@ func TestApiHandlers_AdditionalBranches(t *testing.T) {
 			return srv.apiUserHandler(c, nil, b)
 		},
 		func(c context.Context, _ any, b command.Body) (map[string]interface{}, error) {
-			return srv.apiPlanHandler(c, nil, b)
+			return srv.apiPRefHandler(c, nil, b)
 		},
 	} {
 		if _, err := verb(ctx, nil, command.Body{"action": "list"}); err == nil {

--- a/services/accounts/coverage_test.go
+++ b/services/accounts/coverage_test.go
@@ -59,15 +59,13 @@ func TestAccountStore_UpdateAllFields(t *testing.T) {
 	newName := "Acme Inc."
 	newMode := accountsIface.AuthModeExternalOIDC
 	newConfig := &accountsIface.AuthConfig{IssuerURL: "https://idp.example.com"}
-	newPlan := "enterprise"
 	newStatus := accountsIface.AccountStatusSuspended
 	upd, err := store.Update(ctx, acc.ID, accountsIface.UpdateAccountInput{
-		Name:         &newName,
-		AuthMode:     &newMode,
-		AuthConfig:   newConfig,
-		PlanTemplate: &newPlan,
-		Status:       &newStatus,
-		Metadata:     map[string]string{"k1": "v1"},
+		Name:       &newName,
+		AuthMode:   &newMode,
+		AuthConfig: newConfig,
+		Status:     &newStatus,
+		Metadata:   map[string]string{"k1": "v1"},
 	})
 	if err != nil {
 		t.Fatalf("Update: %v", err)
@@ -78,8 +76,8 @@ func TestAccountStore_UpdateAllFields(t *testing.T) {
 	if upd.AuthConfig == nil || upd.AuthConfig.IssuerURL != "https://idp.example.com" {
 		t.Fatalf("Update AuthConfig: %+v", upd.AuthConfig)
 	}
-	if upd.PlanTemplate != newPlan || upd.Status != newStatus {
-		t.Fatalf("Update plan/status: %+v", upd)
+	if upd.Status != newStatus {
+		t.Fatalf("Update status: %+v", upd)
 	}
 	if upd.Metadata["k1"] != "v1" {
 		t.Fatalf("Update metadata: %+v", upd.Metadata)
@@ -123,45 +121,19 @@ func TestAccountStore_RequiredFields(t *testing.T) {
 func TestPlanStore_RequiredFields(t *testing.T) {
 	srv := newTestService(t)
 	ctx := context.Background()
-	acc, _ := newAccountStore(srv.db).Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
-	bs := newPlanStore(srv.db, acc.ID)
+	bs := newPlanStore(srv.db)
 
 	// Empty name → error.
-	if _, err := bs.Create(ctx, accountsIface.CreatePlanInput{Slug: "prod"}); err == nil {
+	if _, err := bs.Create(ctx, accountsIface.CreatePlanInput{}); err == nil {
 		t.Fatalf("expected error for empty plan name")
 	}
-	// Bad slug → error.
-	if _, err := bs.Create(ctx, accountsIface.CreatePlanInput{Slug: "BAD!", Name: "x"}); err == nil {
-		t.Fatalf("expected error for bad plan slug")
-	}
-}
-
-func TestPlanStore_UpdateAllFields(t *testing.T) {
-	srv := newTestService(t)
-	ctx := context.Background()
-	acc, _ := newAccountStore(srv.db).Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
-	bs := newPlanStore(srv.db, acc.ID)
-	b, _ := bs.Create(ctx, accountsIface.CreatePlanInput{Slug: "prod", Name: "Prod"})
-
-	newName := "Production"
-	newMode := accountsIface.PlanModeMetered
-	newPeriod := "rolling-30d"
-	newStatus := accountsIface.PlanStatusGrace
-	upd, err := bs.Update(ctx, b.ID, accountsIface.UpdatePlanInput{
-		Name:       &newName,
-		Mode:       &newMode,
-		Dimensions: []accountsIface.Dimension{{Name: "function.invocations"}},
-		Period:     &newPeriod,
-		Status:     &newStatus,
-	})
+	// Valid create with just a name succeeds.
+	p, err := bs.Create(ctx, accountsIface.CreatePlanInput{Name: "Production"})
 	if err != nil {
-		t.Fatalf("Update: %v", err)
+		t.Fatalf("Create: %v", err)
 	}
-	if upd.Name != newName || upd.Mode != newMode || upd.Period != newPeriod || upd.Status != newStatus {
-		t.Fatalf("Update fields: %+v", upd)
-	}
-	if len(upd.Dimensions) != 1 || upd.Dimensions[0].Name != "function.invocations" {
-		t.Fatalf("Update dimensions: %+v", upd.Dimensions)
+	if p.DisplayName != "Production" {
+		t.Fatalf("DisplayName should default to Name; got %q", p.DisplayName)
 	}
 }
 
@@ -179,21 +151,21 @@ func TestUserStore_RequiredFields(t *testing.T) {
 	}
 }
 
-func TestUserStore_GrantUnknownPlan(t *testing.T) {
+func TestUserStore_GrantUnknownPRef(t *testing.T) {
 	srv := newTestService(t)
 	ctx := context.Background()
 	acc, _ := newAccountStore(srv.db).Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
 	us := newUserStore(srv.db, acc.ID)
 	user, _ := us.Add(ctx, accountsIface.AddUserInput{Provider: "github", ExternalID: "1"})
 
-	if err := us.Grant(ctx, user.ID, accountsIface.GrantPlanInput{PlanID: "ghost-plan"}); err == nil {
-		t.Fatalf("expected error: granting unknown plan")
+	if err := us.Grant(ctx, user.ID, accountsIface.GrantPRefInput{PRefName: "ghost"}); err == nil {
+		t.Fatalf("expected error: granting unknown pref")
 	}
-	if err := us.Grant(ctx, "ghost-user", accountsIface.GrantPlanInput{PlanID: "x"}); err == nil {
+	if err := us.Grant(ctx, "ghost-user", accountsIface.GrantPRefInput{PRefName: "x"}); err == nil {
 		t.Fatalf("expected error: granting on unknown user")
 	}
-	if err := us.Grant(ctx, user.ID, accountsIface.GrantPlanInput{}); err == nil {
-		t.Fatalf("expected error: empty plan id")
+	if err := us.Grant(ctx, user.ID, accountsIface.GrantPRefInput{}); err == nil {
+		t.Fatalf("expected error: empty pref name")
 	}
 }
 
@@ -203,7 +175,7 @@ func TestUserStore_RevokeMissingGrant(t *testing.T) {
 	acc, _ := newAccountStore(srv.db).Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
 	us := newUserStore(srv.db, acc.ID)
 	user, _ := us.Add(ctx, accountsIface.AddUserInput{Provider: "github", ExternalID: "1"})
-	if err := us.Revoke(ctx, user.ID, "ghost-plan"); !errors.Is(err, ErrNotFound) {
+	if err := us.Revoke(ctx, user.ID, "ghost-pref"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
 }
@@ -289,19 +261,22 @@ func TestMemberStore_ExternalIndex(t *testing.T) {
 	if err := ms.AddExternalIndex(ctx, "okta", "subject-123", m.ID); err != nil {
 		t.Fatalf("AddExternalIndex: %v", err)
 	}
-	idx, err := ms.readMemberIndex(ctx, LookupExternalPath("okta", "subject-123"))
+	idx, err := readMemberIndexByPrefix(ctx, srv.db, LookupExternalPrefix("okta", "subject-123"))
 	if err != nil || len(idx) != 1 {
-		t.Fatalf("readMemberIndex: %v %+v", err, idx)
+		t.Fatalf("read external index: %v %+v", err, idx)
 	}
 	if err := ms.RemoveExternalIndex(ctx, "okta", "subject-123", m.ID); err != nil {
 		t.Fatalf("RemoveExternalIndex: %v", err)
 	}
-	if _, err := ms.readMemberIndex(ctx, LookupExternalPath("okta", "subject-123")); !errors.Is(err, ErrNotFound) {
-		t.Fatalf("expected index empty after Remove, got %v", err)
+	idx, err = readMemberIndexByPrefix(ctx, srv.db, LookupExternalPrefix("okta", "subject-123"))
+	if err != nil || len(idx) != 0 {
+		t.Fatalf("expected empty after Remove; got idx=%+v err=%v", idx, err)
 	}
-	// Removing again is a no-op (idempotent).
-	if err := ms.RemoveExternalIndex(ctx, "okta", "subject-123", m.ID); err != nil {
-		t.Fatalf("RemoveExternalIndex idempotent: %v", err)
+	// Removing again is NOT idempotent — the entry is gone, so the helper
+	// surfaces ErrNotFound. Callers that want already-gone-is-fine semantics
+	// must check explicitly (Members.Remove does this; raw helper does not).
+	if err := ms.RemoveExternalIndex(ctx, "okta", "subject-123", m.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound on second Remove, got %v", err)
 	}
 }
 
@@ -317,8 +292,11 @@ func TestInProcessClient_Accessors(t *testing.T) {
 	if cli.Users("any") == nil {
 		t.Fatalf("Users() nil")
 	}
-	if cli.Plans("any") == nil {
+	if cli.Plans() == nil {
 		t.Fatalf("Plans() nil")
+	}
+	if cli.PRefs("any") == nil {
+		t.Fatalf("PRefs() nil")
 	}
 	if cli.Login() == nil {
 		t.Fatalf("Login() nil")

--- a/services/accounts/http_management_test.go
+++ b/services/accounts/http_management_test.go
@@ -189,15 +189,22 @@ func TestHTTPMgmt_Members_InviteAndList(t *testing.T) {
 // --- Users route --------------------------------------------------
 
 // Plan-create is operator-only and not HTTP-exposed, so the test uses the
-// in-process Client to seed a plan before exercising the HTTP user route.
+// in-process Client to seed a plan + PRef before exercising the HTTP user route.
 func TestHTTPMgmt_Users_AddAndList(t *testing.T) {
 	s := setupMgmt(t)
 	ctx := context.Background()
-	plan, err := s.srv.Client().Plans(s.accountID).Create(ctx, accountsIface.CreatePlanInput{
-		Slug: "prod", Name: "Production", Mode: accountsIface.PlanModeQuota,
+	plan, err := s.srv.Client().Plans().Create(ctx, accountsIface.CreatePlanInput{
+		Name: "Production",
 	})
 	if err != nil {
 		t.Fatalf("inline create plan: %v", err)
+	}
+	prefs := s.srv.Client().PRefs(s.accountID)
+	if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "prod", MemberID: "system:test"}); err != nil {
+		t.Fatalf("inline create pref: %v", err)
+	}
+	if _, err := prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: "prod", PlanID: plan.ID, MemberID: "system:test"}); err != nil {
+		t.Fatalf("inline assign pref: %v", err)
 	}
 
 	var added accountsIface.User
@@ -214,7 +221,7 @@ func TestHTTPMgmt_Users_AddAndList(t *testing.T) {
 
 	if err := s.callMgmt(t, "/users", "grant", s.accountID,
 		map[string]string{"id": added.ID},
-		accountsIface.GrantPlanInput{PlanID: plan.ID},
+		accountsIface.GrantPRefInput{PRefName: "prod"},
 		nil,
 	); err != nil {
 		t.Fatalf("grant: %v", err)

--- a/services/accounts/inprocess_client.go
+++ b/services/accounts/inprocess_client.go
@@ -3,28 +3,28 @@ package accounts
 import (
 	"context"
 	"errors"
+	"strings"
+	"time"
 
 	peerCore "github.com/libp2p/go-libp2p/core/peer"
 	accountsIface "github.com/taubyte/tau/core/services/accounts"
 )
 
-// inProcessClient is the in-process Client returned by AccountsService.Client().
 type inProcessClient struct {
 	srv *AccountsService
 
 	accounts *accountStore
+	plans    *planStore // global, account-agnostic
 }
 
 func newInProcessClient(srv *AccountsService) accountsIface.Client {
 	return &inProcessClient{
 		srv:      srv,
 		accounts: newAccountStore(srv.db),
+		plans:    newPlanStore(srv.db),
 	}
 }
 
-// --- Integration surface (verify + plan-resolve) ----------------
-
-// Verify checks whether a git provider account is linked to ≥1 Account.
 func (c *inProcessClient) Verify(ctx context.Context, provider, externalID string) (*accountsIface.VerifyResponse, error) {
 	if provider == "" || externalID == "" {
 		return nil, errors.New("accounts: provider and external_id required")
@@ -52,16 +52,16 @@ func (c *inProcessClient) Verify(ctx context.Context, provider, externalID strin
 			Slug: acc.Slug,
 			Name: acc.Name,
 		}
-		bs := newPlanStore(c.srv.db, e.AccountID)
+		prefs := newPRefStore(c.srv.db, e.AccountID, c.plans)
 		for _, g := range u.PlanGrants {
-			b, err := bs.Get(ctx, g.PlanID)
+			pref, err := prefs.Get(ctx, g.PRefName)
 			if err != nil {
-				continue
+				continue // grant references a PRef that's been removed
 			}
-			summary.Plans = append(summary.Plans, accountsIface.VerifyPlanSummary{
-				ID:        b.ID,
-				Slug:      b.Slug,
-				IsDefault: g.IsDefault,
+			summary.PRefs = append(summary.PRefs, accountsIface.VerifyPRefSummary{
+				Name:        pref.Name,
+				DisplayName: pref.DisplayName,
+				IsDefault:   g.IsDefault,
 			})
 		}
 		resp.Accounts = append(resp.Accounts, summary)
@@ -72,9 +72,13 @@ func (c *inProcessClient) Verify(ctx context.Context, provider, externalID strin
 	return resp, nil
 }
 
-// ResolvePlan validates that (accountSlug, planSlug) names an active Plan
-// the calling git user has a grant on.
-func (c *inProcessClient) ResolvePlan(ctx context.Context, accountSlug, planSlug, provider, externalID string) (*accountsIface.ResolveResponse, error) {
+// ResolvePRef returns Valid=true when (accountSlug, prefName) names an active
+// PRef with a currently-assigned Plan and the caller's git user has a grant
+// on the PRef. Otherwise Valid=false with a typed Reason from the set
+// {account not found, account not active, pref not found, pref disabled,
+// pref has no plan assigned, plan not found, git user not linked to account,
+// git user has no grant on pref}.
+func (c *inProcessClient) ResolvePRef(ctx context.Context, accountSlug, prefName, provider, externalID string) (*accountsIface.ResolveResponse, error) {
 	acc, err := c.accounts.GetBySlug(ctx, accountSlug)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
@@ -82,50 +86,110 @@ func (c *inProcessClient) ResolvePlan(ctx context.Context, accountSlug, planSlug
 		}
 		return nil, err
 	}
-	bs := newPlanStore(c.srv.db, acc.ID)
-	plan, err := bs.GetBySlug(ctx, planSlug)
+	if acc.Status != accountsIface.AccountStatusActive {
+		return &accountsIface.ResolveResponse{Valid: false, Reason: "account not active"}, nil
+	}
+	prefs := newPRefStore(c.srv.db, acc.ID, c.plans)
+	pref, err := prefs.Get(ctx, prefName)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
-			return &accountsIface.ResolveResponse{Valid: false, Reason: "plan not found"}, nil
+			return &accountsIface.ResolveResponse{Valid: false, Reason: "pref not found"}, nil
 		}
 		return nil, err
 	}
-	if plan.Status != accountsIface.PlanStatusActive {
-		return &accountsIface.ResolveResponse{
-			Valid:  false,
-			Reason: "plan suspended",
-			Plan:   plan,
-		}, nil
+	if pref.Status != accountsIface.PRefStatusActive {
+		return &accountsIface.ResolveResponse{Valid: false, Reason: "pref disabled", PRef: pref}, nil
 	}
+
+	planID, err := latestAssignedPlanID(ctx, prefs, pref.Name)
+	if err != nil {
+		return nil, err
+	}
+	if planID == "" {
+		return &accountsIface.ResolveResponse{Valid: false, Reason: "pref has no plan assigned", PRef: pref}, nil
+	}
+	plan, err := c.plans.Get(ctx, planID)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return &accountsIface.ResolveResponse{Valid: false, Reason: "plan not found", PRef: pref}, nil
+		}
+		return nil, err
+	}
+
 	us := newUserStore(c.srv.db, acc.ID)
 	u, err := us.GetByExternal(ctx, provider, externalID)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
-			return &accountsIface.ResolveResponse{Valid: false, Reason: "git user not linked to account"}, nil
+			return &accountsIface.ResolveResponse{Valid: false, Reason: "git user not linked to account", PRef: pref, Plan: plan}, nil
 		}
 		return nil, err
 	}
 	for _, g := range u.PlanGrants {
-		if g.PlanID == plan.ID {
-			return &accountsIface.ResolveResponse{Valid: true, Plan: plan}, nil
+		if g.PRefName == pref.Name {
+			return &accountsIface.ResolveResponse{Valid: true, PRef: pref, Plan: plan}, nil
 		}
 	}
 	return &accountsIface.ResolveResponse{
 		Valid:  false,
-		Reason: "git user has no grant on plan",
+		Reason: "git user has no grant on pref",
+		PRef:   pref,
 		Plan:   plan,
 	}, nil
 }
 
-// readGitUserIndex is a client-side helper to walk the git_user index.
-// Mirrors the helper on userStore (which is per-Account) — the verify path
-// needs it across all Accounts, hence the duplication.
+// latestAssignedPlanID returns the PlanID of the most recent assign event, or
+// "" when the log has no assigns. The PRef's "current plan" is defined as the
+// latest assign — enable/disable events don't change it.
+func latestAssignedPlanID(ctx context.Context, prefs *prefStore, prefName string) (string, error) {
+	events, err := prefs.Events(ctx, prefName, time.Time{}, time.Time{})
+	if err != nil {
+		return "", err
+	}
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].Kind == accountsIface.PRefEventKindAssign {
+			return events[i].PlanID, nil
+		}
+	}
+	return "", nil
+}
+
+// readGitUserIndex walks the git_user index across all accounts. userStore's
+// helper is per-Account; the verify path needs cross-Account, hence this
+// thin wrapper with an empty accountID.
 func (c *inProcessClient) readGitUserIndex(ctx context.Context, provider, externalID string) ([]gitUserIndexEntry, error) {
 	tmp := &userStore{db: c.srv.db, accountID: ""}
 	return tmp.readGitUserIndex(ctx, provider, externalID)
 }
 
-// --- Management surface --------------------------------------------
+func (c *inProcessClient) readMemberEmailIndex(ctx context.Context, email string) ([]memberIndexEntry, error) {
+	return readMemberIndexByPrefix(ctx, c.srv.db, LookupEmailPrefix(email))
+}
+
+// LookupAccountsByEmail is a pure index lookup — no filtering on Account or
+// Member status. Callers apply their own policy on the returned IDs.
+func (c *inProcessClient) LookupAccountsByEmail(ctx context.Context, email string) ([]string, error) {
+	email = strings.ToLower(strings.TrimSpace(email))
+	if email == "" {
+		return nil, errors.New("accounts: email required")
+	}
+	idx, err := c.readMemberEmailIndex(ctx, email)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return []string{}, nil
+		}
+		return nil, err
+	}
+	seen := make(map[string]struct{}, len(idx))
+	out := make([]string, 0, len(idx))
+	for _, e := range idx {
+		if _, dup := seen[e.AccountID]; dup {
+			continue
+		}
+		seen[e.AccountID] = struct{}{}
+		out = append(out, e.AccountID)
+	}
+	return out, nil
+}
 
 func (c *inProcessClient) Accounts() accountsIface.Accounts {
 	return c.accounts
@@ -139,13 +203,16 @@ func (c *inProcessClient) Users(accountID string) accountsIface.Users {
 	return newUserStore(c.srv.db, accountID)
 }
 
-func (c *inProcessClient) Plans(accountID string) accountsIface.Plans {
-	return newPlanStore(c.srv.db, accountID)
+func (c *inProcessClient) Plans() accountsIface.Plans {
+	return c.plans
 }
 
-// Login dispatches to the managed (passkey + magic-link) impl when the
-// service has those subsystems initialised; otherwise falls back to a
-// not-implemented stub (used by unit tests that don't go through service.New).
+func (c *inProcessClient) PRefs(accountID string) accountsIface.PRefs {
+	return newPRefStore(c.srv.db, accountID, c.plans)
+}
+
+// Login falls back to a not-implemented stub when sessions aren't initialised
+// (unit tests that don't go through service.New hit this path).
 func (c *inProcessClient) Login() accountsIface.Login {
 	if c.srv != nil && c.srv.sessions != nil {
 		return &loginDispatcher{managed: newLoginManaged(c.srv), srv: c.srv}
@@ -155,8 +222,6 @@ func (c *inProcessClient) Login() accountsIface.Login {
 
 func (c *inProcessClient) Peers(...peerCore.ID) accountsIface.Client { return c }
 func (c *inProcessClient) Close()                                    {}
-
-// --- not-implemented Login stub ------------------------------------
 
 type notImplementedLogin struct{}
 

--- a/services/accounts/login_managed.go
+++ b/services/accounts/login_managed.go
@@ -11,12 +11,9 @@ import (
 	accountsIface "github.com/taubyte/tau/core/services/accounts"
 )
 
-// loginManaged is the dispatcher for managed-mode authentication: passkey
-// (WebAuthn) when the resolved Member has one registered, magic-link email
-// otherwise.
-//
-// External-mode logins (Okta, OIDC, SAML) route through login_external.go
-// (`!ee` stub) or login_external_ee.go (`ee` real impl).
+// loginManaged dispatches managed-mode auth: passkey when the Member has one
+// registered, magic-link otherwise. External-mode (OIDC/SAML) routes through
+// login_external.go (stub) / login_external_ee.go (ee impl).
 type loginManaged struct {
 	srv *AccountsService
 }
@@ -25,10 +22,9 @@ func newLoginManaged(srv *AccountsService) *loginManaged {
 	return &loginManaged{srv: srv}
 }
 
-// StartManaged kicks off a managed-mode login. The caller provides either an
-// email (resolves to one or more Account/Member pairs) or an explicit
-// account-slug (must be paired with the email at the level above; this v1
-// shape returns a candidate list when ambiguous).
+// StartManaged returns a Candidates list (no challenge) when an email maps
+// to multiple Account/Member pairs — caller then re-calls with AccountSlug
+// to narrow.
 func (l *loginManaged) StartManaged(ctx context.Context, in accountsIface.StartManagedLoginInput) (*accountsIface.ManagedLoginChallenge, error) {
 	if in.Email == "" && in.AccountSlug == "" {
 		return nil, errors.New("accounts: email or account_slug required")
@@ -42,13 +38,10 @@ func (l *loginManaged) StartManaged(ctx context.Context, in accountsIface.StartM
 		return nil, errors.New("accounts: no member found for those credentials")
 	}
 	if len(candidates) > 1 {
-		// Caller must pick one. Return the candidate list; subsequent
-		// StartManaged with AccountSlug + Email narrows.
 		return &accountsIface.ManagedLoginChallenge{Candidates: summarizeCandidates(candidates)}, nil
 	}
 	chosen := candidates[0]
 
-	// Decide passkey vs magic-link.
 	hasPasskey := len(chosen.member.PasskeyCredentials) > 0 && l.srv.webAuthn != nil && l.srv.webAuthn.Available()
 	if hasPasskey {
 		sessionID, options, err := l.srv.webAuthn.BeginLogin(ctx, chosen.account.ID, chosen.member.ID)
@@ -62,7 +55,6 @@ func (l *loginManaged) StartManaged(ctx context.Context, in accountsIface.StartM
 		}, nil
 	}
 
-	// Fallback to magic-link.
 	if l.srv.magicLink == nil {
 		return nil, errors.New("accounts: magic-link sender not configured")
 	}
@@ -72,8 +64,6 @@ func (l *loginManaged) StartManaged(ctx context.Context, in accountsIface.StartM
 	return &accountsIface.ManagedLoginChallenge{MagicLinkSent: true}, nil
 }
 
-// FinishManagedPasskey verifies a WebAuthn assertion previously challenged by
-// StartManaged. On success returns a fresh Member session.
 func (l *loginManaged) FinishManagedPasskey(ctx context.Context, in accountsIface.FinishPasskeyInput) (*accountsIface.Session, error) {
 	if in.SessionID == "" {
 		return nil, errors.New("accounts: session_id required")
@@ -92,7 +82,6 @@ func (l *loginManaged) FinishManagedPasskey(ctx context.Context, in accountsIfac
 	return l.issueSession(ctx, accountID, memberID)
 }
 
-// FinishManagedMagicLink verifies a magic-link code and returns a session.
 func (l *loginManaged) FinishManagedMagicLink(ctx context.Context, in accountsIface.FinishMagicLinkInput) (*accountsIface.Session, error) {
 	if l.srv.magicLink == nil {
 		return nil, errors.New("accounts: magic-link sender not configured")
@@ -104,7 +93,6 @@ func (l *loginManaged) FinishManagedMagicLink(ctx context.Context, in accountsIf
 	return l.issueSession(ctx, accountID, memberID)
 }
 
-// VerifySession is the cookie / bearer-token verification entry point.
 func (l *loginManaged) VerifySession(ctx context.Context, token string) (*accountsIface.Session, error) {
 	if l.srv.sessions == nil {
 		return nil, errors.New("accounts: session store unavailable")
@@ -120,7 +108,6 @@ func (l *loginManaged) VerifySession(ctx context.Context, token string) (*accoun
 	}, nil
 }
 
-// Logout revokes the session bearer.
 func (l *loginManaged) Logout(ctx context.Context, token string) error {
 	if l.srv.sessions == nil {
 		return errors.New("accounts: session store unavailable")
@@ -136,14 +123,11 @@ func (l *loginManaged) issueSession(ctx context.Context, accountID, memberID str
 	return sess, err
 }
 
-// loginCandidate pairs a resolved Member with its Account (loaded from KV).
 type loginCandidate struct {
 	account *accountsIface.Account
 	member  *accountsIface.Member
 }
 
-// resolveCandidates walks the email or account-slug indexes to find matching
-// (account, member) pairs.
 func (l *loginManaged) resolveCandidates(ctx context.Context, in accountsIface.StartManagedLoginInput) ([]loginCandidate, error) {
 	switch {
 	case in.AccountSlug != "" && in.Email == "":
@@ -164,12 +148,12 @@ func (l *loginManaged) resolveCandidates(ctx context.Context, in accountsIface.S
 }
 
 func (l *loginManaged) candidatesFromEmail(ctx context.Context, emailStr string) ([]loginCandidate, error) {
-	idx, err := newMemberStore(l.srv.db, "").readMemberIndex(ctx, LookupEmailPath(emailStr))
+	idx, err := readMemberIndexByPrefix(ctx, l.srv.db, LookupEmailPrefix(emailStr))
 	if err != nil {
-		if errors.Is(err, ErrNotFound) {
-			return nil, nil
-		}
 		return nil, err
+	}
+	if len(idx) == 0 {
+		return nil, nil
 	}
 	out := make([]loginCandidate, 0, len(idx))
 	for _, e := range idx {
@@ -206,11 +190,9 @@ func (l *loginManaged) candidatesFromAccount(ctx context.Context, acc *accountsI
 	return out, nil
 }
 
-// hashLowerSafe is the same lowercased-trimmed form Member.Invite uses on
-// PrimaryEmail; resolving by email needs the same canonicalisation.
+// hashLowerSafe mirrors Member.Invite's canonicalisation — Members store the
+// lowercased+trimmed plaintext email; the hash is only the index key.
 func hashLowerSafe(s string) string {
-	// Members store the lowercased+trimmed plaintext email, not its hash.
-	// (The hash is only the index key.) Mirror the canonicalisation here.
 	return canonicalEmail(s)
 }
 
@@ -225,8 +207,6 @@ func canonicalEmail(s string) string {
 	return string(out)
 }
 
-// summarizeCandidates produces a public VerifyAccountSummary list — used by
-// StartManaged to let the caller pick when an email maps to multiple accounts.
 func summarizeCandidates(in []loginCandidate) []accountsIface.VerifyAccountSummary {
 	out := make([]accountsIface.VerifyAccountSummary, 0, len(in))
 	for _, c := range in {

--- a/services/accounts/lookup_email_test.go
+++ b/services/accounts/lookup_email_test.go
@@ -1,0 +1,230 @@
+package accounts
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	accountsIface "github.com/taubyte/tau/core/services/accounts"
+	"github.com/taubyte/tau/p2p/streams/command"
+)
+
+// LookupAccountsByEmail is a pure email-index lookup. These tests cover the
+// behavior contract spelled out in the design note: empty-input error, empty
+// slice on no matches, multi-account fan-out, no-status-filtering (suspended
+// and pending-claim are both included), case-insensitive matching, dedup, and
+// post-Remove invisibility.
+
+// inviteWithEmail invites a Member with the given email on the given Account.
+func inviteWithEmail(t *testing.T, srv *AccountsService, accountID, email string) *accountsIface.Member {
+	t.Helper()
+	m, err := newMemberStore(srv.db, accountID).Invite(context.Background(), accountsIface.InviteMemberInput{
+		PrimaryEmail: email,
+		Role:         accountsIface.RoleOwner,
+	})
+	if err != nil {
+		t.Fatalf("invite %s: %v", email, err)
+	}
+	return m
+}
+
+func TestLookupAccountsByEmail_EmptyInput(t *testing.T) {
+	srv := newTestService(t)
+	cli := newInProcessClient(srv)
+	if _, err := cli.LookupAccountsByEmail(context.Background(), ""); err == nil {
+		t.Fatalf("expected error for empty email")
+	}
+	if _, err := cli.LookupAccountsByEmail(context.Background(), "   "); err == nil {
+		t.Fatalf("expected error for whitespace-only email")
+	}
+}
+
+func TestLookupAccountsByEmail_NoMatches(t *testing.T) {
+	srv := newTestService(t)
+	cli := newInProcessClient(srv)
+	ids, err := cli.LookupAccountsByEmail(context.Background(), "nobody@example.com")
+	if err != nil {
+		t.Fatalf("LookupAccountsByEmail: %v", err)
+	}
+	if ids == nil {
+		t.Fatalf("expected empty slice, got nil")
+	}
+	if len(ids) != 0 {
+		t.Fatalf("expected 0 ids, got %d (%v)", len(ids), ids)
+	}
+}
+
+func TestLookupAccountsByEmail_SingleAccount(t *testing.T) {
+	srv := newTestService(t)
+	ctx := context.Background()
+	acc, _ := newAccountStore(srv.db).Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
+	inviteWithEmail(t, srv, acc.ID, "alice@example.com")
+
+	cli := newInProcessClient(srv)
+	ids, err := cli.LookupAccountsByEmail(ctx, "alice@example.com")
+	if err != nil {
+		t.Fatalf("LookupAccountsByEmail: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != acc.ID {
+		t.Fatalf("expected [%s], got %v", acc.ID, ids)
+	}
+}
+
+func TestLookupAccountsByEmail_MultipleAccounts(t *testing.T) {
+	srv := newTestService(t)
+	ctx := context.Background()
+	cli := newInProcessClient(srv)
+
+	accA, _ := newAccountStore(srv.db).Create(ctx, accountsIface.CreateAccountInput{Slug: "alpha", Name: "Alpha"})
+	accB, _ := newAccountStore(srv.db).Create(ctx, accountsIface.CreateAccountInput{Slug: "beta", Name: "Beta"})
+	accC, _ := newAccountStore(srv.db).Create(ctx, accountsIface.CreateAccountInput{Slug: "gamma", Name: "Gamma"})
+
+	// alice is on alpha and beta; not on gamma.
+	inviteWithEmail(t, srv, accA.ID, "alice@x")
+	inviteWithEmail(t, srv, accB.ID, "alice@x")
+	inviteWithEmail(t, srv, accC.ID, "bob@x")
+
+	ids, err := cli.LookupAccountsByEmail(ctx, "alice@x")
+	if err != nil {
+		t.Fatalf("LookupAccountsByEmail: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("expected 2 ids, got %d (%v)", len(ids), ids)
+	}
+	sort.Strings(ids)
+	expected := []string{accA.ID, accB.ID}
+	sort.Strings(expected)
+	for i := range expected {
+		if ids[i] != expected[i] {
+			t.Fatalf("ids[%d] = %s, want %s", i, ids[i], expected[i])
+		}
+	}
+}
+
+func TestLookupAccountsByEmail_CaseInsensitive(t *testing.T) {
+	srv := newTestService(t)
+	ctx := context.Background()
+	acc, _ := newAccountStore(srv.db).Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
+	// Member.Invite already normalizes the email to lower+trim on store.
+	inviteWithEmail(t, srv, acc.ID, "alice@example.com")
+
+	cli := newInProcessClient(srv)
+	// Mixed-case lookup matches the lowercase-stored record.
+	ids, err := cli.LookupAccountsByEmail(ctx, "Alice@Example.COM")
+	if err != nil {
+		t.Fatalf("LookupAccountsByEmail: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != acc.ID {
+		t.Fatalf("case-insensitive: expected [%s], got %v", acc.ID, ids)
+	}
+	// Whitespace-padded lookup also matches.
+	ids, err = cli.LookupAccountsByEmail(ctx, "  alice@example.com  ")
+	if err != nil {
+		t.Fatalf("LookupAccountsByEmail (padded): %v", err)
+	}
+	if len(ids) != 1 {
+		t.Fatalf("padded lookup: expected 1 id, got %v", ids)
+	}
+}
+
+func TestLookupAccountsByEmail_IncludesSuspendedAccount(t *testing.T) {
+	srv := newTestService(t)
+	ctx := context.Background()
+	store := newAccountStore(srv.db)
+
+	acc, _ := store.Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
+	inviteWithEmail(t, srv, acc.ID, "alice@x")
+
+	// Suspend the Account.
+	suspended := accountsIface.AccountStatusSuspended
+	if _, err := store.Update(ctx, acc.ID, accountsIface.UpdateAccountInput{Status: &suspended}); err != nil {
+		t.Fatalf("suspend: %v", err)
+	}
+
+	cli := newInProcessClient(srv)
+	ids, err := cli.LookupAccountsByEmail(ctx, "alice@x")
+	if err != nil {
+		t.Fatalf("LookupAccountsByEmail: %v", err)
+	}
+	// No policy at the lookup layer: suspended Accounts are still returned.
+	if len(ids) != 1 || ids[0] != acc.ID {
+		t.Fatalf("expected suspended Account included; got %v", ids)
+	}
+}
+
+func TestLookupAccountsByEmail_IncludesPendingClaim(t *testing.T) {
+	srv := newTestService(t)
+	ctx := context.Background()
+	acc, _ := newAccountStore(srv.db).Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
+
+	// Invite a Member; default Status is "pending-claim" until the invitee
+	// claims (the existing Member.Invite path stamps "pending-claim").
+	inviteWithEmail(t, srv, acc.ID, "alice@x")
+
+	cli := newInProcessClient(srv)
+	ids, err := cli.LookupAccountsByEmail(ctx, "alice@x")
+	if err != nil {
+		t.Fatalf("LookupAccountsByEmail: %v", err)
+	}
+	// No policy at the lookup layer: pending-claim Members are returned.
+	if len(ids) != 1 || ids[0] != acc.ID {
+		t.Fatalf("expected pending-claim Member's Account included; got %v", ids)
+	}
+}
+
+func TestLookupAccountsByEmail_AfterRemove(t *testing.T) {
+	srv := newTestService(t)
+	ctx := context.Background()
+	acc, _ := newAccountStore(srv.db).Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
+	ms := newMemberStore(srv.db, acc.ID)
+	m := inviteWithEmail(t, srv, acc.ID, "alice@x")
+
+	cli := newInProcessClient(srv)
+	if ids, _ := cli.LookupAccountsByEmail(ctx, "alice@x"); len(ids) != 1 {
+		t.Fatalf("setup: expected 1 id, got %v", ids)
+	}
+
+	if err := ms.Remove(ctx, m.ID); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	ids, err := cli.LookupAccountsByEmail(ctx, "alice@x")
+	if err != nil {
+		t.Fatalf("LookupAccountsByEmail after Remove: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("expected 0 ids after Remove, got %v", ids)
+	}
+}
+
+// TestApiLookupAccountsByEmailHandler exercises the wire-level stream verb:
+// happy path returns ids; missing email returns error.
+func TestApiLookupAccountsByEmailHandler(t *testing.T) {
+	srv := newTestService(t)
+	ctx := context.Background()
+	acc, _ := newAccountStore(srv.db).Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
+	inviteWithEmail(t, srv, acc.ID, "alice@x")
+
+	// Happy.
+	resp, err := srv.apiLookupAccountsByEmailHandler(ctx, nil, command.Body{"email": "alice@x"})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	rawIDs, ok := resp["account_ids"]
+	if !ok {
+		t.Fatalf("response missing account_ids: %+v", resp)
+	}
+	switch ids := rawIDs.(type) {
+	case []string:
+		if len(ids) != 1 || ids[0] != acc.ID {
+			t.Fatalf("ids = %v, want [%s]", ids, acc.ID)
+		}
+	default:
+		t.Fatalf("account_ids has unexpected type %T", rawIDs)
+	}
+
+	// Missing email → error.
+	if _, err := srv.apiLookupAccountsByEmailHandler(ctx, nil, command.Body{}); err == nil {
+		t.Fatalf("expected error for missing email")
+	}
+}

--- a/services/accounts/magic_link.go
+++ b/services/accounts/magic_link.go
@@ -16,14 +16,17 @@ import (
 	"github.com/taubyte/tau/services/accounts/email"
 )
 
-// Magic-link layout:
+// KV layout:
 //
-//   /auth/magic_links/{sha256(code)} → {account_id, member_id, exp_unix_ms, used_at?}
-//   /auth/rate_limits/email/{sha256(email)}/{hour_plan} → counter
-//   /auth/rate_limits/ip/{ip}/{hour_plan} → counter
+//   /auth/magic_links/{sha256(code)}                            → magicLinkRecord
+//   /auth/rate_limits/email/{sha256(email)}/{hour}/{attempt_id} → ms-timestamp
+//   /auth/rate_limits/ip/{ip}/{hour}/{attempt_id}               → ms-timestamp
+//   /auth/rate_limits/verify_ip/{ip}/{minute}/{attempt_id}      → ms-timestamp
 //
-// The raw code is never stored — only its sha256. Verify hashes the
-// presented code and looks up that key.
+// Rate buckets are key-per-attempt (not a counter blob) so concurrent bumps
+// from different nodes can't lose each other's increments — "count" = List.
+// Window expiry is implicit via the {hour}/{minute} path segment; stale
+// windows simply stop being read (a sweeper or raft phase can prune).
 
 const (
 	magicLinkPathPrefix   = "/auth/magic_links/"
@@ -51,8 +54,8 @@ const (
 	verifyAttemptsPerIPMinute = 10
 )
 
-// magicLinkRecord is what we persist per code. Only its hash is the key, so
-// the raw code can't be recovered from the KV.
+// magicLinkRecord — the key is sha256(code), so the raw code is never
+// recoverable from the KV.
 type magicLinkRecord struct {
 	AccountID string `cbor:"account_id"`
 	MemberID  string `cbor:"member_id"`
@@ -70,7 +73,6 @@ const (
 	magicLinkSendsPerIPHr    = 20
 )
 
-// magicLinkStore implements send/verify with rate limiting.
 type magicLinkStore struct {
 	db          kvdb.KVDB
 	sender      email.Sender
@@ -85,12 +87,8 @@ func newMagicLinkStore(db kvdb.KVDB, sender email.Sender, accountsURL string) *m
 	}
 }
 
-// SendMagicLink generates a single-use code, persists it under the given
-// (account, member, email), enforces rate limits, and emails the URL.
-//
-// `clientIP` may be empty when the call originates from a context that
-// doesn't carry one (e.g. P2P CLI flow); only the per-email rate limit
-// applies in that case.
+// SendMagicLink: clientIP may be empty for callers that don't carry one (P2P
+// CLI flow) — only the per-email rate limit applies in that case.
 func (s *magicLinkStore) SendMagicLink(ctx context.Context, accountID, memberID, to, clientIP string) error {
 	if to == "" {
 		return errors.New("accounts: magic-link recipient required")
@@ -103,11 +101,9 @@ func (s *magicLinkStore) SendMagicLink(ctx context.Context, accountID, memberID,
 	hourPlan := fmt.Sprintf("%d", now.Unix()/3600)
 	emailHash := hashLower(to)
 
-	// Email-plan rate limit.
 	if err := s.bumpAndCheckRate(ctx, rateLimitEmailPath+emailHash+"/"+hourPlan, magicLinkSendsPerEmailHr); err != nil {
 		return err
 	}
-	// IP-plan rate limit.
 	if clientIP != "" {
 		if err := s.bumpAndCheckRate(ctx, rateLimitIPPath+clientIP+"/"+hourPlan, magicLinkSendsPerIPHr); err != nil {
 			return err
@@ -141,23 +137,29 @@ func (s *magicLinkStore) SendMagicLink(ctx context.Context, accountID, memberID,
 		return err
 	}
 	if err := s.sender.Send(ctx, to, subject, body); err != nil {
-		// Roll back the persisted code so a future user can retry without
-		// hitting the per-email limit until expiry.
+		// Roll back persisted code so the user can retry without burning
+		// their per-email budget until expiry.
 		_ = s.db.Delete(ctx, magicLinkPathPrefix+sha256Hex(code))
 		return err
 	}
 	return nil
 }
 
-// VerifyMagicLink checks the code against the store, marks it used, and
-// returns the (account, member) it authenticates. Returns an error for
-// missing / expired / already-used codes.
+// VerifyMagicLink rate-limits per-IP per minute on failed attempts only
+// (successes don't bump the counter). Without this, the 10^6 search space
+// of a 6-digit code is brute-forceable.
 //
-// `clientIP` (when non-empty) is rate-limited per minute: failed attempts
-// (lookup miss, expired, already-used) bump a per-IP counter; successful
-// verifies don't. Once the counter exceeds verifyAttemptsPerIPMinute the
-// IP is rejected for the rest of the minute. This is what makes 6-digit
-// codes safe — without it the 10^6 search space is brute-forceable.
+// KNOWN RACE (no sub-key fix; raft phase 2 closes it):
+// Two service nodes that both receive the same valid code before CRDT
+// convergence can each pass the `UsedAt == 0` check and each mark the
+// record used. Both will issue a session. Sub-keying the "used" marker
+// doesn't help — both nodes idempotently write distinct claim keys and
+// both still claim success. The only correct fix is single-leader
+// serialization (raft) or a CAS primitive on the KV. Until that lands,
+// the code's TTL (short) plus the verify-failure rate limit (above) bound
+// the blast radius. Don't try to "fix" this with another layer of
+// sub-keyed markers — the issue is exactly-once consumption across
+// partitions, not key-shape.
 func (s *magicLinkStore) VerifyMagicLink(ctx context.Context, code, clientIP string) (accountID, memberID string, err error) {
 	if code == "" {
 		return "", "", errors.New("accounts: magic-link code required")
@@ -197,85 +199,83 @@ func (s *magicLinkStore) VerifyMagicLink(ctx context.Context, code, clientIP str
 	return rec.AccountID, rec.MemberID, nil
 }
 
-// checkVerifyRateLimit returns nil when the IP is under the per-minute
-// failure cap, or an error when it has exceeded it. Counters live at
-// rateLimitVerifyIPPath/{ip}/{minute} so they reset every minute and the
-// keyspace doesn't grow unboundedly.
+// checkVerifyRateLimit uses key-per-attempt under rateLimitVerifyIPPath/
+// {ip}/{minute}/{attempt_id}; count by List, not by counter Get+Put. CRDT-
+// safe (distinct keys can't collide) at the cost of an O(N) list per check,
+// where N is bounded by the per-window limit.
 func (s *magicLinkStore) checkVerifyRateLimit(ctx context.Context, clientIP string) error {
-	key := s.verifyRateKey(clientIP)
-	raw, err := s.db.Get(ctx, key)
+	keys, err := s.db.List(ctx, s.verifyRatePrefix(clientIP))
 	if err != nil {
-		if isMissing(err) {
-			return nil
-		}
-		return fmt.Errorf("accounts: verify rate-limit read: %w", err)
+		return fmt.Errorf("accounts: verify rate-limit list: %w", err)
 	}
-	current, _ := decodeIntDecimal(string(raw))
-	if current >= verifyAttemptsPerIPMinute {
+	if len(keys) >= verifyAttemptsPerIPMinute {
 		return fmt.Errorf("accounts: too many verify attempts; try again in a minute")
 	}
 	return nil
 }
 
-// bumpVerifyFailureCounter increments the IP's failure counter for the
-// current minute. Best-effort — write errors are ignored to keep the verify
-// path returning the user-facing error rather than a confusing rate-limit
-// internal error.
+// bumpVerifyFailureCounter is best-effort: write errors are swallowed so the
+// caller still sees the original user-facing verify error.
 func (s *magicLinkStore) bumpVerifyFailureCounter(ctx context.Context, clientIP string) {
 	if clientIP == "" {
 		return
 	}
-	key := s.verifyRateKey(clientIP)
-	current := 0
-	if raw, err := s.db.Get(ctx, key); err == nil && len(raw) > 0 {
-		current, _ = decodeIntDecimal(string(raw))
-	}
-	current++
-	_ = s.db.Put(ctx, key, []byte(fmt.Sprintf("%d", current)))
+	_ = s.db.Put(ctx, s.verifyRatePrefix(clientIP)+newRateAttemptID(), nowMSBytes())
 }
 
-// verifyRateKey returns the per-minute counter key for an IP.
-func (s *magicLinkStore) verifyRateKey(clientIP string) string {
+// verifyRatePrefix — trailing slash bounds List to this minute's bucket.
+func (s *magicLinkStore) verifyRatePrefix(clientIP string) string {
 	minute := fmt.Sprintf("%d", time.Now().Unix()/60)
-	return rateLimitVerifyIPPath + clientIP + "/" + minute
+	return rateLimitVerifyIPPath + clientIP + "/" + minute + "/"
 }
 
-// bumpAndCheckRate increments the counter at key and returns an error when
-// it exceeds limit.
-func (s *magicLinkStore) bumpAndCheckRate(ctx context.Context, key string, limit int) error {
-	current := 0
-	if raw, err := s.db.Get(ctx, key); err == nil && len(raw) > 0 {
-		current, _ = decodeIntDecimal(string(raw))
-	} else if err != nil && !isMissing(err) {
-		return fmt.Errorf("accounts: rate-limit read: %w", err)
+// bumpAndCheckRate: key-per-attempt under the window prefix, count by List.
+// Sub-keyed (not counter Get+Put) so concurrent bumps from different nodes
+// can't lose each other's increments.
+func (s *magicLinkStore) bumpAndCheckRate(ctx context.Context, prefix string, limit int) error {
+	if prefix == "" || prefix[len(prefix)-1] != '/' {
+		prefix += "/"
 	}
-	if current >= limit {
+	keys, err := s.db.List(ctx, prefix)
+	if err != nil {
+		return fmt.Errorf("accounts: rate-limit list: %w", err)
+	}
+	if len(keys) >= limit {
 		return fmt.Errorf("accounts: rate limit exceeded (%d/hour)", limit)
 	}
-	current++
-	if err := s.db.Put(ctx, key, []byte(fmt.Sprintf("%d", current))); err != nil {
+	if err := s.db.Put(ctx, prefix+newRateAttemptID(), nowMSBytes()); err != nil {
 		return fmt.Errorf("accounts: rate-limit write: %w", err)
 	}
 	return nil
 }
 
-// buildMagicLinkURL is the deep-link presented in the email. Accounts.AccountsURL
-// (e.g. https://accounts.<network>) is set in config.
+// newRateAttemptID — 16-byte crypto-random hex makes collisions effectively
+// impossible across concurrent writers on different nodes within a minute.
+func newRateAttemptID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}
+
+// nowMSBytes — the rate-attempt value is human-readable for KV inspection;
+// counting is via List, not summation, so the format is informational.
+func nowMSBytes() []byte {
+	return []byte(fmt.Sprintf("%d", time.Now().UnixMilli()))
+}
+
 func (s *magicLinkStore) buildMagicLinkURL(code string) string {
 	base := strings.TrimRight(s.accountsURL, "/")
 	if base == "" {
-		// Fallback for dev/dream where the operator hasn't set AccountsURL —
-		// the code itself is what matters; the test harness reads it from
-		// the captured email body.
+		// Dev/dream fallback when AccountsURL isn't configured — the test
+		// harness reads the code straight out of the captured email body.
 		base = "https://accounts.localhost"
 	}
 	return base + "/auth/magic?code=" + code
 }
 
 func generateMagicLinkCode() (string, error) {
-	// Generate `magicLinkCodeDigits` digits of crypto-random uniformly in
-	// [0, 10^digits). We use `crypto/rand.Int` rather than masking off bits
-	// of byte-random to avoid modulo bias.
+	// crypto/rand.Int over [0, 10^digits) — using byte-mask + modulo would
+	// introduce modulo bias on a 10-base space.
 	max := big.NewInt(pow10(magicLinkCodeDigits))
 	n, err := rand.Int(rand.Reader, max)
 	if err != nil {
@@ -284,7 +284,7 @@ func generateMagicLinkCode() (string, error) {
 	return fmt.Sprintf("%0*d", magicLinkCodeDigits, n.Int64()), nil
 }
 
-// pow10 returns 10^n. Inlined so we don't pull math.Pow / float64 ↔ int64.
+// pow10 inlined to avoid pulling math.Pow / float64 ↔ int64.
 func pow10(n int) int64 {
 	out := int64(1)
 	for range n {
@@ -300,15 +300,4 @@ func sha256Hex(s string) string {
 
 func hashLower(email string) string {
 	return sha256Hex(strings.ToLower(strings.TrimSpace(email)))
-}
-
-func decodeIntDecimal(s string) (int, error) {
-	var n int
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			return 0, errors.New("accounts: rate-limit not decimal")
-		}
-		n = n*10 + int(r-'0')
-	}
-	return n, nil
 }

--- a/services/accounts/member.go
+++ b/services/accounts/member.go
@@ -8,23 +8,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fxamacker/cbor/v2"
 	"github.com/taubyte/tau/core/kvdb"
 	accountsIface "github.com/taubyte/tau/core/services/accounts"
 	protocolCommon "github.com/taubyte/tau/services/common"
 )
 
-// memberStore implements accountsIface.Members for one Account.
-//
-// Persistence is split: the Member's profile (sans passkeys) lives at
-// .../members/{member_id}/profile, and each PasskeyCredential lives at
-// .../members/{member_id}/passkeys/{credential_id_hex}. Passkey ops only
-// touch one key.
-//
-// Maintained indexes:
-//
-//	/lookup/email/{sha256(email)}                → JSON [(account_id, member_id), ...]
-//	/lookup/external/{provider}/{subject}        → JSON [(account_id, member_id), ...]
+// memberStore implements accountsIface.Members for one Account. The Member's
+// profile lives separate from its passkeys (each passkey is its own KV key)
+// so passkey ops touch a single key. Lookup-index layout in paths.go.
 type memberStore struct {
 	db        kvdb.KVDB
 	accountID string
@@ -36,14 +27,13 @@ func newMemberStore(db kvdb.KVDB, accountID string) *memberStore {
 
 var _ accountsIface.Members = (*memberStore)(nil)
 
-// memberIndexEntry is one row in the email or external login index.
+// memberIndexEntry is reconstructed from lookup-index keys; not a stored
+// shape — the (account, member) tuple lives in the key path.
 type memberIndexEntry struct {
-	AccountID string `cbor:"account_id"`
-	MemberID  string `cbor:"member_id"`
+	AccountID string
+	MemberID  string
 }
 
-// Invite creates a Member with the given email + role. The Member starts
-// with no passkeys; the invitee registers one via the magic-link claim flow.
 func (s *memberStore) Invite(ctx context.Context, in accountsIface.InviteMemberInput) (*accountsIface.Member, error) {
 	if in.PrimaryEmail == "" {
 		return nil, errors.New("accounts: primary_email required")
@@ -70,7 +60,6 @@ func (s *memberStore) Invite(ctx context.Context, in accountsIface.InviteMemberI
 	return m, nil
 }
 
-// Get loads a Member (including passkeys).
 func (s *memberStore) Get(ctx context.Context, memberID string) (*accountsIface.Member, error) {
 	var m accountsIface.Member
 	if err := getKV(ctx, s.db, MemberProfilePath(s.accountID, memberID), &m); err != nil {
@@ -84,13 +73,10 @@ func (s *memberStore) Get(ctx context.Context, memberID string) (*accountsIface.
 	return &m, nil
 }
 
-// List returns the IDs of all Members on this Account.
 func (s *memberStore) List(ctx context.Context) ([]string, error) {
 	return listChildIDs(ctx, s.db, AccountMembersPrefix(s.accountID))
 }
 
-// Update applies a partial update. Only Role is currently mutable through
-// this surface; passkey + external_subject changes go through their own flows.
 func (s *memberStore) Update(ctx context.Context, memberID string, in accountsIface.UpdateMemberInput) (*accountsIface.Member, error) {
 	m, err := s.Get(ctx, memberID)
 	if err != nil {
@@ -99,7 +85,6 @@ func (s *memberStore) Update(ctx context.Context, memberID string, in accountsIf
 	if in.Role != nil {
 		m.Role = *in.Role
 	}
-	// Persist sans passkeys (they live under their own prefix).
 	persisted := *m
 	persisted.PasskeyCredentials = nil
 	if err := putKV(ctx, s.db, MemberProfilePath(s.accountID, memberID), &persisted); err != nil {
@@ -108,7 +93,6 @@ func (s *memberStore) Update(ctx context.Context, memberID string, in accountsIf
 	return m, nil
 }
 
-// Remove deletes the Member's profile, passkeys, and lookup indexes.
 func (s *memberStore) Remove(ctx context.Context, memberID string) error {
 	m, err := s.Get(ctx, memberID)
 	if err != nil {
@@ -122,17 +106,18 @@ func (s *memberStore) Remove(ctx context.Context, memberID string) error {
 	if err := s.db.Delete(ctx, MemberProfilePath(s.accountID, memberID)); err != nil {
 		return fmt.Errorf("accounts: delete member: %w", err)
 	}
+	// Email-index cleanup is best-effort: the profile is already gone, and
+	// failing Remove because a secondary index couldn't be pruned would
+	// strand the caller. A future sweep or re-Remove can prune the stale row.
 	if err := s.removeEmailIndex(ctx, m.PrimaryEmail, m.ID); err != nil {
-		return err
+		logger.Warnf("accounts: stale email index entry for member %s on account %s: %v",
+			m.ID, s.accountID, err)
 	}
-	if m.ExternalSubject != "" {
-		// We don't know the provider here without re-reading auth_config;
-		// the external index is left slightly stale.
-	}
+	// External-index cleanup needs the provider, which would mean re-reading
+	// auth_config — left slightly stale on purpose.
 	return nil
 }
 
-// listPasskeys reads all PasskeyCredential blobs under a Member.
 func (s *memberStore) listPasskeys(ctx context.Context, memberID string) ([]accountsIface.PasskeyCredential, error) {
 	keys, err := s.db.List(ctx, MemberPasskeysPrefix(s.accountID, memberID))
 	if err != nil {
@@ -152,7 +137,6 @@ func (s *memberStore) listPasskeys(ctx context.Context, memberID string) ([]acco
 	return out, nil
 }
 
-// AddPasskey persists a new WebAuthn credential against this Member.
 func (s *memberStore) AddPasskey(ctx context.Context, memberID string, pk accountsIface.PasskeyCredential) error {
 	if len(pk.CredentialID) == 0 {
 		return errors.New("accounts: passkey credential_id required")
@@ -161,99 +145,64 @@ func (s *memberStore) AddPasskey(ctx context.Context, memberID string, pk accoun
 	return putKV(ctx, s.db, MemberPasskeyPath(s.accountID, memberID, credKey), pk)
 }
 
-// RemovePasskey deletes one Member's passkey by credential id.
 func (s *memberStore) RemovePasskey(ctx context.Context, memberID string, credentialID []byte) error {
 	credKey := hex.EncodeToString(credentialID)
 	return s.db.Delete(ctx, MemberPasskeyPath(s.accountID, memberID, credKey))
 }
 
-// --- email index helpers -------------------------------------------
-
 func (s *memberStore) addEmailIndex(ctx context.Context, email, memberID string) error {
-	idx, err := s.readMemberIndex(ctx, LookupEmailPath(email))
-	if err != nil && !errors.Is(err, ErrNotFound) {
-		return err
-	}
-	idx = append(idx, memberIndexEntry{AccountID: s.accountID, MemberID: memberID})
-	return s.writeMemberIndex(ctx, LookupEmailPath(email), idx)
+	return s.db.Put(ctx, LookupEmailEntryPath(email, s.accountID, memberID), nowBytes())
 }
 
 func (s *memberStore) removeEmailIndex(ctx context.Context, email, memberID string) error {
-	idx, err := s.readMemberIndex(ctx, LookupEmailPath(email))
-	if err != nil {
-		if errors.Is(err, ErrNotFound) {
-			return nil
-		}
-		return err
-	}
-	out := idx[:0]
-	for _, e := range idx {
-		if e.AccountID == s.accountID && e.MemberID == memberID {
-			continue
-		}
-		out = append(out, e)
-	}
-	if len(out) == 0 {
-		return s.db.Delete(ctx, LookupEmailPath(email))
-	}
-	return s.writeMemberIndex(ctx, LookupEmailPath(email), out)
+	return deleteIndexEntry(ctx, s.db, LookupEmailEntryPath(email, s.accountID, memberID))
 }
 
-// AddExternalIndex registers a (provider, subject) → (account, member) entry
-// in the external login index.
 func (s *memberStore) AddExternalIndex(ctx context.Context, provider, subject, memberID string) error {
-	idx, err := s.readMemberIndex(ctx, LookupExternalPath(provider, subject))
-	if err != nil && !errors.Is(err, ErrNotFound) {
-		return err
-	}
-	idx = append(idx, memberIndexEntry{AccountID: s.accountID, MemberID: memberID})
-	return s.writeMemberIndex(ctx, LookupExternalPath(provider, subject), idx)
+	return s.db.Put(ctx, LookupExternalEntryPath(provider, subject, s.accountID, memberID), nowBytes())
 }
 
-// RemoveExternalIndex removes an external-login mapping.
+// RemoveExternalIndex returns ErrNotFound when the entry isn't present —
+// KVDB.Delete is silently idempotent, but callers want a not-found signal.
 func (s *memberStore) RemoveExternalIndex(ctx context.Context, provider, subject, memberID string) error {
-	idx, err := s.readMemberIndex(ctx, LookupExternalPath(provider, subject))
-	if err != nil {
-		if errors.Is(err, ErrNotFound) {
-			return nil
+	return deleteIndexEntry(ctx, s.db, LookupExternalEntryPath(provider, subject, s.accountID, memberID))
+}
+
+// deleteIndexEntry reads-then-deletes so missing-key surfaces as ErrNotFound;
+// KVDB.Delete alone returns nil for missing keys.
+func deleteIndexEntry(ctx context.Context, db kvdb.KVDB, key string) error {
+	if _, err := db.Get(ctx, key); err != nil {
+		if isMissing(err) {
+			return ErrNotFound
 		}
-		return err
+		return fmt.Errorf("accounts: read index %s: %w", key, err)
 	}
-	out := idx[:0]
-	for _, e := range idx {
-		if e.AccountID == s.accountID && e.MemberID == memberID {
+	return db.Delete(ctx, key)
+}
+
+func readMemberIndexByPrefix(ctx context.Context, db kvdb.KVDB, prefix string) ([]memberIndexEntry, error) {
+	keys, err := db.List(ctx, prefix)
+	if err != nil {
+		return nil, fmt.Errorf("accounts: list index %s: %w", prefix, err)
+	}
+	out := make([]memberIndexEntry, 0, len(keys))
+	for _, k := range keys {
+		rest := strings.TrimPrefix(k, prefix)
+		parts := strings.SplitN(rest, "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 			continue
 		}
-		out = append(out, e)
+		out = append(out, memberIndexEntry{AccountID: parts[0], MemberID: parts[1]})
 	}
-	if len(out) == 0 {
-		return s.db.Delete(ctx, LookupExternalPath(provider, subject))
-	}
-	return s.writeMemberIndex(ctx, LookupExternalPath(provider, subject), out)
+	return out, nil
 }
 
-func (s *memberStore) readMemberIndex(ctx context.Context, key string) ([]memberIndexEntry, error) {
-	raw, err := s.db.Get(ctx, key)
-	if err != nil {
-		if isMissing(err) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("accounts: read index %s: %w", key, err)
+func nowBytes() []byte {
+	ts := time.Now().UnixNano()
+	b := make([]byte, 8)
+	for i := 7; i >= 0; i-- {
+		b[i] = byte(ts & 0xff)
+		ts >>= 8
 	}
-	if len(raw) == 0 {
-		return nil, ErrNotFound
-	}
-	var idx []memberIndexEntry
-	if err := cbor.Unmarshal(raw, &idx); err != nil {
-		return nil, fmt.Errorf("accounts: unmarshal index %s: %w", key, err)
-	}
-	return idx, nil
-}
-
-func (s *memberStore) writeMemberIndex(ctx context.Context, key string, idx []memberIndexEntry) error {
-	raw, err := cbor.Marshal(idx)
-	if err != nil {
-		return fmt.Errorf("accounts: marshal index: %w", err)
-	}
-	return s.db.Put(ctx, key, raw)
+	return b
 }

--- a/services/accounts/paths.go
+++ b/services/accounts/paths.go
@@ -3,110 +3,131 @@ package accounts
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"strings"
 )
 
-// KV path layout for the Accounts subsystem. All structured blobs are
-// CBOR-encoded (see kvcodec.go); raw-byte values are noted explicitly.
+// KV path layout. All structured blobs are CBOR-encoded; raw-byte values are
+// called out explicitly.
 //
-//   /accounts/{id}/profile                                       → Account
-//   /accounts/{id}/plans/{plan_id}/profile                       → Plan
-//   /accounts/{id}/members/{member_id}/profile                   → Member (sans passkeys)
-//   /accounts/{id}/members/{member_id}/passkeys/{credential_id}  → PasskeyCredential
-//   /accounts/{id}/users/{user_id}/profile                       → User (sans grants)
-//   /accounts/{id}/users/{user_id}/grants/{plan_id}              → PlanGrant
-//   /accounts/{id}/signing_key                                   → 32 raw random bytes
+//   /plans/{plan_id}                                              → Plan (global, immutable)
 //
-//   /lookup/account_slug/{slug}                                  → account_id (raw bytes)
-//   /lookup/email/{sha256(lower(email))}                         → [{account_id, member_id}, ...]
-//   /lookup/external/{provider}/{subject}                        → [{account_id, member_id}, ...]
-//   /lookup/git_user/{provider}/{external_id}                    → [{account_id, user_id}, ...]
+//   /accounts/{id}/profile                                        → Account
+//   /accounts/{id}/members/{member_id}/profile                    → Member (sans passkeys)
+//   /accounts/{id}/members/{member_id}/passkeys/{credential_id}   → PasskeyCredential
+//   /accounts/{id}/users/{user_id}/profile                        → User (sans grants)
+//   /accounts/{id}/users/{user_id}/grants/{pref_name}             → PlanGrant
+//   /accounts/{id}/prefs/{name}/profile                           → PRef envelope
+//   /accounts/{id}/prefs/{name}/events/{at_unixnano_zeropad}      → PRefEvent
+//   /accounts/{id}/signing_key                                    → 32 raw random bytes
 //
-// Sub-collection items (passkeys, grants) are stored as one blob per element
-// so individual entries can be added/revoked without rewriting the parent.
+//   /lookup/account_slug/{slug}                                       → account_id (raw bytes)
+//   /lookup/email/{sha256(lower(email))}/{account_id}/{member_id}     → 8-byte unixnano added-at
+//   /lookup/external/{provider}/{subject}/{account_id}/{member_id}    → 8-byte unixnano added-at
+//   /lookup/git_user/{provider}/{external_id}/{account_id}/{user_id}  → 8-byte unixnano added-at
+//
+// Lookup indexes are one KV key per entry (not a single CBOR slice) so
+// concurrent writes from different nodes for distinct (account, member|user)
+// pairs touch distinct keys — no read-modify-write blob, no CRDT loss. Same
+// rationale for the per-element sub-collections (passkeys, grants, events).
 
 const (
 	prefixAccounts = "/accounts/"
 	prefixLookup   = "/lookup/"
+	prefixPlans    = "/plans/"
 )
 
-// AccountProfilePath returns the KV path for an Account's JSON profile.
+func PlanProfilePath(planID string) string {
+	return prefixPlans + planID
+}
+
+func PlansPrefix() string {
+	return prefixPlans
+}
+
 func AccountProfilePath(accountID string) string {
 	return prefixAccounts + accountID + "/profile"
 }
 
-// AccountPlansPrefix returns the KV prefix for one Account's Plans.
-func AccountPlansPrefix(accountID string) string {
-	return prefixAccounts + accountID + "/plans/"
-}
-
-// PlanProfilePath returns the KV path for a Plan's JSON profile.
-func PlanProfilePath(accountID, planID string) string {
-	return AccountPlansPrefix(accountID) + planID + "/profile"
-}
-
-// AccountMembersPrefix returns the KV prefix for one Account's Members.
 func AccountMembersPrefix(accountID string) string {
 	return prefixAccounts + accountID + "/members/"
 }
 
-// MemberProfilePath returns the KV path for a Member's JSON profile (sans passkeys).
 func MemberProfilePath(accountID, memberID string) string {
 	return AccountMembersPrefix(accountID) + memberID + "/profile"
 }
 
-// MemberPasskeysPrefix returns the KV prefix under which a Member's passkeys live.
 func MemberPasskeysPrefix(accountID, memberID string) string {
 	return AccountMembersPrefix(accountID) + memberID + "/passkeys/"
 }
 
-// MemberPasskeyPath returns the KV path for one Member passkey credential.
 func MemberPasskeyPath(accountID, memberID, credentialID string) string {
 	return MemberPasskeysPrefix(accountID, memberID) + credentialID
 }
 
-// AccountUsersPrefix returns the KV prefix for one Account's Users.
 func AccountUsersPrefix(accountID string) string {
 	return prefixAccounts + accountID + "/users/"
 }
 
-// UserProfilePath returns the KV path for a User's JSON profile (sans grants).
 func UserProfilePath(accountID, userID string) string {
 	return AccountUsersPrefix(accountID) + userID + "/profile"
 }
 
-// UserGrantsPrefix returns the KV prefix for one User's plan grants.
 func UserGrantsPrefix(accountID, userID string) string {
 	return AccountUsersPrefix(accountID) + userID + "/grants/"
 }
 
-// UserGrantPath returns the KV path for one User's grant on one Plan.
-func UserGrantPath(accountID, userID, planID string) string {
-	return UserGrantsPrefix(accountID, userID) + planID
+func UserGrantPath(accountID, userID, prefName string) string {
+	return UserGrantsPrefix(accountID, userID) + prefName
 }
 
-// LookupAccountSlugPath returns the KV path mapping slug → account_id.
+func AccountPRefsPrefix(accountID string) string {
+	return prefixAccounts + accountID + "/prefs/"
+}
+
+func PRefProfilePath(accountID, prefName string) string {
+	return AccountPRefsPrefix(accountID) + prefName + "/profile"
+}
+
+func PRefEventsPrefix(accountID, prefName string) string {
+	return AccountPRefsPrefix(accountID) + prefName + "/events/"
+}
+
+// PRefEventPath formats atUnixNano as 20-digit zero-padded decimal so byte
+// order matches chronological order on prefix scans.
+func PRefEventPath(accountID, prefName string, atUnixNano int64) string {
+	return PRefEventsPrefix(accountID, prefName) + fmt.Sprintf("%020d", atUnixNano)
+}
+
 func LookupAccountSlugPath(slug string) string {
 	return prefixLookup + "account_slug/" + slug
 }
 
-// LookupEmailPath returns the KV path keyed by sha256(lower(email)) → JSON [(account_id, member_id), ...].
-func LookupEmailPath(email string) string {
-	return prefixLookup + "email/" + hashEmail(email)
+func LookupEmailPrefix(email string) string {
+	return prefixLookup + "email/" + hashEmail(email) + "/"
 }
 
-// LookupExternalPath returns the KV path keyed by (provider, subject) → JSON [(account_id, member_id), ...].
-func LookupExternalPath(provider, subject string) string {
-	return prefixLookup + "external/" + provider + "/" + subject
+func LookupEmailEntryPath(email, accountID, memberID string) string {
+	return LookupEmailPrefix(email) + accountID + "/" + memberID
 }
 
-// LookupGitUserPath returns the KV path keyed by (provider, external_id) → JSON [(account_id, user_id), ...].
-func LookupGitUserPath(provider, externalID string) string {
-	return prefixLookup + "git_user/" + provider + "/" + externalID
+func LookupExternalPrefix(provider, subject string) string {
+	return prefixLookup + "external/" + provider + "/" + subject + "/"
 }
 
-// hashEmail normalises and hashes an email so the keyspace is safe to log
-// without exposing addresses (sha256(lower(trim(email)))).
+func LookupExternalEntryPath(provider, subject, accountID, memberID string) string {
+	return LookupExternalPrefix(provider, subject) + accountID + "/" + memberID
+}
+
+func LookupGitUserPrefix(provider, externalID string) string {
+	return prefixLookup + "git_user/" + provider + "/" + externalID + "/"
+}
+
+func LookupGitUserEntryPath(provider, externalID, accountID, userID string) string {
+	return LookupGitUserPrefix(provider, externalID) + accountID + "/" + userID
+}
+
+// hashEmail keeps the keyspace safe to log: emails never appear verbatim.
 func hashEmail(email string) string {
 	normalized := strings.ToLower(strings.TrimSpace(email))
 	sum := sha256.Sum256([]byte(normalized))

--- a/services/accounts/plan.go
+++ b/services/accounts/plan.go
@@ -4,142 +4,68 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/taubyte/tau/core/kvdb"
 	accountsIface "github.com/taubyte/tau/core/services/accounts"
 	protocolCommon "github.com/taubyte/tau/services/common"
 )
 
-// planStore implements accountsIface.Plans for one Account.
+// planStore implements accountsIface.Plans over the global /plans/ namespace.
+// Plans are not scoped to an Account — a PRef is the only link. Records are
+// immutable and undeletable; Create is the only state-mutating op.
 type planStore struct {
-	db        kvdb.KVDB
-	accountID string
+	db kvdb.KVDB
 }
 
-func newPlanStore(db kvdb.KVDB, accountID string) *planStore {
-	return &planStore{db: db, accountID: accountID}
+func newPlanStore(db kvdb.KVDB) *planStore {
+	return &planStore{db: db}
 }
 
 var _ accountsIface.Plans = (*planStore)(nil)
 
-// Create persists a new Plan under the parent Account. Slug must be unique
-// within the Account (cheap O(N) check via List + GetBySlug — plans per
-// account are small).
 func (s *planStore) Create(ctx context.Context, in accountsIface.CreatePlanInput) (*accountsIface.Plan, error) {
-	if err := validatePlanSlug(in.Slug); err != nil {
-		return nil, err
-	}
 	if in.Name == "" {
 		return nil, errors.New("accounts: plan name required")
 	}
-	if in.Mode == "" {
-		in.Mode = accountsIface.PlanModeHybrid
+	displayName := in.DisplayName
+	if displayName == "" {
+		displayName = in.Name
 	}
-	if existing, _ := s.GetBySlug(ctx, in.Slug); existing != nil {
-		return nil, fmt.Errorf("accounts: plan slug %q already in use", in.Slug)
+	p := &accountsIface.Plan{
+		ID:          protocolCommon.GetNewPlanID(in.Name),
+		Name:        in.Name,
+		DisplayName: displayName,
+		Data:        in.Data,
 	}
-
-	now := time.Now().UTC()
-	b := &accountsIface.Plan{
-		ID:         protocolCommon.GetNewPlanID(s.accountID, in.Slug, now.UnixNano()),
-		AccountID:  s.accountID,
-		Slug:       in.Slug,
-		Name:       in.Name,
-		Mode:       in.Mode,
-		Dimensions: in.Dimensions,
-		Period:     in.Period,
-		Status:     accountsIface.PlanStatusActive,
-		CreatedAt:  now,
-	}
-	if err := putKV(ctx, s.db, PlanProfilePath(s.accountID, b.ID), b); err != nil {
+	if err := putKV(ctx, s.db, PlanProfilePath(p.ID), p); err != nil {
 		return nil, err
 	}
-	return b, nil
+	return p, nil
 }
 
-// Get loads a Plan by ID.
 func (s *planStore) Get(ctx context.Context, planID string) (*accountsIface.Plan, error) {
-	var b accountsIface.Plan
-	if err := getKV(ctx, s.db, PlanProfilePath(s.accountID, planID), &b); err != nil {
+	if planID == "" {
+		return nil, errors.New("accounts: plan_id required")
+	}
+	var p accountsIface.Plan
+	if err := getKV(ctx, s.db, PlanProfilePath(planID), &p); err != nil {
 		return nil, err
 	}
-	return &b, nil
+	return &p, nil
 }
 
-// GetBySlug iterates the Account's Plans and returns the one with matching slug.
-//
-// O(N) scan; we don't index slug-per-Account because Plans-per-Account is
-// expected to be small. If that assumption breaks we add a per-Account slug
-// index (parallel to the global account-slug index).
-func (s *planStore) GetBySlug(ctx context.Context, slug string) (*accountsIface.Plan, error) {
-	ids, err := s.List(ctx)
-	if err != nil {
-		return nil, err
-	}
-	for _, id := range ids {
-		b, err := s.Get(ctx, id)
-		if err != nil {
-			if errors.Is(err, ErrNotFound) {
-				continue
-			}
-			return nil, err
-		}
-		if b.Slug == slug {
-			return b, nil
-		}
-	}
-	return nil, ErrNotFound
-}
-
-// List returns the IDs of all Plans in this Account.
 func (s *planStore) List(ctx context.Context) ([]string, error) {
-	return listChildIDs(ctx, s.db, AccountPlansPrefix(s.accountID))
-}
-
-// Update applies a partial update.
-func (s *planStore) Update(ctx context.Context, planID string, in accountsIface.UpdatePlanInput) (*accountsIface.Plan, error) {
-	b, err := s.Get(ctx, planID)
+	keys, err := s.db.List(ctx, PlansPrefix())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("accounts: list plans: %w", err)
 	}
-	if in.Name != nil {
-		b.Name = *in.Name
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		id := k[len(PlansPrefix()):]
+		if id == "" {
+			continue
+		}
+		out = append(out, id)
 	}
-	if in.Mode != nil {
-		b.Mode = *in.Mode
-	}
-	if in.Dimensions != nil {
-		b.Dimensions = in.Dimensions
-	}
-	if in.Period != nil {
-		b.Period = *in.Period
-	}
-	if in.Status != nil {
-		b.Status = *in.Status
-	}
-	if err := putKV(ctx, s.db, PlanProfilePath(s.accountID, planID), b); err != nil {
-		return nil, err
-	}
-	return b, nil
-}
-
-// Delete removes the Plan. Does not cascade-revoke User grants pointing at
-// it — admin should revoke first; orphan grants will surface at compile time
-// (resolve will return "plan not found"). v2 may add cascade.
-func (s *planStore) Delete(ctx context.Context, planID string) error {
-	if err := s.db.Delete(ctx, PlanProfilePath(s.accountID, planID)); err != nil {
-		return fmt.Errorf("accounts: delete plan: %w", err)
-	}
-	return nil
-}
-
-// validatePlanSlug uses the same alphabet as accounts (URL-safe).
-func validatePlanSlug(slug string) error {
-	// Reuse the account validator — same rules apply.
-	if err := validateAccountSlug(slug); err != nil {
-		// Re-wrap so error message reflects plan context.
-		return fmt.Errorf("plan: %w", err)
-	}
-	return nil
+	return out, nil
 }

--- a/services/accounts/pref.go
+++ b/services/accounts/pref.go
@@ -1,0 +1,290 @@
+package accounts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/taubyte/tau/core/kvdb"
+	accountsIface "github.com/taubyte/tau/core/services/accounts"
+)
+
+// prefStore implements accountsIface.PRefs for one Account.
+//
+// Invariants worth highlighting:
+//   - PRef names are varname-shaped, case-sensitive, and immortal (no
+//     Rename, no Delete; Disable is the only off-switch).
+//   - The envelope is written once at Create and mutated only via
+//     SetDisplayName. Status is NOT persisted — derived on Get from the
+//     latest enable/disable event. This is what keeps Disable/Enable from
+//     racing on a shared envelope blob across nodes.
+//   - The "current" plan is the PlanID of the latest `assign` event.
+//   - Assign on a disabled PRef is rejected (admin must Enable first).
+type prefStore struct {
+	db        kvdb.KVDB
+	accountID string
+	plans     *planStore // global; needed to validate Assign targets
+}
+
+func newPRefStore(db kvdb.KVDB, accountID string, plans *planStore) *prefStore {
+	return &prefStore{db: db, accountID: accountID, plans: plans}
+}
+
+var _ accountsIface.PRefs = (*prefStore)(nil)
+
+func (s *prefStore) Create(ctx context.Context, in accountsIface.CreatePRefInput) (*accountsIface.PRef, error) {
+	if err := validatePRefName(in.Name); err != nil {
+		return nil, err
+	}
+	if in.MemberID == "" {
+		return nil, errors.New("accounts: member_id required")
+	}
+	if existing, _ := s.Get(ctx, in.Name); existing != nil {
+		return nil, fmt.Errorf("accounts: pref %q already exists", in.Name)
+	}
+	displayName := in.DisplayName
+	if displayName == "" {
+		displayName = in.Name
+	}
+	pref := &accountsIface.PRef{
+		Name:        in.Name,
+		AccountID:   s.accountID,
+		DisplayName: displayName,
+		CreatedAt:   time.Now().UTC(),
+	}
+	if err := putKV(ctx, s.db, PRefProfilePath(s.accountID, pref.Name), pref); err != nil {
+		return nil, err
+	}
+	pref.Status = accountsIface.PRefStatusActive
+	return pref, nil
+}
+
+func (s *prefStore) Get(ctx context.Context, name string) (*accountsIface.PRef, error) {
+	var pref accountsIface.PRef
+	if err := getKV(ctx, s.db, PRefProfilePath(s.accountID, name), &pref); err != nil {
+		return nil, err
+	}
+	status, err := s.derivedStatus(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	pref.Status = status
+	return &pref, nil
+}
+
+// derivedStatus walks the event log newest-first and returns the status from
+// the most recent disable/enable. Assigns are skipped — they don't affect
+// the active/disabled axis. Default for a PRef with no such events is Active.
+func (s *prefStore) derivedStatus(ctx context.Context, name string) (accountsIface.PRefStatus, error) {
+	keys, err := s.db.List(ctx, PRefEventsPrefix(s.accountID, name))
+	if err != nil {
+		return "", fmt.Errorf("accounts: list pref events for status: %w", err)
+	}
+	var latestKey string
+	for _, k := range keys {
+		if k > latestKey {
+			latestKey = k
+		}
+	}
+	for latestKey != "" {
+		var ev accountsIface.PRefEvent
+		if err := getKV(ctx, s.db, latestKey, &ev); err != nil {
+			if errors.Is(err, ErrNotFound) {
+				break
+			}
+			return "", err
+		}
+		switch ev.Kind {
+		case accountsIface.PRefEventKindDisable:
+			return accountsIface.PRefStatusDisabled, nil
+		case accountsIface.PRefEventKindEnable:
+			return accountsIface.PRefStatusActive, nil
+		}
+		var nextKey string
+		for _, k := range keys {
+			if k < latestKey && k > nextKey {
+				nextKey = k
+			}
+		}
+		latestKey = nextKey
+	}
+	return accountsIface.PRefStatusActive, nil
+}
+
+func (s *prefStore) List(ctx context.Context) ([]string, error) {
+	return listChildIDs(ctx, s.db, AccountPRefsPrefix(s.accountID))
+}
+
+// SetDisplayName mutates only the cosmetic field. Works on disabled PRefs.
+func (s *prefStore) SetDisplayName(ctx context.Context, name, displayName string) (*accountsIface.PRef, error) {
+	pref, err := s.Get(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if displayName == "" {
+		displayName = pref.Name
+	}
+	pref.DisplayName = displayName
+	if err := putKV(ctx, s.db, PRefProfilePath(s.accountID, name), pref); err != nil {
+		return nil, err
+	}
+	return pref, nil
+}
+
+func (s *prefStore) Assign(ctx context.Context, in accountsIface.AssignPRefInput) (*accountsIface.PRefEvent, error) {
+	if in.PlanID == "" {
+		return nil, errors.New("accounts: plan_id required")
+	}
+	pref, err := s.Get(ctx, in.Name)
+	if err != nil {
+		return nil, err
+	}
+	if pref.Status != accountsIface.PRefStatusActive {
+		return nil, fmt.Errorf("accounts: pref %q is disabled; enable before assigning", in.Name)
+	}
+	if _, err := s.plans.Get(ctx, in.PlanID); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			// Plan exists on a peer but hasn't converged here yet — surface
+			// the retry hint instead of a bare "not found".
+			return nil, fmt.Errorf("accounts: plan %q not found (retry if newly created on another node)", in.PlanID)
+		}
+		return nil, err
+	}
+	return s.writeEvent(ctx, in.Name, accountsIface.PRefEvent{
+		Kind:     accountsIface.PRefEventKindAssign,
+		PlanID:   in.PlanID,
+		MemberID: in.MemberID,
+		Note:     in.Note,
+	})
+}
+
+func (s *prefStore) Disable(ctx context.Context, in accountsIface.DisablePRefInput) (*accountsIface.PRefEvent, error) {
+	if _, err := s.Get(ctx, in.Name); err != nil {
+		return nil, err
+	}
+	return s.writeEvent(ctx, in.Name, accountsIface.PRefEvent{
+		Kind:     accountsIface.PRefEventKindDisable,
+		MemberID: in.MemberID,
+		Note:     in.Note,
+	})
+}
+
+func (s *prefStore) Enable(ctx context.Context, in accountsIface.EnablePRefInput) (*accountsIface.PRefEvent, error) {
+	if _, err := s.Get(ctx, in.Name); err != nil {
+		return nil, err
+	}
+	return s.writeEvent(ctx, in.Name, accountsIface.PRefEvent{
+		Kind:     accountsIface.PRefEventKindEnable,
+		MemberID: in.MemberID,
+		Note:     in.Note,
+	})
+}
+
+// Events returns events whose At falls within [from, to] (inclusive), in
+// chronological order. A zero-valued bound disables that side. The sort is
+// explicit because db.List does not guarantee key order.
+func (s *prefStore) Events(ctx context.Context, name string, from, to time.Time) ([]accountsIface.PRefEvent, error) {
+	prefix := PRefEventsPrefix(s.accountID, name)
+	keys, err := s.db.List(ctx, prefix)
+	if err != nil {
+		return nil, fmt.Errorf("accounts: list pref events: %w", err)
+	}
+	out := make([]accountsIface.PRefEvent, 0, len(keys))
+	for _, k := range keys {
+		var ev accountsIface.PRefEvent
+		if err := getKV(ctx, s.db, k, &ev); err != nil {
+			if errors.Is(err, ErrNotFound) {
+				continue
+			}
+			return nil, err
+		}
+		if !from.IsZero() && ev.At.Before(from) {
+			continue
+		}
+		if !to.IsZero() && ev.At.After(to) {
+			continue
+		}
+		out = append(out, ev)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].At.Before(out[j].At) })
+	return out, nil
+}
+
+func (s *prefStore) LatestEvent(ctx context.Context, name string) (*accountsIface.PRefEvent, error) {
+	prefix := PRefEventsPrefix(s.accountID, name)
+	keys, err := s.db.List(ctx, prefix)
+	if err != nil {
+		return nil, fmt.Errorf("accounts: list pref events: %w", err)
+	}
+	if len(keys) == 0 {
+		return nil, ErrNotFound
+	}
+	// Keys are zero-padded by PRefEventPath, so lexical max = chronological max.
+	var maxKey string
+	for _, k := range keys {
+		if k > maxKey {
+			maxKey = k
+		}
+	}
+	var ev accountsIface.PRefEvent
+	if err := getKV(ctx, s.db, maxKey, &ev); err != nil {
+		return nil, err
+	}
+	return &ev, nil
+}
+
+func (s *prefStore) writeEvent(ctx context.Context, name string, ev accountsIface.PRefEvent) (*accountsIface.PRefEvent, error) {
+	if ev.MemberID == "" {
+		return nil, errors.New("accounts: member_id required")
+	}
+	ev.At = time.Now().UTC()
+	key := PRefEventPath(s.accountID, name, ev.At.UnixNano())
+	if err := putKV(ctx, s.db, key, ev); err != nil {
+		return nil, err
+	}
+	return &ev, nil
+}
+
+// validatePRefName enforces varname rules: [a-zA-Z_][a-zA-Z0-9_]*, max 64.
+// Case-sensitive — "Pro" and "pro" are distinct names.
+func validatePRefName(name string) error {
+	if name == "" {
+		return errors.New("accounts: pref name required")
+	}
+	if len(name) > 64 {
+		return errors.New("accounts: pref name too long (>64)")
+	}
+	if !isVarnameStart(rune(name[0])) {
+		return fmt.Errorf("accounts: pref name must start with a letter or underscore (got %q)", string(name[0]))
+	}
+	for _, r := range name[1:] {
+		if !isVarnameRune(r) {
+			return fmt.Errorf("accounts: pref name must be varname (a-zA-Z0-9_); bad char %q", string(r))
+		}
+	}
+	return nil
+}
+
+func isVarnameStart(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z':
+		return true
+	case r >= 'A' && r <= 'Z':
+		return true
+	case r == '_':
+		return true
+	}
+	return false
+}
+
+func isVarnameRune(r rune) bool {
+	if isVarnameStart(r) {
+		return true
+	}
+	if r >= '0' && r <= '9' {
+		return true
+	}
+	return false
+}

--- a/services/accounts/pref_test.go
+++ b/services/accounts/pref_test.go
@@ -1,0 +1,357 @@
+package accounts
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	accountsIface "github.com/taubyte/tau/core/services/accounts"
+)
+
+// Targeted no-tag coverage for pref.go. The store's Enable / SetDisplayName /
+// List / LatestEvent / Events-filtering / validatePRefName edge cases are
+// otherwise exercised only by the dream-tagged integration tests, which
+// don't contribute to this package's no-tag coverage.
+
+func newPRefStoreForTest(t *testing.T, srv *AccountsService, accountSlug string) (string, *prefStore) {
+	t.Helper()
+	acc, err := newAccountStore(srv.db).Create(context.Background(), accountsIface.CreateAccountInput{
+		Slug: accountSlug, Name: accountSlug,
+	})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	return acc.ID, newPRefStore(srv.db, acc.ID, newPlanStore(srv.db))
+}
+
+func TestValidatePRefName_EdgeCases(t *testing.T) {
+	good := []string{"pro", "Pro", "pref_1", "_under", "a", "A1", "x_y_z"}
+	for _, n := range good {
+		if err := validatePRefName(n); err != nil {
+			t.Errorf("name %q should be valid: %v", n, err)
+		}
+	}
+	bad := []string{"", "1leading", "with space", "kebab-name", "tail-", "with!bang", "with.dot",
+		strings.Repeat("a", 65)}
+	for _, n := range bad {
+		if err := validatePRefName(n); err == nil {
+			t.Errorf("name %q should be invalid", n)
+		}
+	}
+}
+
+func TestPRefStore_Create_Errors(t *testing.T) {
+	srv := newTestService(t)
+	_, prefs := newPRefStoreForTest(t, srv, "acme")
+	ctx := context.Background()
+
+	// Missing member_id.
+	if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "pro"}); err == nil {
+		t.Fatalf("expected error for empty member_id")
+	}
+	// Bad name.
+	if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "bad-name", MemberID: "system:t"}); err == nil {
+		t.Fatalf("expected error for invalid name")
+	}
+	// Happy path then duplicate.
+	if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "pro", MemberID: "system:t"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "pro", MemberID: "system:t"}); err == nil {
+		t.Fatalf("expected error for duplicate name")
+	}
+}
+
+func TestPRefStore_List(t *testing.T) {
+	srv := newTestService(t)
+	_, prefs := newPRefStoreForTest(t, srv, "acme")
+	ctx := context.Background()
+	for _, n := range []string{"pro", "free", "enterprise"} {
+		if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: n, MemberID: "system:t"}); err != nil {
+			t.Fatalf("Create %s: %v", n, err)
+		}
+	}
+	names, err := prefs.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(names) != 3 {
+		t.Fatalf("want 3 prefs, got %d (%v)", len(names), names)
+	}
+}
+
+func TestPRefStore_SetDisplayName(t *testing.T) {
+	srv := newTestService(t)
+	_, prefs := newPRefStoreForTest(t, srv, "acme")
+	ctx := context.Background()
+	pref, _ := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "pro", DisplayName: "Pro", MemberID: "system:t"})
+	if pref.DisplayName != "Pro" {
+		t.Fatalf("create DisplayName: %q", pref.DisplayName)
+	}
+
+	upd, err := prefs.SetDisplayName(ctx, "pro", "Production")
+	if err != nil {
+		t.Fatalf("SetDisplayName: %v", err)
+	}
+	if upd.DisplayName != "Production" {
+		t.Fatalf("update DisplayName: %q", upd.DisplayName)
+	}
+
+	// Empty falls back to Name.
+	upd, err = prefs.SetDisplayName(ctx, "pro", "")
+	if err != nil {
+		t.Fatalf("SetDisplayName empty: %v", err)
+	}
+	if upd.DisplayName != "pro" {
+		t.Fatalf("empty DisplayName should default to Name; got %q", upd.DisplayName)
+	}
+
+	// Works on disabled PRef too — pure cosmetic, no status check.
+	if _, err := prefs.Disable(ctx, accountsIface.DisablePRefInput{Name: "pro", MemberID: "system:t"}); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	upd, err = prefs.SetDisplayName(ctx, "pro", "Pro (legacy)")
+	if err != nil {
+		t.Fatalf("SetDisplayName on disabled: %v", err)
+	}
+	if upd.DisplayName != "Pro (legacy)" {
+		t.Fatalf("display name not updated on disabled pref")
+	}
+	if upd.Status != accountsIface.PRefStatusDisabled {
+		t.Fatalf("Status should still be disabled after cosmetic update; got %s", upd.Status)
+	}
+
+	// Missing PRef.
+	if _, err := prefs.SetDisplayName(ctx, "ghost", "Whatever"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for missing pref; got %v", err)
+	}
+}
+
+func TestPRefStore_EnableDisableRoundTrip(t *testing.T) {
+	srv := newTestService(t)
+	plans := newPlanStore(srv.db)
+	plan, _ := plans.Create(context.Background(), accountsIface.CreatePlanInput{Name: "P"})
+
+	_, prefs := newPRefStoreForTest(t, srv, "acme")
+	ctx := context.Background()
+	if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "pro", MemberID: "system:t"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Assign before disable: succeeds.
+	if _, err := prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: "pro", PlanID: plan.ID, MemberID: "system:t"}); err != nil {
+		t.Fatalf("Assign: %v", err)
+	}
+
+	// Disable.
+	if _, err := prefs.Disable(ctx, accountsIface.DisablePRefInput{Name: "pro", MemberID: "system:t"}); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	g, _ := prefs.Get(ctx, "pro")
+	if g.Status != accountsIface.PRefStatusDisabled {
+		t.Fatalf("status after Disable: %s", g.Status)
+	}
+
+	// Assign on disabled is rejected.
+	if _, err := prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: "pro", PlanID: plan.ID, MemberID: "system:t"}); err == nil {
+		t.Fatalf("expected Assign-on-disabled to be rejected")
+	}
+
+	// Enable.
+	if _, err := prefs.Enable(ctx, accountsIface.EnablePRefInput{Name: "pro", MemberID: "system:t"}); err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+	g, _ = prefs.Get(ctx, "pro")
+	if g.Status != accountsIface.PRefStatusActive {
+		t.Fatalf("status after Enable: %s", g.Status)
+	}
+
+	// Disable on missing PRef → error.
+	if _, err := prefs.Disable(ctx, accountsIface.DisablePRefInput{Name: "ghost", MemberID: "system:t"}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for Disable on missing pref; got %v", err)
+	}
+	if _, err := prefs.Enable(ctx, accountsIface.EnablePRefInput{Name: "ghost", MemberID: "system:t"}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for Enable on missing pref; got %v", err)
+	}
+}
+
+func TestPRefStore_Assign_Errors(t *testing.T) {
+	srv := newTestService(t)
+	_, prefs := newPRefStoreForTest(t, srv, "acme")
+	ctx := context.Background()
+	if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "pro", MemberID: "system:t"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Missing plan_id.
+	if _, err := prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: "pro", MemberID: "system:t"}); err == nil {
+		t.Fatalf("expected error for empty plan_id")
+	}
+	// Plan doesn't exist locally → retryable error with hint.
+	_, err := prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: "pro", PlanID: "ghost-plan-id", MemberID: "system:t"})
+	if err == nil {
+		t.Fatalf("expected error for unknown plan_id")
+	}
+	if !strings.Contains(err.Error(), "retry") {
+		t.Fatalf("error should mention retry hint; got %v", err)
+	}
+	// Missing PRef.
+	if _, err := prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: "ghost", PlanID: "x", MemberID: "system:t"}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for missing pref; got %v", err)
+	}
+}
+
+func TestPRefStore_Events_Filtering(t *testing.T) {
+	srv := newTestService(t)
+	plans := newPlanStore(srv.db)
+	plan, _ := plans.Create(context.Background(), accountsIface.CreatePlanInput{Name: "P"})
+	_, prefs := newPRefStoreForTest(t, srv, "acme")
+	ctx := context.Background()
+	if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "pro", MemberID: "system:t"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Three events spaced ≥1s apart so the cbor time encoding's sub-second
+	// truncation can't collapse them onto the same stored timestamp.
+	if _, err := prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: "pro", PlanID: plan.ID, MemberID: "system:t"}); err != nil {
+		t.Fatalf("Assign: %v", err)
+	}
+	time.Sleep(1100 * time.Millisecond)
+	if _, err := prefs.Disable(ctx, accountsIface.DisablePRefInput{Name: "pro", MemberID: "system:t"}); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	time.Sleep(1100 * time.Millisecond)
+	if _, err := prefs.Enable(ctx, accountsIface.EnablePRefInput{Name: "pro", MemberID: "system:t"}); err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+
+	// Unbounded scan → all three. Use the stored At values (post-roundtrip)
+	// as reference points so the filter bounds match what the store sees.
+	all, err := prefs.Events(ctx, "pro", time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("Events all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("want 3 events, got %d", len(all))
+	}
+	tAssign, tDisable, tEnable := all[0].At, all[1].At, all[2].At
+	if tAssign.Equal(tDisable) || tDisable.Equal(tEnable) {
+		t.Fatalf("events not distinguishable post-roundtrip: %v %v %v", tAssign, tDisable, tEnable)
+	}
+
+	// from bound — exclude assign.
+	mids, err := prefs.Events(ctx, "pro", tDisable, time.Time{})
+	if err != nil {
+		t.Fatalf("Events from-bounded: %v", err)
+	}
+	if len(mids) != 2 {
+		t.Fatalf("from-bounded scan want 2, got %d", len(mids))
+	}
+
+	// to bound — exclude enable.
+	cuts, err := prefs.Events(ctx, "pro", time.Time{}, tDisable)
+	if err != nil {
+		t.Fatalf("Events to-bounded: %v", err)
+	}
+	if len(cuts) != 2 {
+		t.Fatalf("to-bounded scan want 2, got %d", len(cuts))
+	}
+
+	// Narrow window — only the disable event.
+	narrows, err := prefs.Events(ctx, "pro", tDisable, tDisable)
+	if err != nil {
+		t.Fatalf("Events narrow: %v", err)
+	}
+	if len(narrows) != 1 {
+		t.Fatalf("narrow window want 1, got %d", len(narrows))
+	}
+	if narrows[0].Kind != accountsIface.PRefEventKindDisable {
+		t.Fatalf("narrow window kind = %s, want disable", narrows[0].Kind)
+	}
+}
+
+func TestPRefStore_LatestEvent(t *testing.T) {
+	srv := newTestService(t)
+	plans := newPlanStore(srv.db)
+	plan, _ := plans.Create(context.Background(), accountsIface.CreatePlanInput{Name: "P"})
+	_, prefs := newPRefStoreForTest(t, srv, "acme")
+	ctx := context.Background()
+	if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "pro", MemberID: "system:t"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// No events yet → ErrNotFound.
+	if _, err := prefs.LatestEvent(ctx, "pro"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("empty log should be ErrNotFound; got %v", err)
+	}
+
+	_, _ = prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: "pro", PlanID: plan.ID, MemberID: "system:t"})
+	time.Sleep(2 * time.Millisecond)
+	_, _ = prefs.Disable(ctx, accountsIface.DisablePRefInput{Name: "pro", MemberID: "system:t"})
+
+	latest, err := prefs.LatestEvent(ctx, "pro")
+	if err != nil {
+		t.Fatalf("LatestEvent: %v", err)
+	}
+	if latest.Kind != accountsIface.PRefEventKindDisable {
+		t.Fatalf("latest kind = %s, want disable", latest.Kind)
+	}
+}
+
+// derivedStatus's walk-back loop: latest event is an assign; the function
+// must skip past assigns to find the most recent enable/disable.
+func TestPRefStore_DerivedStatus_WalksPastAssigns(t *testing.T) {
+	srv := newTestService(t)
+	plans := newPlanStore(srv.db)
+	plan, _ := plans.Create(context.Background(), accountsIface.CreatePlanInput{Name: "P"})
+	plan2, _ := plans.Create(context.Background(), accountsIface.CreatePlanInput{Name: "P2"})
+	_, prefs := newPRefStoreForTest(t, srv, "acme")
+	ctx := context.Background()
+	if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "pro", MemberID: "system:t"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Sequence: Disable → Enable → Assign → Assign → Get
+	// Latest event is the second assign; derivedStatus must skip both
+	// assigns and report Active (latest enable wins).
+	_, _ = prefs.Disable(ctx, accountsIface.DisablePRefInput{Name: "pro", MemberID: "system:t"})
+	time.Sleep(time.Millisecond)
+	_, _ = prefs.Enable(ctx, accountsIface.EnablePRefInput{Name: "pro", MemberID: "system:t"})
+	time.Sleep(time.Millisecond)
+	_, _ = prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: "pro", PlanID: plan.ID, MemberID: "system:t"})
+	time.Sleep(time.Millisecond)
+	_, _ = prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: "pro", PlanID: plan2.ID, MemberID: "system:t"})
+
+	got, err := prefs.Get(ctx, "pro")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != accountsIface.PRefStatusActive {
+		t.Fatalf("status with assigns-after-enable should be active; got %s", got.Status)
+	}
+
+	// Sequence ending in Disable → Get returns Disabled.
+	_, _ = prefs.Disable(ctx, accountsIface.DisablePRefInput{Name: "pro", MemberID: "system:t"})
+	got, err = prefs.Get(ctx, "pro")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != accountsIface.PRefStatusDisabled {
+		t.Fatalf("status after Disable should be disabled; got %s", got.Status)
+	}
+}
+
+func TestPRefStore_WriteEvent_RequiresMemberID(t *testing.T) {
+	srv := newTestService(t)
+	_, prefs := newPRefStoreForTest(t, srv, "acme")
+	ctx := context.Background()
+	if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "pro", MemberID: "system:t"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Disable with empty MemberID → writeEvent rejects.
+	if _, err := prefs.Disable(ctx, accountsIface.DisablePRefInput{Name: "pro", MemberID: ""}); err == nil {
+		t.Fatalf("expected error for empty member_id on Disable")
+	}
+}

--- a/services/accounts/store_test.go
+++ b/services/accounts/store_test.go
@@ -108,14 +108,15 @@ func TestAccountStore_SlugValidation(t *testing.T) {
 	store := newAccountStore(srv.db)
 	ctx := context.Background()
 
-	bad := []string{"", "Acme", "with space", "x!", "-leading", "trailing-", "thisslugiswaytoolongforthelimitsetbythevalidatorwhichmaxesoutatsixtyfourchars-"}
+	bad := []string{"", "with space", "x!", "1leading", "trailing-", "kebab-case", "thisslugiswaytoolongforthelimitsetbythevalidatorwhichmaxesoutatsixtyfourchars_"}
 	for _, slug := range bad {
 		if _, err := store.Create(ctx, accountsIface.CreateAccountInput{Slug: slug, Name: "x"}); err == nil {
 			t.Errorf("slug %q should have failed validation", slug)
 		}
 	}
 
-	ok := []string{"acme", "acme-corp", "acme_dev", "team-1"}
+	// Varname rules are case-sensitive: Acme and acme are distinct slugs.
+	ok := []string{"acme", "Acme", "acme_dev", "team_1", "_under"}
 	for _, slug := range ok {
 		if _, err := store.Create(ctx, accountsIface.CreateAccountInput{Slug: slug, Name: "x"}); err != nil {
 			t.Errorf("slug %q should be valid: %v", slug, err)
@@ -127,29 +128,25 @@ func TestPlanStore_CRUD(t *testing.T) {
 	srv := newTestService(t)
 	ctx := context.Background()
 
-	accStore := newAccountStore(srv.db)
-	acc, err := accStore.Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
-	if err != nil {
-		t.Fatalf("Create account: %v", err)
-	}
-	bs := newPlanStore(srv.db, acc.ID)
+	bs := newPlanStore(srv.db)
 
 	plan, err := bs.Create(ctx, accountsIface.CreatePlanInput{
-		Slug: "prod",
 		Name: "Production",
-		Mode: accountsIface.PlanModeQuota,
 	})
 	if err != nil {
 		t.Fatalf("Create plan: %v", err)
 	}
-	if plan.AccountID != acc.ID {
-		t.Fatalf("plan account_id mismatch")
+	if plan.Name != "Production" {
+		t.Fatalf("plan name mismatch: %+v", plan)
+	}
+	if plan.DisplayName != "Production" {
+		t.Fatalf("DisplayName should default to Name; got %q", plan.DisplayName)
 	}
 
-	// GetBySlug.
-	bySlug, err := bs.GetBySlug(ctx, "prod")
-	if err != nil || bySlug.ID != plan.ID {
-		t.Fatalf("GetBySlug: %v %+v", err, bySlug)
+	// Get.
+	got, err := bs.Get(ctx, plan.ID)
+	if err != nil || got.ID != plan.ID {
+		t.Fatalf("Get: %v %+v", err, got)
 	}
 
 	// List.
@@ -158,17 +155,7 @@ func TestPlanStore_CRUD(t *testing.T) {
 		t.Fatalf("List: %v %+v", err, ids)
 	}
 
-	// Update + Delete.
-	suspended := accountsIface.PlanStatusSuspended
-	if _, err := bs.Update(ctx, plan.ID, accountsIface.UpdatePlanInput{Status: &suspended}); err != nil {
-		t.Fatalf("Update: %v", err)
-	}
-	if err := bs.Delete(ctx, plan.ID); err != nil {
-		t.Fatalf("Delete: %v", err)
-	}
-	if _, err := bs.Get(ctx, plan.ID); !errors.Is(err, ErrNotFound) {
-		t.Fatalf("Get after delete: %v", err)
-	}
+	// Plans are immutable and undeletable — no Update, no Delete.
 }
 
 func TestUserStore_GrantsAndDefault(t *testing.T) {
@@ -177,9 +164,20 @@ func TestUserStore_GrantsAndDefault(t *testing.T) {
 
 	accStore := newAccountStore(srv.db)
 	acc, _ := accStore.Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
-	bs := newPlanStore(srv.db, acc.ID)
-	prod, _ := bs.Create(ctx, accountsIface.CreatePlanInput{Slug: "prod", Name: "Prod"})
-	stg, _ := bs.Create(ctx, accountsIface.CreatePlanInput{Slug: "staging", Name: "Staging"})
+
+	// Two PRefs. Grants are PRef-name-keyed; the plan they point at is
+	// irrelevant for the grant default semantics this test exercises.
+	plans := newPlanStore(srv.db)
+	plan, _ := plans.Create(ctx, accountsIface.CreatePlanInput{Name: "Prod"})
+	prefs := newPRefStore(srv.db, acc.ID, plans)
+	for _, name := range []string{"prod", "staging"} {
+		if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: name, MemberID: "system:test"}); err != nil {
+			t.Fatalf("Create pref %s: %v", name, err)
+		}
+		if _, err := prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: name, PlanID: plan.ID, MemberID: "system:test"}); err != nil {
+			t.Fatalf("Assign pref %s: %v", name, err)
+		}
+	}
 
 	us := newUserStore(srv.db, acc.ID)
 	user, err := us.Add(ctx, accountsIface.AddUserInput{
@@ -192,7 +190,7 @@ func TestUserStore_GrantsAndDefault(t *testing.T) {
 	}
 
 	// First grant becomes default automatically.
-	if err := us.Grant(ctx, user.ID, accountsIface.GrantPlanInput{PlanID: prod.ID}); err != nil {
+	if err := us.Grant(ctx, user.ID, accountsIface.GrantPRefInput{PRefName: "prod"}); err != nil {
 		t.Fatalf("Grant prod: %v", err)
 	}
 	got, _ := us.Get(ctx, user.ID)
@@ -201,7 +199,7 @@ func TestUserStore_GrantsAndDefault(t *testing.T) {
 	}
 
 	// Second grant non-default.
-	if err := us.Grant(ctx, user.ID, accountsIface.GrantPlanInput{PlanID: stg.ID}); err != nil {
+	if err := us.Grant(ctx, user.ID, accountsIface.GrantPRefInput{PRefName: "staging"}); err != nil {
 		t.Fatalf("Grant staging: %v", err)
 	}
 	got, _ = us.Get(ctx, user.ID)
@@ -216,21 +214,21 @@ func TestUserStore_GrantsAndDefault(t *testing.T) {
 	}
 
 	// Promote staging to default → prod is demoted.
-	if err := us.Grant(ctx, user.ID, accountsIface.GrantPlanInput{PlanID: stg.ID, IsDefault: true}); err != nil {
+	if err := us.Grant(ctx, user.ID, accountsIface.GrantPRefInput{PRefName: "staging", IsDefault: true}); err != nil {
 		t.Fatalf("Promote staging: %v", err)
 	}
 	got, _ = us.Get(ctx, user.ID)
 	for _, g := range got.PlanGrants {
-		if g.PlanID == prod.ID && g.IsDefault {
+		if g.PRefName == "prod" && g.IsDefault {
 			t.Fatalf("prod should be demoted")
 		}
-		if g.PlanID == stg.ID && !g.IsDefault {
+		if g.PRefName == "staging" && !g.IsDefault {
 			t.Fatalf("staging should be default")
 		}
 	}
 
 	// Revoke default → other grant promotes.
-	if err := us.Revoke(ctx, user.ID, stg.ID); err != nil {
+	if err := us.Revoke(ctx, user.ID, "staging"); err != nil {
 		t.Fatalf("Revoke: %v", err)
 	}
 	got, _ = us.Get(ctx, user.ID)
@@ -272,19 +270,10 @@ func TestVerifyAndResolve(t *testing.T) {
 		t.Fatalf("Verify unknown: %v %+v", err, r)
 	}
 
-	// 2) Set up: Account + Plan + User + Grant.
-	accStore := newAccountStore(srv.db)
-	acc, _ := accStore.Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
-	bs := newPlanStore(srv.db, acc.ID)
-	prod, _ := bs.Create(ctx, accountsIface.CreatePlanInput{Slug: "prod", Name: "Prod"})
-	us := newUserStore(srv.db, acc.ID)
-	user, _ := us.Add(ctx, accountsIface.AddUserInput{Provider: "github", ExternalID: "42", DisplayName: "alice"})
-	_ = user
-	if err := us.Grant(ctx, user.ID, accountsIface.GrantPlanInput{PlanID: prod.ID}); err != nil {
-		t.Fatalf("Grant: %v", err)
-	}
+	// 2) Set up: Account + Plan + PRef (assigned) + User + Grant.
+	seedAccountUserPRef(t, srv, "acme", "prod", "github", "42")
 
-	// 3) Verify → linked, with one Account and one Plan.
+	// 3) Verify → linked, with one Account and one PRef.
 	r, err = cli.Verify(ctx, "github", "42")
 	if err != nil || !r.Linked {
 		t.Fatalf("Verify linked: %v %+v", err, r)
@@ -292,53 +281,60 @@ func TestVerifyAndResolve(t *testing.T) {
 	if len(r.Accounts) != 1 || r.Accounts[0].Slug != "acme" {
 		t.Fatalf("expected one Account 'acme', got %+v", r.Accounts)
 	}
-	if len(r.Accounts[0].Plans) != 1 || r.Accounts[0].Plans[0].Slug != "prod" {
-		t.Fatalf("expected one plan 'prod', got %+v", r.Accounts[0].Plans)
+	if len(r.Accounts[0].PRefs) != 1 || r.Accounts[0].PRefs[0].Name != "prod" {
+		t.Fatalf("expected one pref 'prod', got %+v", r.Accounts[0].PRefs)
 	}
-	if !r.Accounts[0].Plans[0].IsDefault {
+	if !r.Accounts[0].PRefs[0].IsDefault {
 		t.Fatalf("expected prod to be default grant")
 	}
 
-	// 4) ResolvePlan → valid for known grant.
-	res, err := cli.ResolvePlan(ctx, "acme", "prod", "github", "42")
+	// 4) ResolvePRef → valid for known grant.
+	res, err := cli.ResolvePRef(ctx, "acme", "prod", "github", "42")
 	if err != nil || !res.Valid {
-		t.Fatalf("ResolvePlan valid: %v %+v", err, res)
+		t.Fatalf("ResolvePRef valid: %v %+v", err, res)
 	}
 
-	// 5) ResolvePlan → invalid for unknown plan.
-	res, _ = cli.ResolvePlan(ctx, "acme", "nope", "github", "42")
+	// 5) ResolvePRef → invalid for unknown pref.
+	res, _ = cli.ResolvePRef(ctx, "acme", "nope", "github", "42")
 	if res.Valid {
-		t.Fatalf("ResolvePlan nope: should be invalid")
+		t.Fatalf("ResolvePRef nope: should be invalid")
 	}
-	if res.Reason != "plan not found" {
-		t.Fatalf("ResolvePlan nope: bad reason %q", res.Reason)
+	if res.Reason != "pref not found" {
+		t.Fatalf("ResolvePRef nope: bad reason %q", res.Reason)
 	}
 
-	// 6) ResolvePlan → invalid when User has no grant on the plan.
-	other, _ := bs.Create(ctx, accountsIface.CreatePlanInput{Slug: "staging", Name: "Stg"})
-	_ = other
-	res, _ = cli.ResolvePlan(ctx, "acme", "staging", "github", "42")
-	if res.Valid {
-		t.Fatalf("ResolvePlan without grant: should be invalid")
+	// 6) ResolvePRef → invalid when User has no grant on the pref.
+	// Create a second PRef with the same plan; user has no grant on it.
+	acc, _ := newAccountStore(srv.db).GetBySlug(ctx, "acme")
+	plan, _ := newPlanStore(srv.db).Create(ctx, accountsIface.CreatePlanInput{Name: "Staging"})
+	prefs := newPRefStore(srv.db, acc.ID, newPlanStore(srv.db))
+	if _, err := prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "staging", MemberID: "system:test"}); err != nil {
+		t.Fatalf("Create staging pref: %v", err)
 	}
-	if res.Reason != "git user has no grant on plan" {
+	if _, err := prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: "staging", PlanID: plan.ID, MemberID: "system:test"}); err != nil {
+		t.Fatalf("Assign staging pref: %v", err)
+	}
+	res, _ = cli.ResolvePRef(ctx, "acme", "staging", "github", "42")
+	if res.Valid {
+		t.Fatalf("ResolvePRef without grant: should be invalid")
+	}
+	if res.Reason != "git user has no grant on pref" {
 		t.Fatalf("bad reason %q", res.Reason)
 	}
 
-	// 7) ResolvePlan → invalid when account doesn't exist.
-	res, _ = cli.ResolvePlan(ctx, "ghost", "prod", "github", "42")
+	// 7) ResolvePRef → invalid when account doesn't exist.
+	res, _ = cli.ResolvePRef(ctx, "ghost", "prod", "github", "42")
 	if res.Valid || res.Reason != "account not found" {
-		t.Fatalf("ResolvePlan ghost: %+v", res)
+		t.Fatalf("ResolvePRef ghost: %+v", res)
 	}
 
-	// 8) ResolvePlan → invalid for suspended plan.
-	suspended := accountsIface.PlanStatusSuspended
-	if _, err := bs.Update(ctx, prod.ID, accountsIface.UpdatePlanInput{Status: &suspended}); err != nil {
-		t.Fatalf("suspend: %v", err)
+	// 8) ResolvePRef → invalid for disabled pref.
+	if _, err := prefs.Disable(ctx, accountsIface.DisablePRefInput{Name: "prod", MemberID: "system:test"}); err != nil {
+		t.Fatalf("disable: %v", err)
 	}
-	res, _ = cli.ResolvePlan(ctx, "acme", "prod", "github", "42")
-	if res.Valid || res.Reason != "plan suspended" {
-		t.Fatalf("ResolvePlan suspended: %+v", res)
+	res, _ = cli.ResolvePRef(ctx, "acme", "prod", "github", "42")
+	if res.Valid || res.Reason != "pref disabled" {
+		t.Fatalf("ResolvePRef disabled: %+v", res)
 	}
 }
 
@@ -362,9 +358,9 @@ func TestMemberStore_InviteAndIndex(t *testing.T) {
 	}
 
 	// Lookup index has the entry.
-	idx, err := ms.readMemberIndex(ctx, LookupEmailPath("alice@example.com"))
+	idx, err := readMemberIndexByPrefix(ctx, srv.db, LookupEmailPrefix("alice@example.com"))
 	if err != nil {
-		t.Fatalf("readMemberIndex: %v", err)
+		t.Fatalf("read email index: %v", err)
 	}
 	if len(idx) != 1 || idx[0].MemberID != m.ID {
 		t.Fatalf("index entry: %+v", idx)
@@ -374,7 +370,8 @@ func TestMemberStore_InviteAndIndex(t *testing.T) {
 	if err := ms.Remove(ctx, m.ID); err != nil {
 		t.Fatalf("Remove: %v", err)
 	}
-	if _, err := ms.readMemberIndex(ctx, LookupEmailPath("alice@example.com")); !errors.Is(err, ErrNotFound) {
-		t.Fatalf("index after Remove: %v", err)
+	idx, err = readMemberIndexByPrefix(ctx, srv.db, LookupEmailPrefix("alice@example.com"))
+	if err != nil || len(idx) != 0 {
+		t.Fatalf("index after Remove: idx=%+v err=%v", idx, err)
 	}
 }

--- a/services/accounts/stream.go
+++ b/services/accounts/stream.go
@@ -9,10 +9,12 @@ package accounts
 func (srv *AccountsService) setupStreamRoutes() {
 	srv.stream.Define(StreamVerbVerify, srv.apiVerifyHandler)
 	srv.stream.Define(StreamVerbResolve, srv.apiResolveHandler)
+	srv.stream.Define(StreamVerbLookupAccountsByEmail, srv.apiLookupAccountsByEmailHandler)
 
 	srv.stream.Define(StreamVerbAccount, srv.apiAccountHandler)
 	srv.stream.Define(StreamVerbMember, srv.apiMemberHandler)
 	srv.stream.Define(StreamVerbUser, srv.apiUserHandler)
 	srv.stream.Define(StreamVerbPlan, srv.apiPlanHandler)
+	srv.stream.Define(StreamVerbPRef, srv.apiPRefHandler)
 	srv.stream.Define(StreamVerbLogin, srv.apiLoginHandler)
 }

--- a/services/accounts/test_helpers_dreaming.go
+++ b/services/accounts/test_helpers_dreaming.go
@@ -8,34 +8,23 @@ import (
 	"github.com/taubyte/tau/services/accounts/email"
 )
 
-// Test-only helpers compiled in only under `-tags=dreaming`. They expose
-// internals (session issuance, captured email sender) so the dream-mode
-// integration tests in services/accounts/tests/ can exercise the full
-// HTTP / wire stack without forcing the magic-link side-channel.
-//
-// These intentionally live here (not in *_test.go) so packages outside
-// services/accounts can import them when running under -tags=dreaming.
+// Test-only helpers exposed to packages outside services/accounts under
+// -tags=dreaming. Living here (not in *_test.go) lets the dream integration
+// tests in services/accounts/tests/ import them.
 
-// IssueTestSession mints a Member-session bearer for the given (account,
-// member) without going through magic-link or passkey. The bearer verifies
-// as long as the per-Account signing key is reachable.
+// IssueTestSession bypasses magic-link/passkey to mint a Member-session
+// bearer directly. Verifies as long as the per-Account signing key is reachable.
 func (srv *AccountsService) IssueTestSession(ctx context.Context, accountID, memberID string) (string, error) {
 	if srv.sessions == nil {
-		// In dream tests the auth subsystems are wired by service.New, so
-		// this branch only fires if the caller constructed an AccountsService
-		// without going through New. Guarded for safety.
+		// service.New normally wires sessions; this guards callers that
+		// constructed AccountsService without going through New.
 		srv.sessions = newSessionStore(srv.db, parseSessionTTL(""))
 	}
 	_, bearer, err := srv.sessions.Issue(ctx, accountID, memberID)
 	return bearer, err
 }
 
-// SwapEmailSender installs a captured sender on the running service so dream
-// tests can read what the magic-link flow emails out. Returns the sender
-// previously in use (typically a stdout sender) so tests can restore it.
-//
-// The returned StdoutSender's Sent() slice grows with every outbound email
-// — tests use that to extract the magic-link code from a real round-trip.
+// SwapEmailSender returns the previous sender so tests can restore it.
 func (srv *AccountsService) SwapEmailSender(captured email.Sender) email.Sender {
 	if srv.magicLink == nil {
 		return nil
@@ -45,12 +34,8 @@ func (srv *AccountsService) SwapEmailSender(captured email.Sender) email.Sender 
 	return prev
 }
 
-// IssueTestSessionForMember is a convenience that mints a session for an
-// already-created Member identified by primary email. Returns the bearer
-// and the resolved (account_id, member_id).
 func (srv *AccountsService) IssueTestSessionForMember(ctx context.Context, primaryEmail string) (bearer, accountID, memberID string, err error) {
-	tmp := &memberStore{db: srv.db}
-	idx, err := tmp.readMemberIndex(ctx, LookupEmailPath(primaryEmail))
+	idx, err := readMemberIndexByPrefix(ctx, srv.db, LookupEmailPrefix(primaryEmail))
 	if err != nil {
 		return "", "", "", err
 	}

--- a/services/accounts/tests/auth_integration_test.go
+++ b/services/accounts/tests/auth_integration_test.go
@@ -56,11 +56,16 @@ func TestAuth_VerifiesAgainstAccounts_Dreaming(t *testing.T) {
 	cli := svc.Client()
 	acc, err := cli.Accounts().Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
 	assert.NilError(t, err)
-	plan, err := cli.Plans(acc.ID).Create(ctx, accountsIface.CreatePlanInput{Slug: "prod", Name: "Prod"})
+	plan, err := cli.Plans().Create(ctx, accountsIface.CreatePlanInput{Name: "Prod"})
+	assert.NilError(t, err)
+	prefs := cli.PRefs(acc.ID)
+	_, err = prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "prod", MemberID: "system:test"})
+	assert.NilError(t, err)
+	_, err = prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: "prod", PlanID: plan.ID, MemberID: "system:test"})
 	assert.NilError(t, err)
 	user, err := cli.Users(acc.ID).Add(ctx, accountsIface.AddUserInput{Provider: "github", ExternalID: "42"})
 	assert.NilError(t, err)
-	assert.NilError(t, cli.Users(acc.ID).Grant(ctx, user.ID, accountsIface.GrantPlanInput{PlanID: plan.ID}))
+	assert.NilError(t, cli.Users(acc.ID).Grant(ctx, user.ID, accountsIface.GrantPRefInput{PRefName: "prod"}))
 
 	// Sanity: the wire path used by services/auth (P2P accounts client →
 	// stream verb → in-process Verify) round-trips the same shape.

--- a/services/accounts/tests/dreaming_test.go
+++ b/services/accounts/tests/dreaming_test.go
@@ -61,12 +61,15 @@ func TestAccounts_Dreaming(t *testing.T) {
 		assert.Equal(t, acc.AuthMode, accountsIface.AuthModeManaged)
 		assert.Equal(t, acc.Status, accountsIface.AccountStatusActive)
 
-		bs := cli.Plans(acc.ID)
-		plan, err := bs.Create(ctx, accountsIface.CreatePlanInput{
-			Slug: "prod",
+		plan, err := cli.Plans().Create(ctx, accountsIface.CreatePlanInput{
 			Name: "Production",
-			Mode: accountsIface.PlanModeQuota,
 		})
+		assert.NilError(t, err)
+
+		prefs := cli.PRefs(acc.ID)
+		_, err = prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "prod", MemberID: "system:test"})
+		assert.NilError(t, err)
+		_, err = prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: "prod", PlanID: plan.ID, MemberID: "system:test"})
 		assert.NilError(t, err)
 
 		us := cli.Users(acc.ID)
@@ -77,18 +80,18 @@ func TestAccounts_Dreaming(t *testing.T) {
 		})
 		assert.NilError(t, err)
 
-		assert.NilError(t, us.Grant(ctx, user.ID, accountsIface.GrantPlanInput{PlanID: plan.ID}))
+		assert.NilError(t, us.Grant(ctx, user.ID, accountsIface.GrantPRefInput{PRefName: "prod"}))
 	})
 
-	t.Run("Verify returns linked account + plan", func(t *testing.T) {
+	t.Run("Verify returns linked account + pref", func(t *testing.T) {
 		resp, err := cli.Verify(ctx, "github", "42")
 		assert.NilError(t, err)
 		assert.Equal(t, resp.Linked, true)
 		assert.Equal(t, len(resp.Accounts), 1)
 		assert.Equal(t, resp.Accounts[0].Slug, "acme")
-		assert.Equal(t, len(resp.Accounts[0].Plans), 1)
-		assert.Equal(t, resp.Accounts[0].Plans[0].Slug, "prod")
-		assert.Equal(t, resp.Accounts[0].Plans[0].IsDefault, true)
+		assert.Equal(t, len(resp.Accounts[0].PRefs), 1)
+		assert.Equal(t, resp.Accounts[0].PRefs[0].Name, "prod")
+		assert.Equal(t, resp.Accounts[0].PRefs[0].IsDefault, true)
 	})
 
 	t.Run("Verify returns not-linked for unknown user", func(t *testing.T) {
@@ -97,21 +100,21 @@ func TestAccounts_Dreaming(t *testing.T) {
 		assert.Equal(t, resp.Linked, false)
 	})
 
-	t.Run("ResolvePlan happy path", func(t *testing.T) {
-		resp, err := cli.ResolvePlan(ctx, "acme", "prod", "github", "42")
+	t.Run("ResolvePRef happy path", func(t *testing.T) {
+		resp, err := cli.ResolvePRef(ctx, "acme", "prod", "github", "42")
 		assert.NilError(t, err)
 		assert.Equal(t, resp.Valid, true)
 	})
 
-	t.Run("ResolvePlan rejects unknown plan", func(t *testing.T) {
-		resp, err := cli.ResolvePlan(ctx, "acme", "doesnotexist", "github", "42")
+	t.Run("ResolvePRef rejects unknown pref", func(t *testing.T) {
+		resp, err := cli.ResolvePRef(ctx, "acme", "doesnotexist", "github", "42")
 		assert.NilError(t, err)
 		assert.Equal(t, resp.Valid, false)
-		assert.Equal(t, resp.Reason, "plan not found")
+		assert.Equal(t, resp.Reason, "pref not found")
 	})
 
-	t.Run("ResolvePlan rejects unknown account", func(t *testing.T) {
-		resp, err := cli.ResolvePlan(ctx, "ghost", "prod", "github", "42")
+	t.Run("ResolvePRef rejects unknown account", func(t *testing.T) {
+		resp, err := cli.ResolvePRef(ctx, "ghost", "prod", "github", "42")
 		assert.NilError(t, err)
 		assert.Equal(t, resp.Valid, false)
 		assert.Equal(t, resp.Reason, "account not found")
@@ -225,11 +228,16 @@ func TestAccounts_DreamingWire(t *testing.T) {
 
 	acc, err := srvCli.Accounts().Create(ctx, accountsIface.CreateAccountInput{Slug: "acme", Name: "Acme"})
 	assert.NilError(t, err)
-	plan, err := srvCli.Plans(acc.ID).Create(ctx, accountsIface.CreatePlanInput{Slug: "prod", Name: "Prod"})
+	plan, err := srvCli.Plans().Create(ctx, accountsIface.CreatePlanInput{Name: "Prod"})
+	assert.NilError(t, err)
+	prefs := srvCli.PRefs(acc.ID)
+	_, err = prefs.Create(ctx, accountsIface.CreatePRefInput{Name: "prod", MemberID: "system:test"})
+	assert.NilError(t, err)
+	_, err = prefs.Assign(ctx, accountsIface.AssignPRefInput{Name: "prod", PlanID: plan.ID, MemberID: "system:test"})
 	assert.NilError(t, err)
 	user, err := srvCli.Users(acc.ID).Add(ctx, accountsIface.AddUserInput{Provider: "github", ExternalID: "42"})
 	assert.NilError(t, err)
-	assert.NilError(t, srvCli.Users(acc.ID).Grant(ctx, user.ID, accountsIface.GrantPlanInput{PlanID: plan.ID}))
+	assert.NilError(t, srvCli.Users(acc.ID).Grant(ctx, user.ID, accountsIface.GrantPRefInput{PRefName: "prod"}))
 
 	t.Run("Verify over the wire", func(t *testing.T) {
 		resp, err := wire.Verify(ctx, "github", "42")
@@ -237,9 +245,9 @@ func TestAccounts_DreamingWire(t *testing.T) {
 		assert.Equal(t, resp.Linked, true)
 		assert.Equal(t, len(resp.Accounts), 1)
 		assert.Equal(t, resp.Accounts[0].Slug, "acme")
-		assert.Equal(t, len(resp.Accounts[0].Plans), 1)
-		assert.Equal(t, resp.Accounts[0].Plans[0].Slug, "prod")
-		assert.Equal(t, resp.Accounts[0].Plans[0].IsDefault, true)
+		assert.Equal(t, len(resp.Accounts[0].PRefs), 1)
+		assert.Equal(t, resp.Accounts[0].PRefs[0].Name, "prod")
+		assert.Equal(t, resp.Accounts[0].PRefs[0].IsDefault, true)
 	})
 
 	t.Run("Verify not-linked over the wire", func(t *testing.T) {
@@ -248,23 +256,23 @@ func TestAccounts_DreamingWire(t *testing.T) {
 		assert.Equal(t, resp.Linked, false)
 	})
 
-	t.Run("ResolvePlan happy path over the wire", func(t *testing.T) {
-		resp, err := wire.ResolvePlan(ctx, "acme", "prod", "github", "42")
+	t.Run("ResolvePRef happy path over the wire", func(t *testing.T) {
+		resp, err := wire.ResolvePRef(ctx, "acme", "prod", "github", "42")
 		assert.NilError(t, err)
 		assert.Equal(t, resp.Valid, true)
 		assert.Assert(t, resp.Plan != nil)
-		assert.Equal(t, resp.Plan.Slug, "prod")
+		assert.Equal(t, resp.Plan.Name, "Prod")
 	})
 
-	t.Run("ResolvePlan bad plan over the wire", func(t *testing.T) {
-		resp, err := wire.ResolvePlan(ctx, "acme", "ghost", "github", "42")
+	t.Run("ResolvePRef bad pref over the wire", func(t *testing.T) {
+		resp, err := wire.ResolvePRef(ctx, "acme", "ghost", "github", "42")
 		assert.NilError(t, err)
 		assert.Equal(t, resp.Valid, false)
-		assert.Equal(t, resp.Reason, "plan not found")
+		assert.Equal(t, resp.Reason, "pref not found")
 	})
 
-	t.Run("ResolvePlan bad account over the wire", func(t *testing.T) {
-		resp, err := wire.ResolvePlan(ctx, "ghost", "prod", "github", "42")
+	t.Run("ResolvePRef bad account over the wire", func(t *testing.T) {
+		resp, err := wire.ResolvePRef(ctx, "ghost", "prod", "github", "42")
 		assert.NilError(t, err)
 		assert.Equal(t, resp.Valid, false)
 		assert.Equal(t, resp.Reason, "account not found")
@@ -283,10 +291,15 @@ func TestAccounts_DreamingWire(t *testing.T) {
 		assert.Equal(t, got.Slug, "acme")
 		assert.Equal(t, got.Name, "Acme")
 
-		// Per-Account sub-surfaces work.
-		bids, err := wire.Plans(acc.ID).List(ctx)
+		// Global plan list returns ≥1 (we seeded one).
+		bids, err := wire.Plans().List(ctx)
 		assert.NilError(t, err)
-		assert.Equal(t, len(bids), 1)
+		assert.Assert(t, len(bids) >= 1, "expected at least one plan, got %d", len(bids))
+
+		// Per-Account sub-surfaces work.
+		pnames, err := wire.PRefs(acc.ID).List(ctx)
+		assert.NilError(t, err)
+		assert.Equal(t, len(pnames), 1)
 
 		uids, err := wire.Users(acc.ID).List(ctx)
 		assert.NilError(t, err)

--- a/services/accounts/tests/strict_test.go
+++ b/services/accounts/tests/strict_test.go
@@ -88,8 +88,8 @@ func TestStrict_VerifyAcceptsAfterFixture_Dreaming(t *testing.T) {
 	assert.Equal(t, post.Linked, true)
 	assert.Equal(t, len(post.Accounts), 1)
 	assert.Equal(t, post.Accounts[0].Slug, dreamFixtures.FakeAccountSlug)
-	assert.Equal(t, len(post.Accounts[0].Plans), 1)
-	assert.Equal(t, post.Accounts[0].Plans[0].Slug, dreamFixtures.FakeAccountPlan)
+	assert.Equal(t, len(post.Accounts[0].PRefs), 1)
+	assert.Equal(t, post.Accounts[0].PRefs[0].Name, dreamFixtures.FakeAccountPRef)
 }
 
 // TestStrict_ResolvePlanRejectsBadPlan_Dreaming — fixture seeded, but the
@@ -102,13 +102,13 @@ func TestStrict_ResolvePlanRejectsBadPlan_Dreaming(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
-	resp, err := cli.ResolvePlan(ctx,
+	resp, err := cli.ResolvePRef(ctx,
 		dreamFixtures.FakeAccountSlug, "nonexistent-plan",
 		dreamFixtures.FakeAccountUserProv, dreamFixtures.FakeAccountUserExtID,
 	)
 	assert.NilError(t, err)
 	assert.Equal(t, resp.Valid, false)
-	assert.Equal(t, resp.Reason, "plan not found")
+	assert.Equal(t, resp.Reason, "pref not found")
 }
 
 // TestStrict_ResolvePlanRejectsBadAccount_Dreaming — same shape, but the account
@@ -122,8 +122,8 @@ func TestStrict_ResolvePlanRejectsBadAccount_Dreaming(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
-	resp, err := cli.ResolvePlan(ctx,
-		"nonexistent-account", dreamFixtures.FakeAccountPlan,
+	resp, err := cli.ResolvePRef(ctx,
+		"nonexistent-account", dreamFixtures.FakeAccountPRef,
 		dreamFixtures.FakeAccountUserProv, dreamFixtures.FakeAccountUserExtID,
 	)
 	assert.NilError(t, err)
@@ -145,8 +145,8 @@ func TestStrict_ResolvePlanRejectsUngrantedUser_Dreaming(t *testing.T) {
 	defer cancel()
 
 	// "github:99999" is not the seeded user — the seeded user is "42".
-	resp, err := cli.ResolvePlan(ctx,
-		dreamFixtures.FakeAccountSlug, dreamFixtures.FakeAccountPlan,
+	resp, err := cli.ResolvePRef(ctx,
+		dreamFixtures.FakeAccountSlug, dreamFixtures.FakeAccountPRef,
 		"github", "99999",
 	)
 	assert.NilError(t, err)
@@ -196,7 +196,7 @@ func TestStrict_InjectMemberCustom_Dreaming(t *testing.T) {
 	assert.NilError(t, u.RunFixture("injectAccount", dreamFixtures.AccountInjection{
 		AccountSlug: "umbrella",
 		AccountName: "Umbrella Corp",
-		PlanSlug:    "enterprise",
+		PRefName:    "enterprise",
 	}))
 
 	assert.NilError(t, u.RunFixture("injectMember", dreamFixtures.MemberInjection{
@@ -228,7 +228,7 @@ func TestStrict_InjectAccountCustom_Dreaming(t *testing.T) {
 	custom := dreamFixtures.AccountInjection{
 		AccountSlug: "umbrella",
 		AccountName: "Umbrella Corp",
-		PlanSlug:    "enterprise",
+		PRefName:    "enterprise",
 		UserExtID:   "777",
 	}
 	assert.NilError(t, u.RunFixture("injectAccount", custom))
@@ -237,13 +237,13 @@ func TestStrict_InjectAccountCustom_Dreaming(t *testing.T) {
 	defer cancel()
 
 	// Custom plan resolves cleanly.
-	resp, err := cli.ResolvePlan(ctx, "umbrella", "enterprise", "github", "777")
+	resp, err := cli.ResolvePRef(ctx, "umbrella", "enterprise", "github", "777")
 	assert.NilError(t, err)
 	assert.Equal(t, resp.Valid, true)
 
 	// Default seed (acme/prod/42) was NOT injected, so it should still
 	// reject cleanly — confirms inject is additive, not a wholesale reset.
-	miss, err := cli.ResolvePlan(ctx, "acme", "prod", "github", "42")
+	miss, err := cli.ResolvePRef(ctx, "acme", "prod", "github", "42")
 	assert.NilError(t, err)
 	assert.Equal(t, miss.Valid, false)
 }

--- a/services/accounts/user.go
+++ b/services/accounts/user.go
@@ -4,25 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
-	"github.com/fxamacker/cbor/v2"
 	"github.com/taubyte/tau/core/kvdb"
 	accountsIface "github.com/taubyte/tau/core/services/accounts"
 	protocolCommon "github.com/taubyte/tau/services/common"
 )
 
-// userStore implements accountsIface.Users for one Account.
-//
-// Persistence is split: the User's profile (sans grants) lives at
-// .../users/{user_id}/profile, and each PlanGrant lives at
-// .../users/{user_id}/grants/{plan_id}. This lets Grant/Revoke modify a
-// single grant without touching the profile, and lets List(grants) walk a
-// per-User prefix.
-//
-// Maintained indexes:
-//
-//	/lookup/git_user/{provider}/{external_id} → JSON [(account_id, user_id), ...]
+// userStore implements accountsIface.Users for one Account. Grants are keyed
+// by PRef name (account-scoped), not plan_id — so users automatically follow
+// plan upgrades when the PRef's pointer swaps without re-issuing the grant.
 type userStore struct {
 	db        kvdb.KVDB
 	accountID string
@@ -34,21 +26,19 @@ func newUserStore(db kvdb.KVDB, accountID string) *userStore {
 
 var _ accountsIface.Users = (*userStore)(nil)
 
-// gitUserIndexEntry is one row in the git_user lookup index.
+// gitUserIndexEntry is reconstructed from index keys; not a stored shape.
 type gitUserIndexEntry struct {
-	AccountID string `cbor:"account_id"`
-	UserID    string `cbor:"user_id"`
+	AccountID string
+	UserID    string
 }
 
-// Add records a new linked git account on this Account. Provider+external_id
-// must be unique within the Account (a given github user can only be linked
-// once per Account). Across Accounts the same git user can be linked many
-// times — the global git_user index tracks all of them.
+// Add enforces (provider, external_id) uniqueness within this Account. The
+// same git user may be linked to many Accounts — the global git_user index
+// tracks all of them.
 func (s *userStore) Add(ctx context.Context, in accountsIface.AddUserInput) (*accountsIface.User, error) {
 	if in.Provider == "" || in.ExternalID == "" {
 		return nil, errors.New("accounts: provider and external_id required")
 	}
-	// Uniqueness within Account.
 	if existing, _ := s.GetByExternal(ctx, in.Provider, in.ExternalID); existing != nil {
 		return nil, fmt.Errorf("accounts: git user %s/%s already linked to this account",
 			in.Provider, in.ExternalID)
@@ -66,14 +56,12 @@ func (s *userStore) Add(ctx context.Context, in accountsIface.AddUserInput) (*ac
 		return nil, err
 	}
 	if err := s.addGitUserIndex(ctx, u.Provider, u.ExternalID, u.ID); err != nil {
-		// best-effort rollback
 		_ = s.db.Delete(ctx, UserProfilePath(s.accountID, u.ID))
 		return nil, err
 	}
 	return u, nil
 }
 
-// Get loads a User (including its grants).
 func (s *userStore) Get(ctx context.Context, userID string) (*accountsIface.User, error) {
 	var u accountsIface.User
 	if err := getKV(ctx, s.db, UserProfilePath(s.accountID, userID), &u); err != nil {
@@ -87,8 +75,6 @@ func (s *userStore) Get(ctx context.Context, userID string) (*accountsIface.User
 	return &u, nil
 }
 
-// GetByExternal finds a User by (provider, external_id) within this Account.
-// Walks the global git_user index then filters to this Account.
 func (s *userStore) GetByExternal(ctx context.Context, provider, externalID string) (*accountsIface.User, error) {
 	idx, err := s.readGitUserIndex(ctx, provider, externalID)
 	if err != nil {
@@ -105,46 +91,44 @@ func (s *userStore) GetByExternal(ctx context.Context, provider, externalID stri
 	return nil, ErrNotFound
 }
 
-// List returns the IDs of all Users on this Account.
 func (s *userStore) List(ctx context.Context) ([]string, error) {
 	return listChildIDs(ctx, s.db, AccountUsersPrefix(s.accountID))
 }
 
-// Remove deletes the User profile, all grants, and removes the git_user index entry.
 func (s *userStore) Remove(ctx context.Context, userID string) error {
 	u, err := s.Get(ctx, userID)
 	if err != nil {
 		return err
 	}
-	// Delete each grant individually (KVDB lacks a "delete prefix" primitive).
 	for _, g := range u.PlanGrants {
-		if err := s.db.Delete(ctx, UserGrantPath(s.accountID, userID, g.PlanID)); err != nil {
+		if err := s.db.Delete(ctx, UserGrantPath(s.accountID, userID, g.PRefName)); err != nil {
 			return fmt.Errorf("accounts: delete grant: %w", err)
 		}
 	}
 	if err := s.db.Delete(ctx, UserProfilePath(s.accountID, userID)); err != nil {
 		return fmt.Errorf("accounts: delete user: %w", err)
 	}
+	// git_user-index cleanup is best-effort: profile delete already
+	// succeeded, so don't fail Remove because a secondary index is stale.
 	if err := s.removeGitUserIndex(ctx, u.Provider, u.ExternalID, userID); err != nil {
-		return err
+		logger.Warnf("accounts: stale git_user index entry for user %s on account %s: %v",
+			userID, s.accountID, err)
 	}
 	return nil
 }
 
-// Grant attaches a Plan to the User. If is_default is set, demotes any
-// existing default grant. First grant on a User is auto-default.
-func (s *userStore) Grant(ctx context.Context, userID string, in accountsIface.GrantPlanInput) error {
-	if in.PlanID == "" {
-		return errors.New("accounts: plan_id required")
+// Grant attaches a PRef to the User. The first grant on a User is
+// auto-default; a new grant marked IsDefault demotes any prior default.
+func (s *userStore) Grant(ctx context.Context, userID string, in accountsIface.GrantPRefInput) error {
+	if in.PRefName == "" {
+		return errors.New("accounts: pref_name required")
 	}
-	// Verify the User exists.
 	if _, err := s.Get(ctx, userID); err != nil {
 		return err
 	}
-	// Verify the Plan exists in this Account.
-	bs := newPlanStore(s.db, s.accountID)
-	if _, err := bs.Get(ctx, in.PlanID); err != nil {
-		return fmt.Errorf("accounts: plan %s: %w", in.PlanID, err)
+	ps := newPRefStore(s.db, s.accountID, newPlanStore(s.db))
+	if _, err := ps.Get(ctx, in.PRefName); err != nil {
+		return fmt.Errorf("accounts: pref %q: %w", in.PRefName, err)
 	}
 
 	existing, err := s.listGrants(ctx, userID)
@@ -154,29 +138,28 @@ func (s *userStore) Grant(ctx context.Context, userID string, in accountsIface.G
 
 	makeDefault := in.IsDefault || len(existing) == 0
 
-	// If this grant is becoming default, demote others.
 	if makeDefault {
 		for _, g := range existing {
-			if g.IsDefault && g.PlanID != in.PlanID {
+			if g.IsDefault && g.PRefName != in.PRefName {
 				demoted := g
 				demoted.IsDefault = false
-				if err := putKV(ctx, s.db, UserGrantPath(s.accountID, userID, demoted.PlanID), demoted); err != nil {
+				if err := putKV(ctx, s.db, UserGrantPath(s.accountID, userID, demoted.PRefName), demoted); err != nil {
 					return err
 				}
 			}
 		}
 	}
 
-	g := accountsIface.PlanGrant{PlanID: in.PlanID, IsDefault: makeDefault}
-	if err := putKV(ctx, s.db, UserGrantPath(s.accountID, userID, in.PlanID), g); err != nil {
+	g := accountsIface.PlanGrant{PRefName: in.PRefName, IsDefault: makeDefault}
+	if err := putKV(ctx, s.db, UserGrantPath(s.accountID, userID, in.PRefName), g); err != nil {
 		return err
 	}
 	return nil
 }
 
-// Revoke removes one grant. If it was the default and other grants remain,
-// promotes the first remaining to default.
-func (s *userStore) Revoke(ctx context.Context, userID, planID string) error {
+// Revoke promotes the first remaining grant to default when the removed grant
+// was the default and other grants survive.
+func (s *userStore) Revoke(ctx context.Context, userID, prefName string) error {
 	existing, err := s.listGrants(ctx, userID)
 	if err != nil {
 		return err
@@ -187,7 +170,7 @@ func (s *userStore) Revoke(ctx context.Context, userID, planID string) error {
 		others  []accountsIface.PlanGrant
 	)
 	for _, g := range existing {
-		if g.PlanID == planID {
+		if g.PRefName == prefName {
 			removed = g
 			found = true
 		} else {
@@ -197,20 +180,18 @@ func (s *userStore) Revoke(ctx context.Context, userID, planID string) error {
 	if !found {
 		return ErrNotFound
 	}
-	if err := s.db.Delete(ctx, UserGrantPath(s.accountID, userID, planID)); err != nil {
+	if err := s.db.Delete(ctx, UserGrantPath(s.accountID, userID, prefName)); err != nil {
 		return fmt.Errorf("accounts: delete grant: %w", err)
 	}
-	// Promote the first remaining grant if we removed the default.
 	if removed.IsDefault && len(others) > 0 {
 		others[0].IsDefault = true
-		if err := putKV(ctx, s.db, UserGrantPath(s.accountID, userID, others[0].PlanID), others[0]); err != nil {
+		if err := putKV(ctx, s.db, UserGrantPath(s.accountID, userID, others[0].PRefName), others[0]); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// listGrants reads all grants for a User.
 func (s *userStore) listGrants(ctx context.Context, userID string) ([]accountsIface.PlanGrant, error) {
 	keys, err := s.db.List(ctx, UserGrantsPrefix(s.accountID, userID))
 	if err != nil {
@@ -230,60 +211,36 @@ func (s *userStore) listGrants(ctx context.Context, userID string) ([]accountsIf
 	return grants, nil
 }
 
-// --- git_user index helpers ----------------------------------------
-
 func (s *userStore) addGitUserIndex(ctx context.Context, provider, externalID, userID string) error {
-	idx, err := s.readGitUserIndex(ctx, provider, externalID)
-	if err != nil && !errors.Is(err, ErrNotFound) {
-		return err
-	}
-	idx = append(idx, gitUserIndexEntry{AccountID: s.accountID, UserID: userID})
-	return s.writeGitUserIndex(ctx, provider, externalID, idx)
+	return s.db.Put(ctx, LookupGitUserEntryPath(provider, externalID, s.accountID, userID), nowBytes())
 }
 
+// removeGitUserIndex returns ErrNotFound when the entry isn't present (raw
+// KVDB.Delete is idempotent).
 func (s *userStore) removeGitUserIndex(ctx context.Context, provider, externalID, userID string) error {
-	idx, err := s.readGitUserIndex(ctx, provider, externalID)
-	if err != nil {
-		if errors.Is(err, ErrNotFound) {
-			return nil
-		}
-		return err
-	}
-	out := idx[:0]
-	for _, e := range idx {
-		if e.AccountID == s.accountID && e.UserID == userID {
-			continue
-		}
-		out = append(out, e)
-	}
-	if len(out) == 0 {
-		return s.db.Delete(ctx, LookupGitUserPath(provider, externalID))
-	}
-	return s.writeGitUserIndex(ctx, provider, externalID, out)
+	return deleteIndexEntry(ctx, s.db, LookupGitUserEntryPath(provider, externalID, s.accountID, userID))
 }
 
 func (s *userStore) readGitUserIndex(ctx context.Context, provider, externalID string) ([]gitUserIndexEntry, error) {
-	raw, err := s.db.Get(ctx, LookupGitUserPath(provider, externalID))
+	prefix := LookupGitUserPrefix(provider, externalID)
+	keys, err := s.db.List(ctx, prefix)
 	if err != nil {
-		if isMissing(err) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("accounts: git_user index get: %w", err)
+		return nil, fmt.Errorf("accounts: list git_user index %s: %w", prefix, err)
 	}
-	if len(raw) == 0 {
+	if len(keys) == 0 {
 		return nil, ErrNotFound
 	}
-	var idx []gitUserIndexEntry
-	if err := cbor.Unmarshal(raw, &idx); err != nil {
-		return nil, fmt.Errorf("accounts: git_user index unmarshal: %w", err)
+	out := make([]gitUserIndexEntry, 0, len(keys))
+	for _, k := range keys {
+		rest := strings.TrimPrefix(k, prefix)
+		parts := strings.SplitN(rest, "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			continue
+		}
+		out = append(out, gitUserIndexEntry{AccountID: parts[0], UserID: parts[1]})
 	}
-	return idx, nil
-}
-
-func (s *userStore) writeGitUserIndex(ctx context.Context, provider, externalID string, idx []gitUserIndexEntry) error {
-	raw, err := cbor.Marshal(idx)
-	if err != nil {
-		return fmt.Errorf("accounts: git_user index marshal: %w", err)
+	if len(out) == 0 {
+		return nil, ErrNotFound
 	}
-	return s.db.Put(ctx, LookupGitUserPath(provider, externalID), raw)
+	return out, nil
 }

--- a/services/auth/http_auth_accounts_test.go
+++ b/services/auth/http_auth_accounts_test.go
@@ -26,13 +26,17 @@ func (f *fakeAccountsClient) Verify(ctx context.Context, provider, externalID st
 	}
 	return nil, errNotImpl
 }
-func (f *fakeAccountsClient) ResolvePlan(context.Context, string, string, string, string) (*accountsIface.ResolveResponse, error) {
+func (f *fakeAccountsClient) ResolvePRef(context.Context, string, string, string, string) (*accountsIface.ResolveResponse, error) {
+	return nil, errNotImpl
+}
+func (f *fakeAccountsClient) LookupAccountsByEmail(context.Context, string) ([]string, error) {
 	return nil, errNotImpl
 }
 func (f *fakeAccountsClient) Accounts() accountsIface.Accounts          { return nil }
 func (f *fakeAccountsClient) Members(string) accountsIface.Members      { return nil }
 func (f *fakeAccountsClient) Users(string) accountsIface.Users          { return nil }
-func (f *fakeAccountsClient) Plans(string) accountsIface.Plans          { return nil }
+func (f *fakeAccountsClient) Plans() accountsIface.Plans                { return nil }
+func (f *fakeAccountsClient) PRefs(string) accountsIface.PRefs          { return nil }
 func (f *fakeAccountsClient) Login() accountsIface.Login                { return nil }
 func (f *fakeAccountsClient) Peers(...peerCore.ID) accountsIface.Client { return f }
 func (f *fakeAccountsClient) Close()                                    {}
@@ -80,7 +84,7 @@ func TestGitHubTokenHTTPAuth_AccountsLinked_Allows(t *testing.T) {
 			return &accountsIface.VerifyResponse{
 				Linked: true,
 				Accounts: []accountsIface.VerifyAccountSummary{
-					{Slug: "acme", Plans: []accountsIface.VerifyPlanSummary{{Slug: "prod", IsDefault: true}}},
+					{Slug: "acme", PRefs: []accountsIface.VerifyPRefSummary{{Name: "prod", IsDefault: true}}},
 				},
 			}, nil
 		},

--- a/services/monkey/jobs/account_plan.go
+++ b/services/monkey/jobs/account_plan.go
@@ -8,7 +8,9 @@ import (
 )
 
 // checkAccountPlan validates the project's `clouds.<NetworkFqdn>.{account, plan}`
-// binding against the accounts service. No-op when the accounts client isn't
+// binding against the accounts service. The project schema still calls the
+// field `plan` for back-compat; the value is now treated as a PRef name and
+// resolved via accounts.ResolvePRef. No-op when the accounts client isn't
 // wired or the project doesn't pin this cloud. Shared by code.handle() and
 // config.handle() so both compile paths enforce the same rule.
 func (c Context) checkAccountPlan(p projectSchema.Project) error {
@@ -32,9 +34,9 @@ func (c Context) checkAccountPlan(p projectSchema.Project) error {
 	if provider == "" || externalID == "" {
 		return fmt.Errorf("project config: cannot resolve plan %q without a git provider identity", binding.Plan)
 	}
-	resp, err := c.Accounts.ResolvePlan(c.ctx, binding.Account, binding.Plan, provider, externalID)
+	resp, err := c.Accounts.ResolvePRef(c.ctx, binding.Account, binding.Plan, provider, externalID)
 	if err != nil {
-		return fmt.Errorf("accounts.ResolvePlan(%s/%s, %s/%s): %w", binding.Account, binding.Plan, provider, externalID, err)
+		return fmt.Errorf("accounts.ResolvePRef(%s/%s, %s/%s): %w", binding.Account, binding.Plan, provider, externalID, err)
 	}
 	if !resp.Valid {
 		return fmt.Errorf("project config: plan %q under account %q on cloud %q is invalid: %s",

--- a/services/monkey/jobs/code_account_test.go
+++ b/services/monkey/jobs/code_account_test.go
@@ -15,16 +15,16 @@ import (
 )
 
 // fakeAccounts is a minimal test double for accountsIface.Client. Only
-// ResolvePlan is wired; the rest panic on use to surface accidental calls.
+// ResolvePRef is wired; the rest panic on use to surface accidental calls.
 type fakeAccounts struct {
-	resolveFn func(ctx context.Context, accountSlug, planSlug, provider, externalID string) (*accountsIface.ResolveResponse, error)
+	resolveFn func(ctx context.Context, accountSlug, prefName, provider, externalID string) (*accountsIface.ResolveResponse, error)
 	calls     []string
 }
 
-func (f *fakeAccounts) ResolvePlan(ctx context.Context, accountSlug, planSlug, provider, externalID string) (*accountsIface.ResolveResponse, error) {
-	f.calls = append(f.calls, accountSlug+"/"+planSlug+"|"+provider+"/"+externalID)
+func (f *fakeAccounts) ResolvePRef(ctx context.Context, accountSlug, prefName, provider, externalID string) (*accountsIface.ResolveResponse, error) {
+	f.calls = append(f.calls, accountSlug+"/"+prefName+"|"+provider+"/"+externalID)
 	if f.resolveFn != nil {
-		return f.resolveFn(ctx, accountSlug, planSlug, provider, externalID)
+		return f.resolveFn(ctx, accountSlug, prefName, provider, externalID)
 	}
 	return &accountsIface.ResolveResponse{Valid: true}, nil
 }
@@ -32,10 +32,14 @@ func (f *fakeAccounts) ResolvePlan(ctx context.Context, accountSlug, planSlug, p
 func (f *fakeAccounts) Verify(context.Context, string, string) (*accountsIface.VerifyResponse, error) {
 	return nil, errors.New("unused")
 }
+func (f *fakeAccounts) LookupAccountsByEmail(context.Context, string) ([]string, error) {
+	return nil, errors.New("unused")
+}
 func (f *fakeAccounts) Accounts() accountsIface.Accounts          { return nil }
 func (f *fakeAccounts) Members(string) accountsIface.Members      { return nil }
 func (f *fakeAccounts) Users(string) accountsIface.Users          { return nil }
-func (f *fakeAccounts) Plans(string) accountsIface.Plans          { return nil }
+func (f *fakeAccounts) Plans() accountsIface.Plans                { return nil }
+func (f *fakeAccounts) PRefs(string) accountsIface.PRefs          { return nil }
 func (f *fakeAccounts) Login() accountsIface.Login                { return nil }
 func (f *fakeAccounts) Peers(...peerCore.ID) accountsIface.Client { return f }
 func (f *fakeAccounts) Close()                                    {}

--- a/tools/tau/cli/commands/accounts/list.go
+++ b/tools/tau/cli/commands/accounts/list.go
@@ -21,21 +21,22 @@ func runList(_ *cli.Context) error {
 		return nil
 	}
 	for _, acc := range loaded.Me.Accounts {
+		// CLI surface treats PRefs as "plans" (the user-facing concept).
 		var defaultPlan string
-		for _, p := range acc.Plans {
+		for _, p := range acc.PRefs {
 			if p.IsDefault {
-				defaultPlan = p.Slug
+				defaultPlan = p.Name
 				break
 			}
 		}
-		if defaultPlan == "" && len(acc.Plans) > 0 {
-			defaultPlan = acc.Plans[0].Slug
+		if defaultPlan == "" && len(acc.PRefs) > 0 {
+			defaultPlan = acc.PRefs[0].Name
 		}
 		if defaultPlan == "" {
 			defaultPlan = "<none>"
 		}
 		pterm.Info.Printf("%s — %s  (plans: %d, default: %s)\n",
-			acc.Slug, acc.Name, len(acc.Plans), defaultPlan)
+			acc.Slug, acc.Name, len(acc.PRefs), defaultPlan)
 	}
 	return nil
 }

--- a/tools/tau/cli/commands/accounts/plans.go
+++ b/tools/tau/cli/commands/accounts/plans.go
@@ -5,11 +5,12 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// Plans are operator-managed in v1; Members can only inspect via list.
+// Plans are operator-managed in v1; Members can only inspect via list. The CLI
+// surface refers to the user-facing "plan" concept which is internally a PRef.
 var plansCommand = &cli.Command{
 	Name:    "plans",
 	Aliases: []string{"plan"},
-	Usage:   "Inspect Plans within an Account",
+	Usage:   "Inspect plans within an Account",
 	Subcommands: []*cli.Command{
 		plansListCommand,
 	},
@@ -34,17 +35,17 @@ func runPlansList(ctx *cli.Context) error {
 		if filter != "" && acc.Slug != filter {
 			continue
 		}
-		if len(acc.Plans) == 0 {
+		if len(acc.PRefs) == 0 {
 			pterm.Info.Printf("%s: <no plans>\n", acc.Slug)
 			any = true
 			continue
 		}
-		for _, p := range acc.Plans {
+		for _, p := range acc.PRefs {
 			marker := " "
 			if p.IsDefault {
 				marker = "*"
 			}
-			pterm.Info.Printf("%s %s/%s\n", marker, acc.Slug, p.Slug)
+			pterm.Info.Printf("%s %s/%s\n", marker, acc.Slug, p.Name)
 			any = true
 		}
 	}

--- a/tools/tau/cli/commands/accounts/users.go
+++ b/tools/tau/cli/commands/accounts/users.go
@@ -108,11 +108,11 @@ func runUsersRemove(ctx *cli.Context) error {
 
 var usersGrantCommand = &cli.Command{
 	Name:      "grant",
-	Usage:     "Grant a User access to a Plan within the Account",
+	Usage:     "Grant a User access to a plan within the Account",
 	ArgsUsage: "<account-slug>",
 	Flags: []cli.Flag{
 		&cli.StringFlag{Name: "user", Usage: "User ID", Required: true},
-		&cli.StringFlag{Name: "plan", Usage: "Plan ID", Required: true},
+		&cli.StringFlag{Name: "plan", Usage: "Plan name (PRef name)", Required: true},
 	},
 	Action: runUsersGrant,
 }
@@ -126,7 +126,7 @@ func runUsersGrant(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := loaded.HTTP.GrantPlan(accountID, ctx.String("user"), ctx.String("plan")); err != nil {
+	if err := loaded.HTTP.GrantPRef(accountID, ctx.String("user"), ctx.String("plan")); err != nil {
 		return err
 	}
 	pterm.Success.Printf("Granted plan %s to user %s\n", ctx.String("plan"), ctx.String("user"))


### PR DESCRIPTION
## What

### Plans become global, immutable, undeletable
A Plan is now `ID`, `Name`, `DisplayName`, and an opaque `Data` blob. `Plans()` is un-scoped from accounts; update/delete/get-by-slug are gone. KV layout moves plans to global `/plans/{id}`.

### New: PRefs (plan references)
Account-scoped, named pointers to a plan:
- Name is immortal — varname-shaped (`[a-zA-Z_][a-zA-Z0-9_]*`, case-sensitive, max 64), can be disabled/re-enabled, never deleted
- Append-only event log (`assign` / `disable` / `enable`); status and current plan are **derived** from the latest events; `Events` returns chronological order with inclusive time bounds
- `PRefs` interface: Create / Get / List / SetDisplayName / Assign / Disable / Enable / Events / LatestEvent

### Grants re-keyed: plan_id → pref_name
When a pref's pointer swaps to a new plan, every user granted that pref follows the upgrade — no re-grant sweep. `ResolvePlan` → `ResolvePRef` with a typed reason set; the project schema keeps the field name `plan`, its value is now a pref name.

Propagated in lockstep: stream handlers, p2p + http clients, in-process client, dream fixtures, monkey resolve path, tau CLI, auth/monkey test doubles.

### Also in this change (same files, split would not compile independently)
- **CRDT-safe lookup indexes** — email / external / git-user indexes rewritten from CBOR read-modify-write blobs to one KV key per entry, so concurrent writers on different nodes can't lose entries to CRDT merges
- **`LookupAccountsByEmail`** — new API over the per-entry email index (case-insensitive, deduped, no status filtering)
- **Magic-link rate limiting** — key-per-attempt buckets counted by `List` (same CRDT reasoning); the cross-partition exactly-once consumption race is documented and deferred to a raft phase
- Account slug validation switched to the same varname rules

## Testing
- `go build` across core, services, clients, dream, tools, monkey, auth (isolated tree)
- `go vet -tags dreaming` on accounts + dream fixtures
- `go test ./services/accounts/ ./clients/p2p/accounts/` green; a flaky ordering assumption found during verification was fixed at the source (`Events` now sorts — `db.List` doesn't guarantee key order) and stress-tested 20×