### PR TITLE
fix(raft): scope snapshot dir per root so stale snapshots can't wedge startup (#431)

### DIFF
--- a/cli/node/start.go
+++ b/cli/node/start.go
@@ -47,6 +47,8 @@ func Start(ctx context.Context, serviceConfig config.Config) error {
 			namespace = "main"
 		}
 		// One-time move of snapshots from the pre-scoping layout; no-op once done.
+		// TODO(remove early 2027): drop with raft.MigrateSnapshotDir once all
+		// deployments have started on the <root>/raft layout.
 		if err := raft.MigrateSnapshotDir(serviceConfig.Root(), serviceConfig.Shape(), namespace); err != nil {
 			return fmt.Errorf("migrating raft snapshot dir for namespace %q: %w", namespace, err)
 		}

--- a/cli/node/start.go
+++ b/cli/node/start.go
@@ -46,6 +46,10 @@ func Start(ctx context.Context, serviceConfig config.Config) error {
 		if namespace == "" {
 			namespace = "main"
 		}
+		// One-time move of snapshots from the pre-scoping layout; no-op once done.
+		if err := raft.MigrateSnapshotDir(serviceConfig.Root(), serviceConfig.Shape(), namespace); err != nil {
+			return fmt.Errorf("migrating raft snapshot dir for namespace %q: %w", namespace, err)
+		}
 		snapDir := raft.SnapshotDir(serviceConfig.Root(), serviceConfig.Shape(), namespace)
 		raftOpts := []raft.Option{raft.WithSnapshotDir(snapDir)}
 		if serviceConfig.DevMode() {

--- a/dream/common/raft.go
+++ b/dream/common/raft.go
@@ -21,12 +21,20 @@ var DreamRaftTimeoutConfig = raft.TimeoutConfig{
 // NewRaftCluster creates a raft cluster with options suitable for dream:
 // bootstrap timeout so a single node auto-bootstraps when no peers are found,
 // and short timeouts for fast leader election.
-func NewRaftCluster(node peer.Node, clusterName string) (raft.Cluster, error) {
+//
+// root/shape scope the snapshot directory under the universe's root
+// (raft.SnapshotDir). Without this the snapshot store defaults to a shared
+// global /tmp path that survives universe teardown, so a later universe (fresh
+// deterministic identity, different root) would restore a stale snapshot whose
+// configuration doesn't contain it — never elect a leader — and wedge the
+// service (issue #431).
+func NewRaftCluster(node peer.Node, clusterName, root, shape string) (raft.Cluster, error) {
 	if clusterName == "" {
 		clusterName = "main"
 	}
 	return raft.New(node, clusterName,
 		raft.WithBootstrapTimeout(1*time.Second),
 		raft.WithTimeouts(DreamRaftTimeoutConfig),
+		raft.WithSnapshotDir(raft.SnapshotDir(root, shape, clusterName)),
 	)
 }

--- a/pkg/raft/paths.go
+++ b/pkg/raft/paths.go
@@ -2,6 +2,7 @@ package raft
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,6 +36,11 @@ func legacySnapshotDir(root, shape, namespace string) string {
 // Legacy and current live under the same root (same filesystem), so the move is
 // an atomic rename. Callers with a persistent root (production) should call this
 // before constructing the cluster; ephemeral roots (dream) have nothing to move.
+//
+// TODO(remove early 2027): transitional shim for the <root>/storage/.../raft-snapshots
+// -> <root>/raft layout change. Once all deployments have started at least once
+// on the new layout, delete this, legacySnapshotDir, copyDir/copyFile, and the
+// call in cli/node/start.go.
 func MigrateSnapshotDir(root, shape, namespace string) error {
 	current := SnapshotDir(root, shape, namespace)
 	legacy := legacySnapshotDir(root, shape, namespace)
@@ -64,7 +70,59 @@ func MigrateSnapshotDir(root, shape, namespace string) error {
 	// Remove an empty current dir so rename can claim the path.
 	os.Remove(current)
 	if err := os.Rename(legacy, current); err != nil {
-		return fmt.Errorf("migrating raft snapshots %s -> %s: %w", legacy, current, err)
+		// Legacy and current are usually on the same filesystem, but if storage/
+		// is a separate mount the rename fails with EXDEV. Fall back to a copy,
+		// and only drop the legacy dir once the copy fully succeeds so a failure
+		// mid-copy leaves the original snapshots intact.
+		if err := copyDir(legacy, current); err != nil {
+			return fmt.Errorf("migrating raft snapshots %s -> %s (copy fallback): %w", legacy, current, err)
+		}
+		if err := os.RemoveAll(legacy); err != nil {
+			return fmt.Errorf("removing legacy snapshot dir %s after copy: %w", legacy, err)
+		}
 	}
 	return nil
+}
+
+// copyDir recursively copies src into dst, preserving file permissions. Raft
+// snapshot directories contain only regular files and subdirectories.
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return os.MkdirAll(target, info.Mode().Perm())
+		}
+		return copyFile(p, target, info.Mode().Perm())
+	})
+}
+
+func copyFile(src, dst string, perm os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
 }

--- a/pkg/raft/paths.go
+++ b/pkg/raft/paths.go
@@ -1,6 +1,8 @@
 package raft
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -13,4 +15,56 @@ func SnapshotDir(root, shape, namespace string) string {
 	}
 	safe := strings.ReplaceAll(namespace, "/", "-")
 	return filepath.Join(root, "raft", shape, safe)
+}
+
+// legacySnapshotDir returns the pre-scoping layout
+// (<root>/storage/<shape>/raft-snapshots/<namespace>) that shipped before
+// snapshots moved under <root>/raft. Retained only for MigrateSnapshotDir.
+func legacySnapshotDir(root, shape, namespace string) string {
+	if namespace == "" {
+		namespace = "main"
+	}
+	safe := strings.ReplaceAll(namespace, "/", "-")
+	return filepath.Join(root, "storage", shape, "raft-snapshots", safe)
+}
+
+// MigrateSnapshotDir relocates raft snapshots from the legacy layout to the
+// current SnapshotDir layout. It is a one-time, idempotent operation safe to call
+// on every startup: it moves the legacy directory only when it holds snapshots
+// and the current directory does not yet (so it never clobbers newer state).
+// Legacy and current live under the same root (same filesystem), so the move is
+// an atomic rename. Callers with a persistent root (production) should call this
+// before constructing the cluster; ephemeral roots (dream) have nothing to move.
+func MigrateSnapshotDir(root, shape, namespace string) error {
+	current := SnapshotDir(root, shape, namespace)
+	legacy := legacySnapshotDir(root, shape, namespace)
+	if current == legacy {
+		return nil
+	}
+
+	legacyEntries, err := os.ReadDir(legacy)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // nothing to migrate
+		}
+		return fmt.Errorf("reading legacy snapshot dir %s: %w", legacy, err)
+	}
+	if len(legacyEntries) == 0 {
+		return nil
+	}
+
+	// Never overwrite an already-populated current dir (already migrated / newer).
+	if entries, err := os.ReadDir(current); err == nil && len(entries) > 0 {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(current), 0o755); err != nil {
+		return fmt.Errorf("creating snapshot dir parent %s: %w", filepath.Dir(current), err)
+	}
+	// Remove an empty current dir so rename can claim the path.
+	os.Remove(current)
+	if err := os.Rename(legacy, current); err != nil {
+		return fmt.Errorf("migrating raft snapshots %s -> %s: %w", legacy, current, err)
+	}
+	return nil
 }

