### PR TITLE
[spore-drive] probe multiple DNS resolvers in displace

### DIFF
--- a/pkg/spore-drive/clients/js/package-lock.json
+++ b/pkg/spore-drive/clients/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@taubyte/spore-drive",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@taubyte/spore-drive",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bufbuild/protobuf": "1.4.2",

--- a/pkg/spore-drive/clients/js/package.json
+++ b/pkg/spore-drive/clients/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@taubyte/spore-drive",
-  "version": "0.1.10",
-  "service": "0.1.5",
+  "version": "0.1.11",
+  "service": "0.1.6",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/pkg/spore-drive/clients/py/setup.py
+++ b/pkg/spore-drive/clients/py/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="spore-drive",
-    version="0.1.1",
+    version="0.1.2",
     author="Taubyte",
     author_email="dev@taubyte.com",
     description="Python client for Spore Drive",

--- a/pkg/spore-drive/clients/py/spore_drive/__init__.py
+++ b/pkg/spore-drive/clients/py/spore_drive/__init__.py
@@ -36,4 +36,4 @@ __all__ = [
 ]
 
 # Version information
-__version__ = "0.1.0" 
+__version__ = "0.1.2"

--- a/pkg/spore-drive/clients/py/spore_drive/service_manager.py
+++ b/pkg/spore-drive/clients/py/spore_drive/service_manager.py
@@ -28,7 +28,7 @@ class ServiceManager:
         self.temp_dir: Optional[tempfile.TemporaryDirectory] = None
         
         # Service configuration
-        self.service_version = "0.1.5"
+        self.service_version = "0.1.6"
         self.binary_dir = Path(__file__).parent / "bin"
         self.binary_name = "drive.exe" if platform.system() == "Windows" else "drive"
         self.binary_path = self.binary_dir / self.binary_name

