### PR TITLE
bump ee: tam service rename, member invites, github account linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 
 .claude/
 
+# tam dev sandbox: local configs + third-party brand assets we don't ship.
+ee/satellites/accounts/dev/
+
 pkg/spore-drive/clients/mock/mock
 pkg/taucorder/clients/mock/mock
 
@@ -215,3 +218,4 @@ pkg/spore-drive/clients/py/example/hosts.csv
 pkg/spore-drive/clients/py/spore_drive/bin/
 tools/spore-drive/service/service
 
+.gstack/


### PR DESCRIPTION
## What

Submodule bump `9d004ca → 4a8c3bf` (taubyte/tee), picking up five commits:

- **tam: untrack generated web coverage** — vitest coverage output out of tracking, ee gets a `.gitignore`
- **tam: rename satellite → service; storage layout cleanup** — `satellite.go → service.go`, `tau.tam.accounts` logger, kvdb namespace `tam`, `/signing/key`, `/sessions/revoked/` (pre-prod; old dev data intentionally orphaned)
- **tam: member invites + email-anchored github account linking** — two token-bearer flows (HMAC-signed, pending records in kvdb with boot sweep): admin invites a member by email with a required role → recipient accepts/declines anonymously; admin invites a git user by email (optionally pinning GitHub login/org) → recipient links via GitHub OAuth (mock provider in dev). Account-write authz gates consolidated. Web UI for both flows.
- **tam: web build** — package rename, vitest serialized (shared-global race), dist rebuilt

Depends on #444 (http-auto options), #445 (email templates), #446 (PRefs) — all merged.

Also adds `.gstack/` and `ee/satellites/accounts/dev/` (local sandbox, third-party brand assets) to the root gitignore.

## Testing
`go build ./ee/...` and `go test ./ee/satellites/accounts/service/` green against current main.