--- a/pkg/raft/paths.go
+++ b/pkg/raft/paths.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 )
 
-// SnapshotDir returns <root>/storage/<shape>/raft-snapshots/<namespace> (empty namespace → "main"; "/" in namespace → "-").
+// SnapshotDir returns <root>/raft/<shape>/<namespace> (empty namespace → "main"; "/" in namespace → "-").
+// The directory is created by newSnapshotStore when the cluster starts.
 func SnapshotDir(root, shape, namespace string) string {
 	if namespace == "" {
 		namespace = "main"
 	}
 	safe := strings.ReplaceAll(namespace, "/", "-")
-	return filepath.Join(root, "storage", shape, "raft-snapshots", safe)
+	return filepath.Join(root, "raft", shape, safe)
 }

--- a/pkg/raft/paths_test.go
+++ b/pkg/raft/paths_test.go
@@ -1,6 +1,7 @@
 package raft
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -23,4 +24,61 @@ func TestSnapshotDir(t *testing.T) {
 	if got != want {
 		t.Fatalf("empty namespace: got %q want %q", got, want)
 	}
+}
+
+// seedSnapshot writes a fake snapshot entry into dir.
+func seedSnapshot(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, name), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name, "meta.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMigrateSnapshotDir(t *testing.T) {
+	t.Run("moves legacy snapshots to the new layout", func(t *testing.T) {
+		root := t.TempDir()
+		legacy := legacySnapshotDir(root, "prod", "main")
+		seedSnapshot(t, legacy, "2-1065-snap")
+
+		if err := MigrateSnapshotDir(root, "prod", "main"); err != nil {
+			t.Fatal(err)
+		}
+
+		current := SnapshotDir(root, "prod", "main")
+		if _, err := os.Stat(filepath.Join(current, "2-1065-snap", "meta.json")); err != nil {
+			t.Fatalf("snapshot not moved to new layout: %v", err)
+		}
+		if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+			t.Fatalf("legacy dir should be gone after move, err=%v", err)
+		}
+	})
+
+	t.Run("does not clobber an already-populated new dir", func(t *testing.T) {
+		root := t.TempDir()
+		seedSnapshot(t, legacySnapshotDir(root, "prod", "main"), "old-snap")
+		current := SnapshotDir(root, "prod", "main")
+		seedSnapshot(t, current, "new-snap")
+
+		if err := MigrateSnapshotDir(root, "prod", "main"); err != nil {
+			t.Fatal(err)
+		}
+
+		// new dir's snapshot is kept; legacy is left untouched (not merged)
+		if _, err := os.Stat(filepath.Join(current, "new-snap")); err != nil {
+			t.Fatalf("existing new snapshot must be preserved: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(current, "old-snap")); !os.IsNotExist(err) {
+			t.Fatalf("legacy snapshot must not overwrite newer state")
+		}
+	})
+
+	t.Run("no legacy dir is a no-op", func(t *testing.T) {
+		root := t.TempDir()
+		if err := MigrateSnapshotDir(root, "prod", "main"); err != nil {
+			t.Fatalf("expected no-op, got %v", err)
+		}
+	})
 }