--- a/pkg/spore-drive/drive/displace.go
+++ b/pkg/spore-drive/drive/displace.go
@@ -23,6 +23,39 @@ import (
 
 var systemdResolvedRegexp = regexp.MustCompile(`.*:53[\s\t].*systemd-.*`)
 
+// dnsResolvers is the ordered list of candidate public DNS servers. Each one
+// is probed from the target host before deployment; only the resolvers that
+// actually answer get written into /etc/systemd/resolved.conf, so a host
+// behind a firewall that blocks (say) 1.1.1.1 still gets a working setup.
+var dnsResolvers = []string{
+	"1.1.1.1",         // Cloudflare
+	"1.0.0.1",         // Cloudflare secondary
+	"8.8.8.8",         // Google
+	"8.8.4.4",         // Google secondary
+	"9.9.9.9",         // Quad9
+	"149.112.112.112", // Quad9 secondary
+	"208.67.222.222",  // OpenDNS
+	"208.67.220.220",  // OpenDNS secondary
+}
+
+// probeDNSResolvers returns the subset of dnsResolvers that successfully
+// resolve google.com from the target host within a 5s timeout each.
+func probeDNSResolvers(ctx context.Context, r remoteHost) []string {
+	var working []string
+	for _, dns := range dnsResolvers {
+		out, err := r.Execute(ctx, "dig", "+short", "+timeout=5", "@"+dns, "google.com")
+		if err != nil {
+			continue
+		}
+		ip := strings.TrimSpace(strings.Split(string(out), "\n")[0])
+		if net.ParseIP(ip) == nil {
+			continue
+		}
+		working = append(working, dns)
+	}
+	return working
+}
+
 func (d *sporedrive) Displace(ctx context.Context, course course.Course) <-chan Progress {
 
 	hyphae := course.Hyphae()
@@ -74,7 +107,11 @@ func (d *sporedrive) Displace(ctx context.Context, course course.Course) <-chan 
 	return pCh
 }
 
-func updateResolvedConf(ctx context.Context, h remoteHost) error {
+func updateResolvedConf(ctx context.Context, h remoteHost, resolvers []string) error {
+	if len(resolvers) == 0 {
+		return fmt.Errorf("no DNS resolvers provided")
+	}
+
 	file, err := h.Open("/etc/systemd/resolved.conf")
 	if err != nil {
 		return fmt.Errorf("failed to open /etc/systemd/resolved.conf: %w", err)
@@ -92,7 +129,7 @@ func updateResolvedConf(ctx context.Context, h remoteHost) error {
 	}
 
 	resolveSection := cfg.Section("Resolve")
-	resolveSection.Key("DNS").SetValue("1.1.1.1")
+	resolveSection.Key("DNS").SetValue(strings.Join(resolvers, " "))
 	resolveSection.Key("DNSStubListener").SetValue("no")
 
 	tmpFilePath := "/tmp/resolved.conf"
@@ -508,10 +545,19 @@ func (d *sporedrive) displaceHandler(hypha *course.Hypha, progressCh chan<- Prog
 			return pushError("dependencies", fmt.Errorf("failed to run netstat: %w", err))
 		}
 
+		// Probe candidate DNS resolvers from the host. We only keep the ones
+		// that actually answer, so a host that can't reach (e.g.) 1.1.1.1
+		// still gets a usable resolver list.
+		workingResolvers := probeDNSResolvers(ctx, r)
+		if len(workingResolvers) == 0 {
+			return pushError("dependencies", fmt.Errorf("DNS resolution test failed: none of %v are reachable", dnsResolvers))
+		}
+		pushProgress("dependencies", 90)
+
 		netstatStr := string(netstatOutput)
 		if systemdResolvedRegexp.MatchString(netstatStr) {
 			// systemd-resolved is using port 53, updating DNS settings using ini package
-			if err := updateResolvedConf(ctx, r); err != nil {
+			if err := updateResolvedConf(ctx, r, workingResolvers); err != nil {
 				return pushError("dependencies", fmt.Errorf("failed to update /etc/systemd/resolved.conf: %w", err))
 			}
 
@@ -524,18 +570,6 @@ func (d *sporedrive) displaceHandler(hypha *course.Hypha, progressCh chan<- Prog
 			if _, err := r.Sudo(ctx, "ln", "-sf", "/run/systemd/resolve/resolv.conf", "/etc/resolv.conf"); err != nil {
 				return pushError("dependencies", fmt.Errorf("failed to update /etc/resolv.conf symlink: %w", err))
 			}
-		}
-		pushProgress("dependencies", 90)
-
-		// Validate DNS resolution using 1.1.1.1
-		digOutput, err := r.Execute(ctx, "dig", "+short", "+timeout=5", "@1.1.1.1", "google.com")
-		if err != nil {
-			return pushError("dependencies", fmt.Errorf("failed to perform DNS resolution test: %w", err))
-		}
-
-		ip := strings.TrimSpace(strings.Split(string(digOutput), "\n")[0])
-		if net.ParseIP(ip) == nil {
-			return pushError("dependencies", fmt.Errorf("DNS resolution test failed, invalid IP: `%s`", ip))
 		}
 		pushProgress("dependencies", 100)
 

--- a/pkg/spore-drive/drive/displace_test.go
+++ b/pkg/spore-drive/drive/displace_test.go
@@ -64,6 +64,8 @@ func testDisplace(t *testing.T, sd Spore) {
 			rh.On("Sudo", ctx, "apt-get", "install", "-y", pkg).Once().Return(nil, nil)
 		}
 		rh.On("Sudo", ctx, "netstat", "-lnp").Once().Return(nil, nil)
+		// probeDNSResolvers iterates the full dnsResolvers list; mock each one.
+		// First resolver returns multiple A records, the rest a single one — all valid.
 		rh.On("Execute", ctx, "dig", "+short", "+timeout=5", "@1.1.1.1", "google.com").Once().Return([]byte(`142.250.115.100
 142.250.115.102
 142.250.115.113
@@ -71,6 +73,9 @@ func testDisplace(t *testing.T, sd Spore) {
 142.250.115.101
 142.250.115.139
 		`), nil)
+		for _, dns := range []string{"1.0.0.1", "8.8.8.8", "8.8.4.4", "9.9.9.9", "149.112.112.112", "208.67.222.222", "208.67.220.220"} {
+			rh.On("Execute", ctx, "dig", "+short", "+timeout=5", "@"+dns, "google.com").Once().Return([]byte("142.250.115.100\n"), nil)
+		}
 
 		if updatingTau {
 			rh.On("Execute", ctx, "md5sum", "-bz", "/tb/bin/tau").Once().Return(nil, nil)


### PR DESCRIPTION
## What

Displace hardcoded `1.1.1.1` as the sole resolver written into `resolved.conf`; hosts in networks that block Cloudflare DNS ended up with broken resolution after displace.

Now displace `dig`-probes a list of well-known resolvers (Cloudflare, Google, Quad9, OpenDNS) **from the target host**, writes every reachable one into `resolved.conf`, and fails early (progress 90) when none respond — instead of completing with a host that can't resolve anything.

Client version bumps to release the fix: service `0.1.5 → 0.1.6` in both clients, js `0.1.11`, py `0.1.2`.

## Testing
`go test ./pkg/spore-drive/drive/` green — the displace mock now expects a probe against every resolver in the list.