### PR TITLE
remove runtime panics from service and library code

### DIFF
--- a/clients/http/auth/git.go
+++ b/clients/http/auth/git.go
@@ -5,17 +5,12 @@ import (
 	"strings"
 
 	"github.com/avast/retry-go/v4"
-	git "github.com/taubyte/tau/clients/http/auth/git"
 	"github.com/taubyte/tau/clients/http/auth/git/common"
 )
 
 // Git returns a git client based on the current git provider
 // Currently only github is supported
 func (c *Client) Git() common.Client {
-	if c.gitClient == nil {
-		c.gitClient = git.New(c.http.Context(), c.http.Provider(), c.http.Token())
-	}
-
 	return c.gitClient
 }
 

--- a/clients/http/auth/git/client.go
+++ b/clients/http/auth/git/client.go
@@ -8,11 +8,11 @@ import (
 	githubClient "github.com/taubyte/tau/clients/http/auth/git/github"
 )
 
-func New(ctx context.Context, provider, token string) common.Client {
+func New(ctx context.Context, provider, token string) (common.Client, error) {
 	switch provider {
 	case "github":
-		return githubClient.New(ctx, token)
+		return githubClient.New(ctx, token), nil
 	default:
-		panic(fmt.Sprintf("provider `%s` is not supported", provider))
+		return nil, fmt.Errorf("provider `%s` is not supported", provider)
 	}
 }

--- a/clients/http/auth/new.go
+++ b/clients/http/auth/new.go
@@ -16,8 +16,13 @@ func New(ctx context.Context, options ...http.Option) (*Client, error) {
 		return nil, fmt.Errorf("new auth client failed with: %w", err)
 	}
 
+	gitClient, err := git.New(ctx, client.Provider(), client.Token())
+	if err != nil {
+		return nil, fmt.Errorf("new git client failed with: %w", err)
+	}
+
 	return &Client{
 		http:      client,
-		gitClient: git.New(ctx, client.Provider(), client.Token()),
+		gitClient: gitClient,
 	}, nil
 }

--- a/pkg/kvdb/regexp_methods.go
+++ b/pkg/kvdb/regexp_methods.go
@@ -2,7 +2,6 @@ package kvdb
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"time"
 