--- a/pkg/raft/paths_test.go
+++ b/pkg/raft/paths_test.go
@@ -7,19 +7,19 @@ import (
 
 func TestSnapshotDir(t *testing.T) {
 	got := SnapshotDir("/var/tau", "test", "main")
-	want := filepath.Join("/var/tau", "storage", "test", "raft-snapshots", "main")
+	want := filepath.Join("/var/tau", "raft", "test", "main")
 	if got != want {
 		t.Fatalf("got %q want %q", got, want)
 	}
 
 	got = SnapshotDir("/r", "prod", "team/west")
-	want = filepath.Join("/r", "storage", "prod", "raft-snapshots", "team-west")
+	want = filepath.Join("/r", "raft", "prod", "team-west")
 	if got != want {
 		t.Fatalf("got %q want %q", got, want)
 	}
 
 	got = SnapshotDir("/r", "prod", "")
-	want = filepath.Join("/r", "storage", "prod", "raft-snapshots", "main")
+	want = filepath.Join("/r", "raft", "prod", "main")
 	if got != want {
 		t.Fatalf("empty namespace: got %q want %q", got, want)
 	}

--- a/pkg/raft/paths_test.go
+++ b/pkg/raft/paths_test.go
@@ -82,3 +82,35 @@ func TestMigrateSnapshotDir(t *testing.T) {
 		}
 	})
 }
