### PR TITLE
[dream] gate substrate fixture behind the dreaming build tag

### DIFF
--- a/services/substrate/fixture.go
+++ b/services/substrate/fixture.go
@@ -1,3 +1,6 @@
+//go:build dreaming
+// +build dreaming
+
 package substrate
 
 import (

--- a/tools/dream/.goreleaser.darwin.yml
+++ b/tools/dream/.goreleaser.darwin.yml
@@ -31,6 +31,7 @@ builds:
     tags:
       - darwin
       - odo
+      - dreaming
 
 changelog:
   disable: true

--- a/tools/dream/.goreleaser.linux.yml
+++ b/tools/dream/.goreleaser.linux.yml
@@ -27,6 +27,8 @@ builds:
     env:
       - CGO_ENABLED=0
       - GOAMD64=v2
+    tags:
+      - dreaming
 
 changelog:
   disable: true

--- a/tools/dream/.goreleaser.windows.yml
+++ b/tools/dream/.goreleaser.windows.yml
@@ -28,6 +28,7 @@ builds:
       - GOAMD64=v2
     tags:
       - windows
+      - dreaming
 
 changelog:
   disable: true


### PR DESCRIPTION
## What

- `services/substrate/fixture.go` gets `//go:build dreaming`, matching the rest of the dream-only fixtures — production substrate builds no longer carry it.
- The dream tool's goreleaser configs (linux/darwin/windows) add `dreaming` to build tags so the released binary keeps the fixture.

## Testing
`go build ./services/substrate/...` (untagged) and `go vet -tags dreaming ./services/substrate/` both green.