@@ -16,7 +15,7 @@ type FilterKeyRegEx struct {
 func (f *FilterKeyRegEx) Filter(e query.Entry) bool {
 	for _, r := range f.re {
 		if r == nil {
-			panic(fmt.Sprintf("Query filter got a Nil regexp %v", f))
+			continue
 		}
 		if r.MatchString(e.Key) {
 			return true

--- a/services/seer/dns.go
+++ b/services/seer/dns.go
@@ -24,14 +24,14 @@ func (srv *dnsServer) Start(ctx context.Context) {
 	go func() {
 		logger.Info("Starting DNS Server on UDP")
 		if err := srv.Udp.ListenAndServe(); err != nil {
-			panic("failed starting UDP Server error: " + err.Error())
+			logger.Errorf("UDP DNS server failed with: %s", err.Error())
 		}
 	}()
 
 	go func() {
 		logger.Info("Starting DNS Server on TCP")
 		if err := srv.Tcp.ListenAndServe(); err != nil {
-			panic("failed starting TCP Server error: " + err.Error())
+			logger.Errorf("TCP DNS server failed with: %s", err.Error())
 		}
 	}()
 }

--- a/services/substrate/components/database/globals/p2p/stream/get.go
+++ b/services/substrate/components/database/globals/p2p/stream/get.go
@@ -49,15 +49,25 @@ func (s *StreamHandler) getHandler(ctx context.Context, conn streams.Connection,
 func convertToValue(_type string, value []byte) (interface{}, error) {
 	switch _type {
 	case "uint32":
-		// TODO, this will panic rather than error....
+		if len(value) < 4 {
+			return nil, fmt.Errorf("value too short for %s: %d bytes", _type, len(value))
+		}
 		return binary.BigEndian.Uint32(value), nil
 	case "uint64":
-		// TODO, this will panic rather than error....
+		if len(value) < 8 {
+			return nil, fmt.Errorf("value too short for %s: %d bytes", _type, len(value))
+		}
 		return binary.BigEndian.Uint64(value), nil
 	case "float32":
+		if len(value) < 4 {
+			return nil, fmt.Errorf("value too short for %s: %d bytes", _type, len(value))
+		}
 		bits := binary.BigEndian.Uint32(value)
 		return math.Float32frombits(bits), nil
 	case "float64":
+		if len(value) < 8 {
+			return nil, fmt.Errorf("value too short for %s: %d bytes", _type, len(value))
+		}
 		bits := binary.BigEndian.Uint64(value)
 		return math.Float64frombits(bits), nil
 	case "string":

--- a/services/substrate/components/database/globals/p2p/stream/get_test.go
+++ b/services/substrate/components/database/globals/p2p/stream/get_test.go
@@ -57,3 +57,12 @@ func TestGetHandler(t *testing.T) {
 		return
 	}
 }
+
+func TestConvertToValueShortBuffer(t *testing.T) {
+	short := []byte{0x1, 0x2}
+	for _, _type := range []string{"uint32", "uint64", "float32", "float64"} {
+		if _, err := convertToValue(_type, short); err == nil {
+			t.Errorf("expected error converting %d bytes to %s", len(short), _type)
+		}
+	}
+}

--- a/services/substrate/components/http/function/function.go
+++ b/services/substrate/components/http/function/function.go
@@ -8,6 +8,7 @@ import (
 
 	goHttp "net/http"
 
+	"github.com/ipfs/go-log/v2"
 	"github.com/taubyte/tau/clients/p2p/seer/usage"
 	"github.com/taubyte/tau/core/services/substrate/components"
 	httpComp "github.com/taubyte/tau/core/services/substrate/components/http"
@@ -60,13 +61,10 @@ func (f *Function) Handle(w goHttp.ResponseWriter, r *goHttp.Request, matcher co
 	return time.Now(), f.Call(instance, ev.Id)
 }
 
+var logger = log.Logger("tau.substrate.components.http.function")
+
 func (f *Function) Metrics() *metrics.Function {
 	m := f.metrics
-	mem, err := usage.GetMemoryUsage()
-	if err != nil {
-		// panic as this is unlikely
-		panic(err)
-	}
 
 	maxMemory := f.config.Memory
 	if f.provisioned {
@@ -80,7 +78,11 @@ func (f *Function) Metrics() *metrics.Function {
 		maxMemory = WasmMemorySizeLimit
 	}
 
-	m.Memory = float64(mem.Free) / float64(maxMemory)
+	if mem, err := usage.GetMemoryUsage(); err != nil {
+		logger.Errorf("getting memory usage failed with: %s", err.Error())
+	} else {
+		m.Memory = float64(mem.Free) / float64(maxMemory)
+	}
 
 	return &m
 }

--- a/services/substrate/http.go
+++ b/services/substrate/http.go
@@ -48,7 +48,7 @@ func (srv *Service) startHttp(cfg config.Config) (err error) {
 					http.StatusTemporaryRedirect)
 			}))
 			if err != nil {
-				panic(err)
+				logger.Errorf("http to https redirect server on %s failed with: %s", listen, err.Error())
 			}
 		}()
 	}


### PR DESCRIPTION
Removes panics that could crash a whole node (or were reachable from untrusted input), replacing them with errors or logged failures:

- **substrate globals p2p stream** (`get.go`): `convertToValue` now length-checks the stored value before `binary.BigEndian` decoding. A short buffer arriving over the p2p stream previously panicked the node — remotely triggerable. Added a regression test.
- **seer DNS** (`dns.go`): UDP/TCP `ListenAndServe` failures inside goroutines now log instead of panicking (a transient bind failure killed the whole seer process).
- **substrate HTTP redirect** (`http.go`): same pattern — a bind conflict on the http→https redirect listener crashed the substrate node.
- **http function metrics** (`function.go`): `Metrics()` logs a memory-usage read failure and skips the memory ratio instead of panicking during metrics collection.
- **kvdb regexp filter** (`regexp_methods.go`): skips a nil regexp instead of panicking mid-query (`NewFilterKeyRegEx` never produces one, but a query filter shouldn't be able to crash the process).
- **auth git client** (`clients/http/auth/git`): `New` returns an error for unsupported providers instead of panicking on a data-driven string; the now-dead lazy init in `Client.Git()` is removed since the constructor always sets the client.

Left as-is: `pkg/vm-orbit/satellite/vm/instance.go:81` — the panic in the plugin RPC host function is the error channel to wazero (which recovers host-function panics and fails just that wasm call, not the process); converting it to zero-value returns would silently corrupt plugin results. Init-time fail-fast panics (`dream/init.go`, wazero cache) also left alone.

Verified: `go build ./...` clean, `go vet` clean on touched packages (remaining `stdmethods` warnings are pre-existing and untouched), tests pass for `pkg/kvdb`, `clients/http/auth/...`, and the stream package.