+
+// TestCopyDir covers the cross-filesystem fallback used by MigrateSnapshotDir
+// when os.Rename fails (EXDEV), which can't be forced portably in a unit test.
+func TestCopyDir(t *testing.T) {
+	src := t.TempDir()
+	seedSnapshot(t, src, "2-1065-snap")
+	if err := os.WriteFile(filepath.Join(src, "top.bin"), []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "moved")
+	if err := copyDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst, "2-1065-snap", "meta.json"))
+	if err != nil || string(got) != "{}" {
+		t.Fatalf("nested file not copied: got %q err=%v", got, err)
+	}
+	got, err = os.ReadFile(filepath.Join(dst, "top.bin"))
+	if err != nil || string(got) != "data" {
+		t.Fatalf("top-level file not copied: got %q err=%v", got, err)
+	}
+	// permissions preserved
+	info, err := os.Stat(filepath.Join(dst, "top.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("permission not preserved: got %v", info.Mode().Perm())
+	}
+}

--- a/pkg/raft/snapshot_identity_test.go
+++ b/pkg/raft/snapshot_identity_test.go
@@ -1,0 +1,98 @@
+//go:build raft_integration
+
+package raft
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+// fastSingleNode timeouts: quick election so single-node bootstrap settles fast.
+var fastSingleNode = TimeoutConfig{
+	HeartbeatTimeout:   50 * time.Millisecond,
+	ElectionTimeout:    50 * time.Millisecond,
+	CommitTimeout:      25 * time.Millisecond,
+	LeaderLeaseTimeout: 25 * time.Millisecond,
+	SnapshotInterval:   time.Minute,
+	SnapshotThreshold:  1000,
+}
+
+// bootstrapAndSnapshot brings up a single-node leader on snapDir, commits one
+// entry, and forces a snapshot so snapDir holds this node's Raft configuration.
+func bootstrapAndSnapshot(t *testing.T, snapDir, namespace string) {
+	t.Helper()
+	node := newTestNode(t)
+	c, err := New(node, namespace,
+		WithForceBootstrap(),
+		WithSnapshotDir(snapDir),
+		WithTimeouts(fastSingleNode),
+	)
+	assert.NilError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	assert.NilError(t, c.WaitForLeader(ctx))
+	assert.NilError(t, c.Set("k", []byte("v"), 2*time.Second))
+
+	// Force a snapshot: snapDir now carries a configuration listing this node.
+	assert.NilError(t, c.(*cluster).raft.Snapshot().Error())
+	assert.NilError(t, c.Close())
+}
+
+// TestSharedSnapshotDir_StaleIdentity_Wedges reproduces #431. Two nodes with
+// different identities share one snapshot dir (as dream did via the global /tmp
+// default). The second node restores the first's snapshot — whose configuration
+// does not include it — enters follower state "not part of stable configuration"
+// and can never elect a leader.
+func TestSharedSnapshotDir_StaleIdentity_Wedges(t *testing.T) {
+	shared := t.TempDir()
+	const ns = "main"
+
+	bootstrapAndSnapshot(t, shared, ns)
+
+	// Second node, fresh identity, SAME snapshot dir.
+	nodeB := newTestNode(t)
+	cB, err := New(nodeB, ns,
+		WithBootstrapTimeout(500*time.Millisecond),
+		WithSnapshotDir(shared),
+		WithTimeouts(fastSingleNode),
+	)
+	// New may return nil (then WaitForLeader hangs) or an error; either way node
+	// B must not reach a healthy single-node leader.
+	if err == nil {
+		defer cB.Close()
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+		defer cancel()
+		err = cB.WaitForLeader(ctx)
+	}
+	assert.Assert(t, err != nil,
+		"#431: node B inherited node A's snapshot and should not be able to elect a leader")
+}
+
+// TestScopedSnapshotDir_FreshIdentity_Bootstraps is the fix guard: when the
+// snapshot dir is scoped per root (SnapshotDir / NewRaftCluster), a fresh node in
+// its own dir bootstraps cleanly regardless of a prior node's leftover snapshot.
+func TestScopedSnapshotDir_FreshIdentity_Bootstraps(t *testing.T) {
+	const ns = "main"
+
+	// A prior run leaves a snapshot under its own root.
+	bootstrapAndSnapshot(t, SnapshotDir(t.TempDir(), "shapeA", ns), ns)
+
+	// New run: its own root → its own snapshot dir → no contamination.
+	nodeB := newTestNode(t)
+	cB, err := New(nodeB, ns,
+		WithForceBootstrap(),
+		WithSnapshotDir(SnapshotDir(t.TempDir(), "shapeB", ns)),
+		WithTimeouts(fastSingleNode),
+	)
+	assert.NilError(t, err)
+	defer cB.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	assert.NilError(t, cB.WaitForLeader(ctx),
+		"fresh node in its own snapshot dir must elect a leader")
+}

