### PR TITLE
fix(tau-cli): build in a disposable sandbox, not the user's source tree (#432)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/docker/go-connections v0.5.0
 	github.com/ethereum/go-ethereum v1.12.0
 	github.com/fsnotify/fsnotify v1.7.0
+	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-webauthn/webauthn v0.17.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v71 v71.0.0
@@ -166,7 +167,6 @@ require (
 	github.com/gammazero/deque v1.0.0 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
-	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/tools/tau/cli/commands/build/builder_inject.go
+++ b/tools/tau/cli/commands/build/builder_inject.go
@@ -9,6 +9,39 @@ import (
 )
 
 // newBuilder creates a builder for the given workDir. Tests can override newBuilderFunc to inject a mock.
+//
+// The builder bind-mounts workDir into the build container as writable, so build
+// images can write back into the user's source tree. To keep local builds
+// predictable, we copy workDir into a temp sandbox and build against that. The
+// sandbox is removed when the returned Builder is Closed.
 var newBuilderFunc = func(ctx context.Context, output io.Writer, workDir string) (builders.Builder, error) {
-	return build.New(ctx, output, workDir)
+	return sandboxedBuild(ctx, output, workDir, build.New)
+}
+
+// sandboxedBuild copies workDir into a disposable sandbox and builds against it,
+// so nothing the build container writes lands in the user's source tree. inner
+// is the real builder factory (build.New); it is a parameter so the sandboxing
+// wiring can be tested without docker.
+func sandboxedBuild(ctx context.Context, output io.Writer, workDir string, inner func(context.Context, io.Writer, string) (builders.Builder, error)) (builders.Builder, error) {
+	sandbox, cleanup, err := sandboxSource(workDir)
+	if err != nil {
+		return nil, err
+	}
+	b, err := inner(ctx, output, sandbox)
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+	return &sandboxedBuilder{Builder: b, cleanup: cleanup}, nil
+}
+
+type sandboxedBuilder struct {
+	builders.Builder
+	cleanup func()
+}
+
+func (s *sandboxedBuilder) Close() error {
+	err := s.Builder.Close()
+	s.cleanup()
+	return err
 }

--- a/tools/tau/cli/commands/build/sandbox.go
+++ b/tools/tau/cli/commands/build/sandbox.go
@@ -1,0 +1,108 @@
+package build
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+)
+
+// sandboxSource copies srcDir into a fresh temp directory and returns its path.
+// Files matched by .gitignore (anywhere in the tree) are skipped — keeping the
+// sandbox small and avoiding stale build caches (node_modules, target/, etc.)
+// from leaking into a fresh build. The returned cleanup removes the temp dir;
+// callers should defer it.
+//
+// Rationale: the local CLI shares the user's project directory with the build
+// container as a writable bind mount. Build images routinely create caches,
+// lockfiles, and symlinks under that directory, polluting the user's source
+// tree. Copying into an isolated sandbox makes each build's filesystem effects
+// predictable and disposable. Production (monkey) does not need this because
+// it git-clones a fresh ephemeral workdir per job.
+func sandboxSource(srcDir string) (sandbox string, cleanup func(), err error) {
+	sandbox, err = os.MkdirTemp("", "tau-build-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating sandbox: %w", err)
+	}
+	cleanup = func() { os.RemoveAll(sandbox) }
+
+	ignored, err := loadIgnoreMatcher(srcDir)
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("loading .gitignore in %s: %w", srcDir, err)
+	}
+
+	if err := copyTree(srcDir, sandbox, ignored); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("copying %s to sandbox: %w", srcDir, err)
+	}
+	return sandbox, cleanup, nil
+}
+
+func loadIgnoreMatcher(srcDir string) (gitignore.Matcher, error) {
+	patterns, err := gitignore.ReadPatterns(osfs.New(srcDir), nil)
+	if err != nil {
+		return nil, err
+	}
+	return gitignore.NewMatcher(patterns), nil
+}
+
+func copyTree(src, dst string, ignored gitignore.Matcher) error {
+	return filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+
+		parts := strings.Split(filepath.ToSlash(rel), "/")
+		if ignored.Match(parts, info.IsDir()) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		target := filepath.Join(dst, rel)
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			link, err := os.Readlink(p)
+			if err != nil {
+				return err
+			}
+			return os.Symlink(link, target)
+		case info.IsDir():
+			return os.MkdirAll(target, info.Mode().Perm())
+		case info.Mode().IsRegular():
+			return copyFile(p, target, info.Mode().Perm())
+		default:
+			return nil
+		}
+	})
+}
+
+func copyFile(src, dst string, perm os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/tools/tau/cli/commands/build/sandbox_test.go
+++ b/tools/tau/cli/commands/build/sandbox_test.go
@@ -1,0 +1,119 @@
+package build
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/taubyte/tau/core/builders"
+	"gotest.tools/v3/assert"
+)
+
+func TestSandboxSource_CopiesTreeAndRespectsGitignore(t *testing.T) {
+	src := t.TempDir()
+
+	mustWrite(t, filepath.Join(src, "main.go"), "package main\n")
+	mustWrite(t, filepath.Join(src, ".gitignore"), "node_modules/\n*.log\n!keep.log\n")
+	mustWrite(t, filepath.Join(src, "node_modules", "pkg", "index.js"), "// big\n")
+	mustWrite(t, filepath.Join(src, "debug.log"), "noise\n")
+	mustWrite(t, filepath.Join(src, "keep.log"), "wanted\n")
+	mustWrite(t, filepath.Join(src, "sub", "ok.txt"), "ok\n")
+	mustWrite(t, filepath.Join(src, "sub", ".gitignore"), "secret.txt\n")
+	mustWrite(t, filepath.Join(src, "sub", "secret.txt"), "shh\n")
+
+	sandbox, cleanup, err := sandboxSource(src)
+	assert.NilError(t, err)
+	defer cleanup()
+
+	assertExists(t, filepath.Join(sandbox, "main.go"))
+	assertExists(t, filepath.Join(sandbox, ".gitignore"))
+	assertExists(t, filepath.Join(sandbox, "keep.log"))
+	assertExists(t, filepath.Join(sandbox, "sub", "ok.txt"))
+
+	assertMissing(t, filepath.Join(sandbox, "node_modules"))
+	assertMissing(t, filepath.Join(sandbox, "debug.log"))
+	assertMissing(t, filepath.Join(sandbox, "sub", "secret.txt"))
+}
+
+func TestSandboxSource_CleanupRemovesSandbox(t *testing.T) {
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "a.txt"), "a\n")
+
+	sandbox, cleanup, err := sandboxSource(src)
+	assert.NilError(t, err)
+	assertExists(t, sandbox)
+
+	cleanup()
+	_, err = os.Stat(sandbox)
+	assert.Assert(t, os.IsNotExist(err), "sandbox should be removed, got err=%v", err)
+}
+
+func TestSandboxSource_PreservesSymlinks(t *testing.T) {
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "target.txt"), "hi\n")
+	assert.NilError(t, os.Symlink("target.txt", filepath.Join(src, "link.txt")))
+
+	sandbox, cleanup, err := sandboxSource(src)
+	assert.NilError(t, err)
+	defer cleanup()
+
+	link := filepath.Join(sandbox, "link.txt")
+	info, err := os.Lstat(link)
+	assert.NilError(t, err)
+	assert.Assert(t, info.Mode()&os.ModeSymlink != 0, "expected symlink, got %v", info.Mode())
+	dest, err := os.Readlink(link)
+	assert.NilError(t, err)
+	assert.Equal(t, dest, "target.txt")
+}
+
+// TestSandboxedBuild_BuildsFromSandboxNotSource is the regression guard for #432:
+// the builder must be constructed against a disposable sandbox, not the user's
+// workDir, and the sandbox must be removed on Close. Guards against the sandbox
+// being unwired from newBuilderFunc (which is how the original fix got lost).
+func TestSandboxedBuild_BuildsFromSandboxNotSource(t *testing.T) {
+	workDir := t.TempDir()
+	mustWrite(t, filepath.Join(workDir, "main.go"), "package main\n")
+
+	var builtFrom string
+	inner := func(_ context.Context, _ io.Writer, dir string) (builders.Builder, error) {
+		builtFrom = dir
+		return &mockBuilder{}, nil
+	}
+
+	b, err := sandboxedBuild(context.Background(), io.Discard, workDir, inner)
+	assert.NilError(t, err)
+
+	// built from a sandbox copy, not the user's source dir
+	assert.Assert(t, builtFrom != workDir, "build ran against the user's source dir")
+	assert.Assert(t, builtFrom != "" && builtFrom != workDir)
+	assertExists(t, filepath.Join(builtFrom, "main.go"))
+
+	// simulate the container polluting the sandbox; the user's dir stays clean
+	mustWrite(t, filepath.Join(builtFrom, "node_modules", "junk.js"), "x\n")
+	assertMissing(t, filepath.Join(workDir, "node_modules"))
+
+	// Close disposes the sandbox
+	assert.NilError(t, b.Close())
+	_, err = os.Stat(builtFrom)
+	assert.Assert(t, os.IsNotExist(err), "sandbox should be removed after Close, got err=%v", err)
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	assert.NilError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	assert.NilError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func assertExists(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	assert.NilError(t, err, "expected %s to exist", path)
+}
+
+func assertMissing(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	assert.Assert(t, os.IsNotExist(err), "expected %s to be absent, got err=%v", path, err)
+}


### PR DESCRIPTION
Fixes #432. Supersedes #433 (rebased onto current `main`, with an added wiring test).

## Problem

`tau build function|website|library` bind-mounts the local project directory into the build container **writable** (`pkg/specs/builders/common/methods.go` `SetSourceVolume` → docker mount `ReadOnly:false`). Build images routinely write back into that directory — package caches, lockfiles, toolchain symlinks, generated artifacts — polluting the user's source tree with non-deterministic state.

Production (`monkey`) is unaffected: it passes `git.Temporary()` ephemeral workdirs per job. Only the local CLI path shares the user's persistent dir.

## Reproduced (in /tmp)

Drove the real build path (`newBuilderFunc`) against a throwaway 3-file function project. **Before:** the source tree gained `node_modules/`, `package-lock.json`, `toolchain-symlink`. **After the fix:** source tree unchanged, build runs entirely in the sandbox.

## Fix

`newBuilderFunc` now copies `workDir` into a fresh temp sandbox and builds against that; the sandbox is removed on `Builder.Close()`.

- `.gitignore` is honored (via go-git's matcher) so `node_modules/`, `target/`, etc. are not copied — small, fast, no stale caches.
- Symlinks are preserved.
- `go-billy/v5` promoted to a direct dependency (already in the module graph; `go.sum` unchanged).

## Tests

- `TestSandboxSource_*` — copy honors `.gitignore` (incl. nested + negation), preserves symlinks, cleanup removes the temp dir.
- `TestSandboxedBuild_BuildsFromSandboxNotSource` — **regression guard**: the builder is constructed against the sandbox, not `workDir`; a simulated container write does not touch the user's dir; `Close()` disposes the sandbox. This specifically guards against the sandbox being unwired from `newBuilderFunc` — which is how the original fix (#433) got orphaned when only the injection-point scaffolding landed.

Existing mock-builder tests still pass.

> Note: this is a CLI + docker issue, so it is not reproducible via a `dream` universe; verified locally instead.