### PR TITLE
fix: correct suceeded→succeeded typo in stash.go

### DIFF
--- a/services/monkey/jobs/stash.go
+++ b/services/monkey/jobs/stash.go
@@ -31,7 +31,7 @@ func (c Context) StashBuildFile(zip io.ReadSeekCloser) (cid string, err error) {
 						logger.Errorf("stashing `%s` failed with: %s", cid, err.Error())
 						continue
 					} else {
-						logger.Infof("stashing `%s` suceeded", cid)
+						logger.Infof("stashing `%s` succeeded", cid)
 						return
 					}
 				}


### PR DESCRIPTION
Correct `suceeded` → `succeeded` typo in logger.Infof message (services/monkey/jobs/stash.go line 34).

1 file, 1 line change. User-facing log message when stashing operation succeeds.

Gate-1✅(new) Gate-2✅(1 OPEN < 2) Gate-3✅(1 commit)