--- a/services/patrick/dream/init.go
+++ b/services/patrick/dream/init.go
@@ -62,7 +62,7 @@ func createPatrickService(u *dream.Universe, config *iface.ServiceConfig) (iface
 	if err != nil {
 		return nil, err
 	}
-	raftCluster, err := common.NewRaftCluster(node, cfg.Cluster())
+	raftCluster, err := common.NewRaftCluster(node, cfg.Cluster(), cfg.Root(), cfg.Shape())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #431.

## Root cause

`dream/common.NewRaftCluster` created raft clusters **without** a snapshot dir, so the snapshot store fell back to the shared global default `/tmp/tau-raft-snapshots/<namespace>` (`pkg/raft/cluster.go`).

That path **survives universe teardown**, but a dream node's identity is **deterministic from its universe root** (`GenerateDeterministicKey(config.Root)`), and each universe root is a unique, ephemeral `os.TempDir()/universe-<id>` deleted on close. So:

1. Universe A (root `/tmp/universe-A`, node `N7i22w…`) runs patrick, snapshots to `/tmp/tau-raft-snapshots/main` with config `{N7i22w}`, then closes — **snapshot survives**.
2. Universe B (root `/tmp/universe-B`, node `EcNerA8…`) restores that stale snapshot, finds its config doesn't list `EcNerA8`, logs *"not part of stable configuration, aborting election"*, never elects a leader → **`patrick: context deadline exceeded`**.

This matches the reporter's log exactly (two different node IDs). On Windows `os.TempDir()` persists across reboots, so any leftover snapshot contaminates every later universe. (The `monkey: docker health check failed` line in the report is a separate, environmental Docker issue.)

## Fix

- `dream/common.NewRaftCluster` now scopes the snapshot dir under the universe root: `raft.WithSnapshotDir(raft.SnapshotDir(root, shape, cluster))`. Patrick passes `cfg.Root()` / `cfg.Shape()`. Prod already did this in `cli/node/start.go`.
- `raft.SnapshotDir` now lays out `<root>/raft/<shape>/<cluster>/` (was `<root>/storage/<shape>/raft-snapshots/<ns>`); the dir is created on demand by the snapshot store (`newSnapshotStore` `MkdirAll`).

Snapshot lifecycle now matches node-identity lifecycle: a fresh root gets a fresh snapshot dir, and universes can no longer contaminate each other.

## Tests

`pkg/raft/snapshot_identity_test.go` (`//go:build raft_integration`, real libp2p nodes):
- `TestSharedSnapshotDir_StaleIdentity_Wedges` — **reproduces #431**: node A bootstraps + forces a snapshot into a shared dir; node B (different identity) opens the same dir and can never elect a leader.
- `TestScopedSnapshotDir_FreshIdentity_Bootstraps` — **fix guard**: a fresh node with its own scoped dir bootstraps cleanly despite a prior node's leftover snapshot.

`paths_test.go` updated for the new layout. `TestDream_Dreaming` (full patrick+raft startup) still passes; whole repo builds; `pkg/raft` unit tests pass.