### PR TITLE
fix(ci): scope GITHUB_TOKEN permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
     tags:
       - '*'
 
+# GoReleaser publishes with GORELEASER_TOKEN (see env below); the default
+# token is only used by checkout, so read is enough.
+permissions:
+  contents: read
+
 jobs:
   tau:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes CodeQL code-scanning alert #2 (`actions/missing-workflow-permissions`, medium).

`.github/workflows/release.yml` had no `permissions:` block, so `GITHUB_TOKEN` inherited broad default write scopes. GoReleaser publishes the release using the dedicated `GORELEASER_TOKEN` (overriding `GITHUB_TOKEN` via `env`), so the workflow's default token is only used by `actions/checkout` — `contents: read` is sufficient and least-privilege.