### PR TITLE
fix(vm-orbit): decode f64 host-function returns correctly (#437)

### DIFF
--- a/pkg/vm-orbit/satellite/vm/instance.go
+++ b/pkg/vm-orbit/satellite/vm/instance.go
@@ -90,7 +90,7 @@ func (p *pluginInstance) makeFunc(paramTypes []reflect.Type, retTypes []reflect.
 					_out[idx] = reflect.ValueOf(int64(cOut[idx]))
 				case vm.F32Type:
 					_out[idx] = reflect.ValueOf(math.Float32frombits(uint32(cOut[idx])))
-				case vm.I64Type:
+				case vm.F64Type:
 					_out[idx] = reflect.ValueOf(math.Float64frombits(cOut[idx]))
 				}
 			}

--- a/pkg/vm-orbit/tests/e2e/go/e2e_test.go
+++ b/pkg/vm-orbit/tests/e2e/go/e2e_test.go
@@ -43,6 +43,19 @@ func TestPlugin(t *testing.T) {
 	testReturn(t, ret, 47)
 }
 
+// TestFloat64Return reproduces issue #437: a satellite host function returning
+// an f64 was decoded with a duplicated I64Type switch case, so the guest never
+// received the float. ping returns 1 only when 5.5 round-trips intact.
+func TestFloat64Return(t *testing.T) {
+	assert.NilError(t, initializePlugin())
+	plugin, err := vmPlugin.Load(pluginBinary, context.Background())
+	assert.NilError(t, err)
+	defer plugin.Close()
+
+	ret := basicCall(t, plugin, path.Join(fixtureDir, "float_return.wasm"), uint32(5))
+	testReturn(t, ret, 1)
+}
+
 func TestConcurrentPlugin(t *testing.T) {
 	// Ensure default plugin (addVal=42) so ping(5) returns 47.
 	assert.NilError(t, initializePlugin())

--- a/pkg/vm-orbit/tests/e2e/go/fixtures/_code/float_return.go
+++ b/pkg/vm-orbit/tests/e2e/go/fixtures/_code/float_return.go
@@ -1,0 +1,16 @@
+package lib
+
+//go:wasm-module testing
+//export getFloat64
+func getFloat64(val uint32) float64
+
+//export ping
+func ping(val uint32) uint32 {
+	// Pre-fix (#437) the satellite plugin decodes an f64 host return with the
+	// wrong reflect case, so the guest never gets 5.5 back. Returns 1 only when
+	// the float64 round-trips intact.
+	if getFloat64(val) != float64(val)+0.5 {
+		return 0
+	}
+	return 1
+}

--- a/pkg/vm-orbit/tests/e2e/go/fixtures/plugin/main.go
+++ b/pkg/vm-orbit/tests/e2e/go/fixtures/plugin/main.go
@@ -25,6 +25,11 @@ func (t *tester) W_add42(ctx context.Context, module satellite.Module, stringPtr
 	return uint32(val) + addVal
 }
 
+// W_getFloat64 exercises the satellite->guest f64 result path (issue #437).
+func (t *tester) W_getFloat64(ctx context.Context, module satellite.Module, val uint32) float64 {
+	return float64(val) + 0.5
+}
+
 func (t *tester) W_readWritePlus1(
 	ctx context.Context,
 	module satellite.Module,

--- a/pkg/vm-orbit/tests/e2e/go/utils_test.go
+++ b/pkg/vm-orbit/tests/e2e/go/utils_test.go
@@ -20,7 +20,7 @@ var (
 	basicWasm    string
 	pluginBinary string
 
-	wasmFixtures = []string{"data_helpers", "size_helpers", "basic"}
+	wasmFixtures = []string{"data_helpers", "size_helpers", "basic", "float_return"}
 	pluginName   = "testPlugin"
 )
 


### PR DESCRIPTION
## What

Fixes #437.

`makeFunc` in `pkg/vm-orbit/satellite/vm/instance.go` decodes a satellite host function's return values with a `switch retTypes[idx]`. The `vm.I64Type` case was **duplicated** — the second one, which should have been `vm.F64Type`, ran `math.Float64frombits`. So a host function returning a `float64` matched no case, leaving `_out[idx]` as a zero `reflect.Value`. wazero then rejected the call:

```
reflect: function created by MakeFunc using closure returned zero Value
```

One-line fix: the fourth case is now `vm.F64Type`.

## Reproduction / test

Guarded by a new e2e test in the existing `pkg/vm-orbit/tests/e2e/go` suite:

- `W_getFloat64` host function added to the plugin fixture (returns `float64(val)+0.5`)
- `float_return` WASM fixture calls it and checks the value round-trips
- `TestFloat64Return` asserts the guest gets the float back

Before the fix the test fails with the wazero error above; after, it passes. Full e2e suite green.

## Scope

Only the satellite/orbit (out-of-process, RPC) host-function path was affected — builtin SDK host modules don't go through this decode. No shipped plugin currently returns an f64, which is why it went unnoticed.