### PR TITLE
feat(migration): move node-local project data to hoarder-hosted instances

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -59,6 +59,7 @@ func newApp() *cli.App {
 			buildInfoCommand(),
 			startCommand(),
 			configCommand(),
+			exportDataCommand(),
 		},
 	}
 

--- a/cli/app/export_cmd.go
+++ b/cli/app/export_cmd.go
@@ -1,0 +1,191 @@
+package app
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	"github.com/ipfs/boxo/blockservice"
+	"github.com/ipfs/boxo/blockstore"
+	offline "github.com/ipfs/boxo/exchange/offline"
+	"github.com/ipfs/boxo/ipld/merkledag"
+	unixfile "github.com/ipfs/boxo/ipld/unixfs/file"
+	"github.com/ipfs/go-cid"
+	ds "github.com/ipfs/go-datastore"
+	helpers "github.com/taubyte/tau/p2p/helpers"
+	"github.com/taubyte/tau/services/substrate/migration"
+	"github.com/urfave/cli/v2"
+)
+
+// exportDataCommand inspects and exports the project data still held in a
+// STOPPED node's datastore — the operator action path for namespaces the
+// data migration reports but cannot move (no naming config, or bytes below
+// the replica target). Read-only: it never writes to the store.
+func exportDataCommand() *cli.Command {
+	serviceFlag := &cli.StringFlag{
+		Name:  "service",
+		Value: "substrate",
+		Usage: "service whose data directory to open (under the tau root)",
+	}
+	return &cli.Command{
+		Name:  "export",
+		Usage: "inspect/export project data held in a stopped node's datastore (read-only)",
+		Subcommands: []*cli.Command{
+			{
+				Name:   "list",
+				Usage:  "list data namespaces and their key/file counts",
+				Flags:  []cli.Flag{serviceFlag},
+				Action: withNodeStore(exportList),
+			},
+			{
+				Name:  "dump",
+				Usage: "dump one namespace's keys/values as JSON",
+				Flags: []cli.Flag{
+					serviceFlag,
+					&cli.StringFlag{Name: "namespace", Usage: "namespace hash (see list)", Required: true},
+					&cli.StringFlag{Name: "out", Usage: "output file (default: stdout)"},
+				},
+				Action: withNodeStore(exportDump),
+			},
+			{
+				Name:  "file",
+				Usage: "extract a file's bytes from the local blockstore",
+				Flags: []cli.Flag{
+					serviceFlag,
+					&cli.StringFlag{Name: "cid", Usage: "file content CID (see dump)", Required: true},
+					&cli.StringFlag{Name: "out", Usage: "output file", Required: true},
+				},
+				Action: withNodeStore(exportFile),
+			},
+		},
+	}
+}
+
+// withNodeStore opens the service's datastore (<root>/<service>) read-side and
+// hands it to the action. A running node holds the store's lock — surface that
+// plainly.
+func withNodeStore(fn func(*cli.Context, ds.Batching) error) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		dataRoot := path.Join(c.Path("root"), c.String("service"))
+		if _, err := os.Stat(dataRoot); err != nil {
+			return fmt.Errorf("data root %q: %w", dataRoot, err)
+		}
+		store, err := helpers.NewDatastore(dataRoot)
+		if err != nil {
+			return fmt.Errorf("opening datastore at %q failed (is the node still running? it must be stopped): %w", dataRoot, err)
+		}
+		defer store.Close()
+		return fn(c, store)
+	}
+}
+
+func exportList(c *cli.Context, store ds.Batching) error {
+	ctx := c.Context
+	hashes, err := migration.Namespaces(ctx, store)
+	if err != nil {
+		return err
+	}
+	if len(hashes) == 0 {
+		fmt.Println("no data namespaces")
+		return nil
+	}
+	for _, h := range hashes {
+		entries, err := migration.Entries(ctx, store, h)
+		if err != nil {
+			fmt.Printf("%s\tkeys: ?\terror: %s\n", h, err)
+			continue
+		}
+		fmt.Printf("%s\tkeys: %d\tfiles: %d\n", h, len(entries), len(migration.FileCids(entries)))
+	}
+	return nil
+}
+
+type exportEntry struct {
+	Key         string `json:"key"`
+	ValueBase64 string `json:"value_base64"`
+}
+
+type exportDoc struct {
+	Namespace string        `json:"namespace"`
+	Entries   []exportEntry `json:"entries"`
+	FileCids  []exportRef   `json:"file_cids,omitempty"`
+}
+
+type exportRef struct {
+	Cid   string `json:"cid"`
+	Local bool   `json:"local"` // root block present in this store
+}
+
+func exportDump(c *cli.Context, store ds.Batching) error {
+	ctx := c.Context
+	hash := c.String("namespace")
+	entries, err := migration.Entries(ctx, store, hash)
+	if err != nil {
+		return err
+	}
+
+	doc := exportDoc{Namespace: hash, Entries: make([]exportEntry, 0, len(entries))}
+	for k, v := range entries {
+		doc.Entries = append(doc.Entries, exportEntry{Key: k, ValueBase64: base64.StdEncoding.EncodeToString(v)})
+	}
+
+	bs := blockstore.NewIdStore(blockstore.NewBlockstore(store))
+	for _, cs := range migration.FileCids(entries) {
+		ref := exportRef{Cid: cs}
+		if c, err := cid.Decode(cs); err == nil {
+			ref.Local, _ = bs.Has(ctx, c)
+		}
+		doc.FileCids = append(doc.FileCids, ref)
+	}
+
+	out := os.Stdout
+	if p := c.String("out"); p != "" {
+		f, err := os.Create(p)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		out = f
+	}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(doc)
+}
+
+func exportFile(c *cli.Context, store ds.Batching) error {
+	ctx := c.Context
+	root, err := cid.Decode(c.String("cid"))
+	if err != nil {
+		return fmt.Errorf("bad cid: %w", err)
+	}
+
+	bs := blockstore.NewIdStore(blockstore.NewBlockstore(store))
+	dag := merkledag.NewDAGService(blockservice.New(bs, offline.Exchange(bs)))
+	nd, err := dag.Get(ctx, root)
+	if err != nil {
+		return fmt.Errorf("reading %s from the local store failed with: %w", root, err)
+	}
+	f, err := unixfile.NewUnixfsFile(ctx, dag, nd)
+	if err != nil {
+		return fmt.Errorf("interpreting %s as a file failed with: %w", root, err)
+	}
+	r, ok := f.(io.Reader)
+	if !ok {
+		return fmt.Errorf("cid is a directory, not a file")
+	}
+
+	out, err := os.Create(c.String("out"))
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	n, err := io.Copy(out, r)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("wrote %d bytes to %s\n", n, c.String("out"))
+	return nil
+}

--- a/cli/app/export_cmd_test.go
+++ b/cli/app/export_cmd_test.go
@@ -1,0 +1,173 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ipfs/boxo/blockservice"
+	"github.com/ipfs/boxo/blockstore"
+	chunker "github.com/ipfs/boxo/chunker"
+	offline "github.com/ipfs/boxo/exchange/offline"
+	"github.com/ipfs/boxo/ipld/merkledag"
+	"github.com/ipfs/boxo/ipld/unixfs/importer/balanced"
+	ihelper "github.com/ipfs/boxo/ipld/unixfs/importer/helpers"
+	ds "github.com/ipfs/go-datastore"
+	crdt "github.com/ipfs/go-ds-crdt"
+	ipld "github.com/ipfs/go-ipld-format"
+	helpers "github.com/taubyte/tau/p2p/helpers"
+)
+
+// seedExportFixture writes a namespace into a service data dir under the tau
+// root, the same shape a node's kvdb layer leaves behind (/crdt/<hash>).
+func seedExportFixture(t *testing.T, root, service, hash string, entries map[string][]byte) {
+	t.Helper()
+	dataRoot := filepath.Join(root, service)
+	if err := os.MkdirAll(dataRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	store, err := helpers.NewDatastore(dataRoot)
+	if err != nil {
+		t.Fatalf("opening fixture store failed: %v", err)
+	}
+	defer store.Close()
+
+	bs := blockstore.NewIdStore(blockstore.NewBlockstore(store))
+	dag := merkledag.NewDAGService(blockservice.New(bs, offline.Exchange(bs)))
+	view, err := crdt.New(store, ds.NewKey("crdt/"+hash), dag, nil, crdt.DefaultOptions())
+	if err != nil {
+		t.Fatalf("opening fixture namespace failed: %v", err)
+	}
+	defer view.Close()
+	for k, v := range entries {
+		if err := view.Put(context.Background(), ds.NewKey(k), v); err != nil {
+			t.Fatalf("seeding key failed: %v", err)
+		}
+	}
+}
+
+func TestExportListAndDump(t *testing.T) {
+	root := t.TempDir()
+	hash := "fixturehash123"
+	seedExportFixture(t, root, "substrate", hash, map[string][]byte{
+		"/some/key": []byte("value"),
+		"/file/a/1": []byte("QmYwAPJzv5CZsnAzt8auVZRn1pfejgxk2GYDdVQGWvVFrH"), // not present locally
+	})
+
+	outFile := filepath.Join(t.TempDir(), "dump.json")
+	if err := newApp().Run([]string{"tau", "--root", root, "export", "dump", "--namespace", hash, "--out", outFile}); err != nil {
+		t.Fatalf("dump failed: %v", err)
+	}
+
+	raw, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc exportDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("dump output not JSON: %v", err)
+	}
+	if doc.Namespace != hash || len(doc.Entries) != 2 {
+		t.Fatalf("unexpected dump: %+v", doc)
+	}
+	if len(doc.FileCids) != 1 || doc.FileCids[0].Local {
+		t.Fatalf("file cid presence wrong (bytes are NOT local): %+v", doc.FileCids)
+	}
+
+	if err := newApp().Run([]string{"tau", "--root", root, "export", "list"}); err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+
+	// A service dir with no data namespaces lists nothing and succeeds.
+	if err := os.MkdirAll(filepath.Join(root, "hoarder"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := newApp().Run([]string{"tau", "--root", root, "export", "list", "--service", "hoarder"}); err != nil {
+		t.Fatalf("list on empty service failed: %v", err)
+	}
+
+	// Dumping a nonexistent namespace yields an empty doc, not an error.
+	if err := newApp().Run([]string{"tau", "--root", root, "export", "dump", "--namespace", "nope"}); err != nil {
+		t.Fatalf("dump of empty namespace should succeed: %v", err)
+	}
+}
+
+func TestExportFileBytes(t *testing.T) {
+	root := t.TempDir()
+	data := bytes.Repeat([]byte("file payload "), 4096) // multi-block
+
+	// Build a UnixFS DAG in the fixture store, the shape AddFile leaves behind.
+	dataRoot := filepath.Join(root, "substrate")
+	if err := os.MkdirAll(dataRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	store, err := helpers.NewDatastore(dataRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bs := blockstore.NewIdStore(blockstore.NewBlockstore(store))
+	dag := merkledag.NewDAGService(blockservice.New(bs, offline.Exchange(bs)))
+	nd, err := balanced.Layout(exportDagBuilder(t, dag, bytes.NewReader(data)))
+	if err != nil {
+		t.Fatalf("building file dag failed: %v", err)
+	}
+	store.Close()
+
+	out := filepath.Join(t.TempDir(), "exported.bin")
+	if err := newApp().Run([]string{"tau", "--root", root, "export", "file", "--cid", nd.Cid().String(), "--out", out}); err != nil {
+		t.Fatalf("export file failed: %v", err)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("exported bytes differ: %d vs %d", len(got), len(data))
+	}
+
+	// A CID the store has never seen fails plainly.
+	bad := nd.Cid().String()[:len(nd.Cid().String())-2] + "aa"
+	if err := newApp().Run([]string{"tau", "--root", root, "export", "file", "--cid", bad, "--out", out}); err == nil {
+		t.Fatal("expected an error for an unknown/invalid cid")
+	}
+}
+
+func exportDagBuilder(t *testing.T, dag ipld.DAGService, r io.Reader) *ihelper.DagBuilderHelper {
+	t.Helper()
+	params := ihelper.DagBuilderParams{Dagserv: dag, Maxlinks: ihelper.DefaultLinksPerBlock, CidBuilder: merkledag.V0CidPrefix()}
+	db, err := params.New(chunker.NewSizeSplitter(r, 16384))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func TestExportRefusesLockedOrMissingStore(t *testing.T) {
+	root := t.TempDir()
+	seedExportFixture(t, root, "substrate", "somehash", map[string][]byte{"/k": []byte("v")})
+
+	// Hold the store open, as a running node would.
+	store, err := helpers.NewDatastore(filepath.Join(root, "substrate"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	err = newApp().Run([]string{"tau", "--root", root, "export", "list"})
+	if err == nil {
+		t.Fatal("expected an error against a locked store")
+	}
+	if !strings.Contains(err.Error(), "stopped") {
+		t.Fatalf("error must tell the operator to stop the node, got: %v", err)
+	}
+
+	// A service dir that doesn't exist errors plainly.
+	if err := newApp().Run([]string{"tau", "--root", root, "export", "list", "--service", "nosuch"}); err == nil {
+		t.Fatal("expected an error for a missing service data dir")
+	}
+}

--- a/clients/p2p/hoarder/kvdb.go
+++ b/clients/p2p/hoarder/kvdb.go
@@ -48,6 +48,7 @@ type remoteKV struct {
 }
 
 var _ coreKvdb.KVDB = (*remoteKV)(nil)
+var _ hoarderIface.NxKVDB = (*remoteKV)(nil)
 
 func (r *remoteKV) instanceBody() command.Body {
 	return command.Body{
@@ -235,6 +236,18 @@ func (r *remoteKV) Get(ctx context.Context, key string) ([]byte, error) {
 func (r *remoteKV) Put(ctx context.Context, key string, v []byte) error {
 	_, err := r.do(ctx, command.Body{hoarderSpecs.BodyKVOp: hoarderSpecs.KVPut, hoarderSpecs.BodyKey: key, hoarderSpecs.BodyValue: v})
 	return err
+}
+
+// PutNx writes the key only if absent on the serving replica, atomically
+// against concurrent writes there. Returns existed=true when the key was
+// already present (nothing written).
+func (r *remoteKV) PutNx(ctx context.Context, key string, v []byte) (bool, error) {
+	resp, err := r.do(ctx, command.Body{hoarderSpecs.BodyKVOp: hoarderSpecs.KVPutNx, hoarderSpecs.BodyKey: key, hoarderSpecs.BodyValue: v})
+	if err != nil {
+		return false, err
+	}
+	existed, _ := maps.Bool(resp, hoarderSpecs.BodyExisted)
+	return existed, nil
 }
 
 func (r *remoteKV) Delete(ctx context.Context, key string) error {

--- a/clients/p2p/hoarder/metas.go
+++ b/clients/p2p/hoarder/metas.go
@@ -1,0 +1,71 @@
+package hoarder
+
+import (
+	"fmt"
+
+	hoarderIface "github.com/taubyte/tau/core/services/hoarder"
+	"github.com/taubyte/tau/p2p/streams/command"
+	hoarderSpecs "github.com/taubyte/tau/pkg/specs/hoarder"
+	"github.com/taubyte/tau/utils/maps"
+)
+
+// Metas resolves instance hashes to their placement identity records; hashes
+// with no record are omitted from the result.
+func (c *Client) Metas(hashes ...string) ([]hoarderIface.InstanceInfo, error) {
+	resp, err := c.Send(hoarderSpecs.HoarderCommand, command.Body{
+		hoarderSpecs.BodyAction: hoarderSpecs.ActionMetas,
+		hoarderSpecs.BodyHashes: hashes,
+	}, c.peers...)
+	if err != nil {
+		return nil, fmt.Errorf("resolving metas failed with: %w", err)
+	}
+
+	raw := maps.SafeInterfaceToStringKeys(resp[hoarderSpecs.BodyMetas])
+	out := make([]hoarderIface.InstanceInfo, 0, len(raw))
+	for hash, entry := range raw {
+		m := maps.SafeInterfaceToStringKeys(entry)
+		kind, err := maps.Int(m, hoarderSpecs.BodyKind)
+		if err != nil {
+			continue
+		}
+		out = append(out, hoarderIface.InstanceInfo{
+			Hash: hash,
+			Kind: hoarderIface.ResourceKind(kind),
+			Meta: hoarderIface.MetaData{
+				ConfigId:      maps.TryString(m, hoarderSpecs.BodyConfig),
+				ProjectId:     maps.TryString(m, hoarderSpecs.BodyProject),
+				ApplicationId: maps.TryString(m, hoarderSpecs.BodyApp),
+				Match:         maps.TryString(m, hoarderSpecs.BodyMatch),
+				Branch:        maps.TryString(m, hoarderSpecs.BodyBranch),
+			},
+		})
+	}
+	return out, nil
+}
+
+// StashStatus reports the live stash claim count per CID (0 = unknown) and the
+// fleet-clamped stash replica target.
+func (c *Client) StashStatus(cids ...string) (map[string]int, int, error) {
+	resp, err := c.Send(hoarderSpecs.HoarderCommand, command.Body{
+		hoarderSpecs.BodyAction: hoarderSpecs.ActionStashStatus,
+		hoarderSpecs.BodyCids:   cids,
+	}, c.peers...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("resolving stash status failed with: %w", err)
+	}
+
+	raw := maps.SafeInterfaceToStringKeys(resp[hoarderSpecs.BodyClaims])
+	out := make(map[string]int, len(raw))
+	for cid, v := range raw {
+		n, err := maps.Int(map[string]interface{}{"n": v}, "n")
+		if err != nil {
+			continue
+		}
+		out[cid] = n
+	}
+	target, err := maps.Int(resp, hoarderSpecs.BodyTarget)
+	if err != nil {
+		return nil, 0, fmt.Errorf("reading stash target failed with: %w", err)
+	}
+	return out, target, nil
+}

--- a/clients/p2p/hoarder/tests/p2p_test.go
+++ b/clients/p2p/hoarder/tests/p2p_test.go
@@ -20,6 +20,7 @@ import (
 	streams "github.com/taubyte/tau/p2p/streams/service"
 	"github.com/taubyte/tau/pkg/config"
 	hoarderSpecs "github.com/taubyte/tau/pkg/specs/hoarder"
+	multihash "github.com/taubyte/tau/utils/multihash"
 
 	peer "github.com/taubyte/tau/p2p/peer"
 	"github.com/taubyte/tau/services/common"
@@ -225,7 +226,44 @@ func TestHoarderClient(t *testing.T) {
 	if kv.Factory() != nil {
 		t.Fatal("remote Factory should be nil")
 	}
+
+	// Conditional write: only the first putnx of a key lands; a later one
+	// reports existed and never overwrites.
+	nx, ok := kv.(hoarderIface.NxKVDB)
+	if !ok {
+		t.Fatal("remote handle must support conditional writes")
+	}
+	if existed, err := nx.PutNx(kctx, "cond", []byte("first")); err != nil || existed {
+		t.Fatalf("first PutNx = existed %v, %v", existed, err)
+	}
+	if existed, err := nx.PutNx(kctx, "cond", []byte("second")); err != nil || !existed {
+		t.Fatalf("second PutNx = existed %v, %v", existed, err)
+	}
+	if v, err := kv.Get(kctx, "cond"); err != nil || string(v) != "first" {
+		t.Fatalf("PutNx overwrote: %q, %v", v, err)
+	}
 	kv.Close()
+
+	// Metas resolves the placement identity of a hash recorded by first-touch;
+	// unknown hashes are omitted.
+	kvHash := multihash.Hash("kvproj" + "" + "/kv")
+	metas, err := hc.Metas(kvHash, "unknown-hash")
+	if err != nil {
+		t.Fatalf("Metas: %v", err)
+	}
+	if len(metas) != 1 || metas[0].Hash != kvHash ||
+		metas[0].Kind != hoarderIface.Global || metas[0].Meta.ProjectId != "kvproj" || metas[0].Meta.Match != "/kv" {
+		t.Fatalf("Metas = %+v", metas)
+	}
+
+	// StashStatus reports live claims for the stashed cid and the fleet target.
+	claims, target, err := hc.StashStatus(cid, "unknown-cid")
+	if err != nil {
+		t.Fatalf("StashStatus: %v", err)
+	}
+	if target != 1 || claims[cid] != 1 || claims["unknown-cid"] != 0 {
+		t.Fatalf("StashStatus = %v target %d", claims, target)
+	}
 }
 
 // TestHoarderClient_BadAck points the client at a hoarder that accepts the push

--- a/core/services/hoarder/client.go
+++ b/core/services/hoarder/client.go
@@ -1,6 +1,7 @@
 package hoarder
 
 import (
+	"context"
 	"io"
 
 	peerCore "github.com/libp2p/go-libp2p/core/peer"
@@ -18,8 +19,31 @@ type Client interface {
 	// KVDB returns a remote-backed kvdb.KVDB for a database/storage instance —
 	// operations are p2p calls to the hoarders holding it.
 	KVDB(kind ResourceKind, project, application, match, branch string) (kvdb.KVDB, error)
+	// Metas resolves instance hashes to their placement identity records; hashes
+	// with no record are omitted. Lets a node that knows only a data-path hash
+	// recover the instance's identity.
+	Metas(hashes ...string) ([]InstanceInfo, error)
+	// StashStatus reports the live stash claim count per CID (0 = unknown) and
+	// the current fleet-clamped stash replica target — the check a byte holder
+	// runs before dropping its local copy.
+	StashStatus(cids ...string) (claims map[string]int, target int, err error)
 	Peers(...peerCore.ID) Client
 	Close()
+}
+
+// InstanceInfo is a placement identity record as returned by Metas.
+type InstanceInfo struct {
+	Hash string
+	Kind ResourceKind
+	Meta MetaData
+}
+
+// NxKVDB is a KVDB handle that also supports conditional writes. The remote
+// hoarder-backed handle implements it; PutNx returns existed=true when the key
+// was already present on the serving replica and nothing was written.
+type NxKVDB interface {
+	kvdb.KVDB
+	PutNx(ctx context.Context, key string, value []byte) (existed bool, err error)
 }
 
 // StashConfig carries push options. Target is the desired replica count; Owner

--- a/pkg/specs/hoarder/stream.go
+++ b/pkg/specs/hoarder/stream.go
@@ -22,6 +22,11 @@ const (
 	BodyApp     = "application"
 	BodyMatch   = "match"
 	BodyPeers   = "peers"
+	BodyHashes  = "hashes"
+	BodyCids    = "cids"
+	BodyMetas   = "metas"
+	BodyClaims  = "claims"
+	BodyConfig  = "configId"
 
 	ActionRare     = "rare"
 	ActionList     = "list"
@@ -29,6 +34,13 @@ const (
 	ActionStatus   = "status"
 	ActionLoad     = "load"
 	ActionUnload   = "unload"
+	// ActionMetas resolves instance hashes to their placement identity records —
+	// lets a node that knows only a data-path hash recover (kind, project, app,
+	// match, branch).
+	ActionMetas = "metas"
+	// ActionStashStatus reports the live stash claim count per CID — lets a byte
+	// holder confirm a CID is replicated before dropping its local copy.
+	ActionStashStatus = "stashStatus"
 )
 
 // KVDBCommand is the remote data-plane route. Body carries {kind, project,
@@ -70,7 +82,14 @@ const (
 	KVBatch     = "batch"
 	KVListRegex = "listRegex"
 	KVSync      = "sync"
+	// KVPutNx writes the key only if absent, atomically against concurrent
+	// writes on the serving replica. The response carries BodyExisted=true when
+	// the key was already present and nothing was written.
+	KVPutNx = "putnx"
 )
+
+// BodyExisted is set true on a putnx response when the key already existed.
+const BodyExisted = "existed"
 
 // Typed result codes carried in the response's BodyCode field for control-flow
 // signals the client routes on (never as free text). A response with no BodyCode

--- a/pkg/specs/hoarder/vars.go
+++ b/pkg/specs/hoarder/vars.go
@@ -48,4 +48,19 @@ var (
 	// DefaultStashReplicas is the target replica count for stashed CIDs when
 	// the caller does not specify one.
 	DefaultStashReplicas = 2
+
+	// AssetSweepRetries bounds how many times the boot-time asset sweep retries
+	// a failing TNS listing before giving up until the next boot.
+	AssetSweepRetries = 10
+
+	// AssetSweepRetryInterval is the backoff between asset-sweep TNS retries.
+	AssetSweepRetryInterval = 6 * time.Second
+
+	// AssetSweepFetchTimeout bounds fetching one asset's bytes during the sweep.
+	AssetSweepFetchTimeout = 2 * time.Minute
+
+	// AssetSweepInterval is the period of the recurring asset sweep after the
+	// boot pass — the self-heal for an asset published while every push to the
+	// stash failed (e.g. the fleet was unreachable during a build).
+	AssetSweepInterval = 10 * time.Minute
 )

--- a/services/hoarder/assets.go
+++ b/services/hoarder/assets.go
@@ -1,0 +1,156 @@
+package hoarder
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	ifaceTns "github.com/taubyte/tau/core/services/tns"
+	spec "github.com/taubyte/tau/pkg/specs/common"
+	hoarderSpecs "github.com/taubyte/tau/pkg/specs/hoarder"
+)
+
+// assetSweepLoop ensures every build asset published in TNS is stash-
+// replicated. An asset key (`assets/<hash>` → CID) can exist without stash
+// claims — the build predates this data plane, every claimant was lost, or
+// every push failed while the fleet was unreachable — leaving the bytes on
+// whichever node happens to hold them, un-replicated. The sweep adopts such
+// CIDs: fetch the bytes, pin, claim, fan out to the replica target.
+// Additive-only: it never deletes anything. Runs once after boot (membership
+// must form first so the one-adopter-per-CID selection is stable), then on a
+// slow recurring interval as the self-heal for later gaps.
+func (srv *Service) assetSweepLoop(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(2 * hoarderSpecs.LivenessTimeout):
+	}
+
+	for {
+		srv.assetSweepOnce(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(hoarderSpecs.AssetSweepInterval):
+		}
+	}
+}
+
+// assetSweepOnce runs one sweep, retrying a failing TNS listing a bounded
+// number of times.
+func (srv *Service) assetSweepOnce(ctx context.Context) {
+	for attempt := 0; attempt < hoarderSpecs.AssetSweepRetries; attempt++ {
+		if ctx.Err() != nil {
+			return
+		}
+		cids, err := srv.tnsAssetCids()
+		if err == nil {
+			srv.adoptAssets(ctx, cids)
+			return
+		}
+		logger.Errorf("asset sweep: listing TNS assets failed with: %s", err)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(hoarderSpecs.AssetSweepRetryInterval):
+		}
+	}
+	logger.Error("asset sweep: TNS unreachable, retrying next sweep")
+}
+
+// tnsAssetCids lists every asset CID recorded in TNS: keys under `assets/`,
+// each holding the CID string the build published.
+func (srv *Service) tnsAssetCids() ([]string, error) {
+	keysIface, err := srv.tnsClient.Lookup(ifaceTns.Query{Prefix: []string{"assets"}})
+	if err != nil {
+		return nil, err
+	}
+	keys, ok := keysIface.([]string)
+	if !ok {
+		return nil, fmt.Errorf("unexpected lookup result type %T", keysIface)
+	}
+
+	cids := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts := strings.Split(strings.TrimPrefix(k, "/"), "/")
+		if len(parts) != 2 || parts[0] != "assets" {
+			continue
+		}
+		obj, err := srv.tnsClient.Fetch(spec.NewTnsPath(parts))
+		if err != nil {
+			logger.Errorf("asset sweep: fetching %s failed with: %s", k, err)
+			continue
+		}
+		if cid, ok := obj.Interface().(string); ok && cid != "" {
+			cids = append(cids, cid)
+		}
+	}
+	return dedup(cids), nil
+}
+
+// adoptAssets stash-replicates every CID whose live claim count is below the
+// stash target. One adopter per CID (deterministic selection over live
+// membership) so the fleet doesn't race-fetch the same bytes; claims/meta
+// writes are idempotent regardless.
+func (srv *Service) adoptAssets(ctx context.Context, cids []string) (adopted, skipped int) {
+	self := srv.node.ID().String()
+	for _, cid := range cids {
+		if ctx.Err() != nil {
+			return
+		}
+		members := srv.activeMembers()
+		target := stashTarget(len(members))
+		if claims, err := srv.listStashClaims(ctx, cid); err == nil && len(srv.liveClaimants(claims)) >= target {
+			skipped++
+			continue
+		}
+		if want := placementDesired(cid, members, 1); len(want) == 0 || want[0] != self {
+			continue
+		}
+		if err := srv.adoptAsset(ctx, cid, target); err != nil {
+			// Loud on purpose: no reachable holder means this asset is already
+			// unservable cloud-wide until its resource is rebuilt.
+			logger.Errorf("asset sweep: adopting %s failed with: %s", cid, err)
+			continue
+		}
+		adopted++
+	}
+	if adopted > 0 || skipped > 0 {
+		logger.Infof("asset sweep: adopted %d asset(s), %d already replicated", adopted, skipped)
+	}
+	return
+}
+
+// adoptAsset pulls the CID's bytes (bitswap, from whichever node holds them)
+// into the local blockstore, records the stash placement + this node's claim,
+// and fans out to co-claimants.
+func (srv *Service) adoptAsset(ctx context.Context, cid string, target int) error {
+	fctx, cancel := context.WithTimeout(ctx, hoarderSpecs.AssetSweepFetchTimeout)
+	defer cancel()
+	f, err := srv.node.GetFile(fctx, cid)
+	if err != nil {
+		return fmt.Errorf("fetching bytes failed with: %w", err)
+	}
+	_, err = io.Copy(io.Discard, f) // reading pulls the full DAG locally
+	f.Close()
+	if err != nil {
+		return fmt.Errorf("reading bytes failed with: %w", err)
+	}
+
+	if err := srv.putStashMeta(ctx, cid, &StashMeta{Target: target}); err != nil {
+		return err
+	}
+	if err := srv.addStashClaim(ctx, cid, srv.node.ID().String()); err != nil {
+		return err
+	}
+	srv.fanoutStash(ctx, cid, target, "")
+	return nil
+}
+
+// stashTarget is the system-calculated stash replica target: the stash default
+// clamped to the live fleet, so single-node clouds converge to 1.
+func stashTarget(liveFleet int) int {
+	return max(min(hoarderSpecs.DefaultStashReplicas, liveFleet), 1)
+}

--- a/services/hoarder/assets_test.go
+++ b/services/hoarder/assets_test.go
@@ -1,0 +1,143 @@
+package hoarder
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	hoarderIface "github.com/taubyte/tau/core/services/hoarder"
+	ifaceTns "github.com/taubyte/tau/core/services/tns"
+	"github.com/taubyte/tau/p2p/streams/command"
+	hoarderSpecs "github.com/taubyte/tau/pkg/specs/hoarder"
+	"github.com/taubyte/tau/utils/maps"
+)
+
+// fakeAssetTns serves a canned assets index: Lookup lists the keys, Fetch
+// returns each key's CID value. Everything else panics via the embedded nil
+// interface — exactly what a unit test wants.
+type fakeAssetTns struct {
+	ifaceTns.Client
+	keys map[string]string // "/assets/<hash>" → cid
+}
+
+func (f *fakeAssetTns) Lookup(ifaceTns.Query) (interface{}, error) {
+	out := make([]string, 0, len(f.keys))
+	for k := range f.keys {
+		out = append(out, k)
+	}
+	return out, nil
+}
+
+func (f *fakeAssetTns) Fetch(path ifaceTns.Path) (ifaceTns.Object, error) {
+	return fakeObject{v: f.keys["/"+path.String()]}, nil
+}
+
+type fakeObject struct {
+	ifaceTns.Object
+	v string
+}
+
+func (f fakeObject) Interface() interface{} { return f.v }
+
+func TestAssetSweep_AdoptsUnclaimedAndSkipsReplicated(t *testing.T) {
+	srv := newTestService(t)
+	ctx := t.Context()
+	self := srv.node.ID().String()
+
+	// Seed bytes on the node — the shape of an asset whose CID is recorded in
+	// TNS but was never stash-claimed.
+	cid, err := srv.node.AddFile(bytes.NewReader([]byte("built artifact bytes")))
+	if err != nil {
+		t.Fatalf("seeding file failed: %v", err)
+	}
+	srv.tnsClient = &fakeAssetTns{keys: map[string]string{"/assets/somehash": cid}}
+
+	cids, err := srv.tnsAssetCids()
+	if err != nil {
+		t.Fatalf("listing asset cids failed: %v", err)
+	}
+	if len(cids) != 1 || cids[0] != cid {
+		t.Fatalf("unexpected cid list: %v", cids)
+	}
+
+	adopted, skipped := srv.adoptAssets(ctx, cids)
+	if adopted != 1 || skipped != 0 {
+		t.Fatalf("expected 1 adopted / 0 skipped, got %d / %d", adopted, skipped)
+	}
+	if _, ok := srv.stashClaimSince(ctx, cid, self); !ok {
+		t.Fatal("adopted asset has no stash claim")
+	}
+	meta, err := srv.getStashMeta(ctx, cid)
+	if err != nil || meta.Target != 1 { // single-node fleet clamps the target to 1
+		t.Fatalf("unexpected stash meta: %+v, err %v", meta, err)
+	}
+
+	// Second pass: already at target → skipped, nothing re-fetched.
+	adopted, skipped = srv.adoptAssets(ctx, cids)
+	if adopted != 0 || skipped != 1 {
+		t.Fatalf("expected 0 adopted / 1 skipped, got %d / %d", adopted, skipped)
+	}
+}
+
+func TestAssetSweep_UnfetchableCidReportedNotClaimed(t *testing.T) {
+	srv := newTestService(t)
+	ctx := t.Context()
+
+	// A CID nothing holds: the fetch must time out and leave no claim behind.
+	restore := hoarderSpecs.AssetSweepFetchTimeout
+	hoarderSpecs.AssetSweepFetchTimeout = 300 * time.Millisecond
+	defer func() { hoarderSpecs.AssetSweepFetchTimeout = restore }()
+
+	missing := "QmYwAPJzv5CZsnAzt8auVZRn1pfejgxk2GYDdVQGWvVFrH"
+	adopted, skipped := srv.adoptAssets(ctx, []string{missing})
+	if adopted != 0 || skipped != 0 {
+		t.Fatalf("expected nothing adopted/skipped, got %d / %d", adopted, skipped)
+	}
+	if _, ok := srv.stashClaimSince(ctx, missing, srv.node.ID().String()); ok {
+		t.Fatal("unfetchable cid must not be claimed")
+	}
+}
+
+func TestMetasAndStashStatusHandlers(t *testing.T) {
+	srv := newTestService(t)
+	ctx := t.Context()
+	self := srv.node.ID().String()
+
+	hash := instanceHash(meta("users"))
+	if err := srv.putMeta(ctx, hash, &RegistryMeta{
+		Kind: hoarderIface.Database, ConfigId: "cfg-1", ProjectId: "proj", Match: "users", Branch: "main",
+	}); err != nil {
+		t.Fatalf("putMeta failed: %v", err)
+	}
+
+	resp, err := srv.metasHandler(ctx, command.Body{hoarderSpecs.BodyHashes: []string{hash, "absent-hash"}})
+	if err != nil {
+		t.Fatalf("metasHandler failed: %v", err)
+	}
+	got := maps.SafeInterfaceToStringKeys(resp[hoarderSpecs.BodyMetas])
+	if len(got) != 1 {
+		t.Fatalf("expected 1 meta, got %d", len(got))
+	}
+	entry := maps.SafeInterfaceToStringKeys(got[hash])
+	if maps.TryString(entry, hoarderSpecs.BodyMatch) != "users" ||
+		maps.TryString(entry, hoarderSpecs.BodyProject) != "proj" ||
+		maps.TryString(entry, hoarderSpecs.BodyConfig) != "cfg-1" {
+		t.Fatalf("meta fields wrong: %v", entry)
+	}
+
+	cid := "QmSomeCid"
+	if err := srv.addStashClaim(ctx, cid, self); err != nil {
+		t.Fatalf("addStashClaim failed: %v", err)
+	}
+	resp, err = srv.stashStatusHandler(ctx, command.Body{hoarderSpecs.BodyCids: []string{cid, "unknown-cid"}})
+	if err != nil {
+		t.Fatalf("stashStatusHandler failed: %v", err)
+	}
+	claims := maps.SafeInterfaceToStringKeys(resp[hoarderSpecs.BodyClaims])
+	if n, _ := maps.Int(claims, cid); n != 1 {
+		t.Fatalf("expected 1 live claim for %s, got %v", cid, claims[cid])
+	}
+	if n, _ := maps.Int(claims, "unknown-cid"); n != 0 {
+		t.Fatalf("expected 0 claims for unknown cid, got %v", claims["unknown-cid"])
+	}
+}

--- a/services/hoarder/kvdb.go
+++ b/services/hoarder/kvdb.go
@@ -39,6 +39,8 @@ func (srv *Service) kvdbHandler(ctx context.Context, conn streams.Connection, bo
 		resp, err = srv.kvGet(ctx, handle, body)
 	case hoarderSpecs.KVPut:
 		resp, err = srv.kvPut(ctx, handle, hash, body)
+	case hoarderSpecs.KVPutNx:
+		resp, err = srv.kvPutNx(ctx, handle, hash, body)
 	case hoarderSpecs.KVDelete:
 		resp, err = srv.kvDelete(ctx, handle, hash, body)
 	case hoarderSpecs.KVList:
@@ -198,9 +200,55 @@ func (srv *Service) kvPut(ctx context.Context, handle kvdb.KVDB, hash string, bo
 	if err != nil {
 		return nil, fmt.Errorf("encrypting value failed with: %w", err)
 	}
-	if err := handle.Put(ctx, key, enc); err != nil {
+	// Local commit under the instance write lock so putnx's check-and-write is
+	// atomic against it; the replication barrier runs outside the lock.
+	mu := srv.writeLock(hash)
+	mu.Lock()
+	err = handle.Put(ctx, key, enc)
+	mu.Unlock()
+	if err != nil {
 		return nil, fmt.Errorf("put failed with: %w", err)
 	}
+	srv.replicateWrite(ctx, hash, body)
+	return cr.Response{}, nil
+}
+
+// kvPutNx writes the key only if it is absent, atomically against concurrent
+// writes on this node (put/delete/batch share the same per-instance write
+// lock). Used when older data is replayed into a live instance: a value written
+// through the normal path must never be overwritten by the replay, so the
+// replay writes conditionally. Response carries existed=true when the key was
+// already present and nothing was written (no replication either).
+func (srv *Service) kvPutNx(ctx context.Context, handle kvdb.KVDB, hash string, body command.Body) (cr.Response, error) {
+	key, err := maps.String(body, hoarderSpecs.BodyKey)
+	if err != nil {
+		return nil, err
+	}
+	value, err := maps.ByteArray(body, hoarderSpecs.BodyValue)
+	if err != nil {
+		return nil, fmt.Errorf("missing value: %w", err)
+	}
+	if err := srv.admitWrite(maps.TryString(body, hoarderSpecs.BodyProject), len(value)); err != nil {
+		return cr.Response{hoarderSpecs.BodyCode: hoarderSpecs.CodeOverCapacity}, nil
+	}
+	enc, err := srv.cipherEncrypt(value)
+	if err != nil {
+		return nil, fmt.Errorf("encrypting value failed with: %w", err)
+	}
+
+	mu := srv.writeLock(hash)
+	mu.Lock()
+	if cur, gerr := handle.Get(ctx, key); gerr == nil && cur != nil {
+		mu.Unlock()
+		return cr.Response{hoarderSpecs.BodyExisted: true}, nil
+	}
+	err = handle.Put(ctx, key, enc)
+	mu.Unlock()
+	if err != nil {
+		return nil, fmt.Errorf("putnx failed with: %w", err)
+	}
+	// Replicated as putnx too: the co-owner nx-checks its own state, so a value
+	// it already holds through the normal path is never clobbered there either.
 	srv.replicateWrite(ctx, hash, body)
 	return cr.Response{}, nil
 }
@@ -210,7 +258,11 @@ func (srv *Service) kvDelete(ctx context.Context, handle kvdb.KVDB, hash string,
 	if err != nil {
 		return nil, err
 	}
-	if err := handle.Delete(ctx, key); err != nil {
+	mu := srv.writeLock(hash)
+	mu.Lock()
+	err = handle.Delete(ctx, key)
+	mu.Unlock()
+	if err != nil {
 		return nil, fmt.Errorf("delete failed with: %w", err)
 	}
 	srv.replicateWrite(ctx, hash, body)
@@ -346,6 +398,23 @@ func (srv *Service) kvBatch(ctx context.Context, handle kvdb.KVDB, hash string, 
 		return nil, fmt.Errorf("missing or malformed ops")
 	}
 
+	// Build + commit under the instance write lock (local work only); the
+	// replication barrier runs after release.
+	mu := srv.writeLock(hash)
+	mu.Lock()
+	resp, err := srv.applyBatch(ctx, handle, body, rawOps)
+	mu.Unlock()
+	if resp != nil || err != nil {
+		return resp, err
+	}
+	srv.replicateWrite(ctx, hash, body)
+	return cr.Response{}, nil
+}
+
+// applyBatch builds and commits the grouped ops. Runs under the instance write
+// lock. A non-nil response is a typed refusal (over-capacity); (nil, nil) is
+// success.
+func (srv *Service) applyBatch(ctx context.Context, handle kvdb.KVDB, body command.Body, rawOps []interface{}) (cr.Response, error) {
 	batch, err := handle.Batch(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("opening batch failed with: %w", err)
@@ -389,8 +458,7 @@ func (srv *Service) kvBatch(ctx context.Context, handle kvdb.KVDB, hash string, 
 	if err := batch.Commit(); err != nil {
 		return nil, fmt.Errorf("batch commit failed with: %w", err)
 	}
-	srv.replicateWrite(ctx, hash, body)
-	return cr.Response{}, nil
+	return nil, nil
 }
 
 func (srv *Service) kvSync(ctx context.Context, handle kvdb.KVDB, body command.Body) (cr.Response, error) {

--- a/services/hoarder/loader.go
+++ b/services/hoarder/loader.go
@@ -25,13 +25,32 @@ type loader struct {
 	lock    sync.Mutex
 	loaded  map[string]*loadedInstance
 	claimed map[string]bool
+	// writeLocks serialize an instance's local write commits (put/putnx/delete/
+	// batch) so putnx's check-and-write is atomic against concurrent writers on
+	// this node. Locks live for the process — tying them to load/unload would
+	// let a racing writer hold a stale lock while a fresh one is handed out.
+	writeLocks map[string]*sync.Mutex
 }
 
 func newLoader() *loader {
 	return &loader{
-		loaded:  make(map[string]*loadedInstance),
-		claimed: make(map[string]bool),
+		loaded:     make(map[string]*loadedInstance),
+		claimed:    make(map[string]bool),
+		writeLocks: make(map[string]*sync.Mutex),
 	}
+}
+
+// writeLock returns the per-instance write mutex. Held across the LOCAL commit
+// only — never across the replication barrier's network round-trip.
+func (srv *Service) writeLock(hash string) *sync.Mutex {
+	srv.ldr.lock.Lock()
+	defer srv.ldr.lock.Unlock()
+	mu, ok := srv.ldr.writeLocks[hash]
+	if !ok {
+		mu = new(sync.Mutex)
+		srv.ldr.writeLocks[hash] = mu
+	}
+	return mu
 }
 
 func (srv *Service) markClaimed(hash string) {

--- a/services/hoarder/putnx_test.go
+++ b/services/hoarder/putnx_test.go
@@ -1,0 +1,106 @@
+package hoarder
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/taubyte/tau/p2p/streams/command"
+	hoarderSpecs "github.com/taubyte/tau/pkg/specs/hoarder"
+	"github.com/taubyte/tau/utils/maps"
+)
+
+func putnxBody(key string, value []byte) command.Body {
+	return command.Body{
+		hoarderSpecs.BodyKVOp:  hoarderSpecs.KVPutNx,
+		hoarderSpecs.BodyKey:   key,
+		hoarderSpecs.BodyValue: value,
+	}
+}
+
+func putBody(key string, value []byte) command.Body {
+	return command.Body{
+		hoarderSpecs.BodyKVOp:  hoarderSpecs.KVPut,
+		hoarderSpecs.BodyKey:   key,
+		hoarderSpecs.BodyValue: value,
+	}
+}
+
+func TestKVPutNx_Semantics(t *testing.T) {
+	srv := newTestService(t)
+	ctx := t.Context()
+	hash := "putnx-test-instance"
+	handle, err := srv.load(hash)
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+
+	// First write: key absent → written.
+	resp, err := srv.kvPutNx(ctx, handle, hash, putnxBody("k", []byte("first")))
+	if err != nil {
+		t.Fatalf("putnx failed: %v", err)
+	}
+	if existed, _ := maps.Bool(resp, hoarderSpecs.BodyExisted); existed {
+		t.Fatal("fresh key reported existed")
+	}
+
+	// Second write: key present → skipped, value unchanged.
+	resp, err = srv.kvPutNx(ctx, handle, hash, putnxBody("k", []byte("second")))
+	if err != nil {
+		t.Fatalf("second putnx failed: %v", err)
+	}
+	if existed, _ := maps.Bool(resp, hoarderSpecs.BodyExisted); !existed {
+		t.Fatal("present key not reported existed")
+	}
+
+	got, err := srv.kvGet(ctx, handle, command.Body{hoarderSpecs.BodyKey: "k"})
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if v, _ := maps.ByteArray(got, hoarderSpecs.BodyValue); string(v) != "first" {
+		t.Fatalf("putnx overwrote an existing key: got %q", v)
+	}
+}
+
+// TestKVPutNx_AtomicWithPut proves the per-instance write lock: a concurrent
+// unconditional put must never end up shadowed by a putnx replaying an older
+// value. In every legal interleaving the final value is the put's — the putnx
+// either lands first (put overwrites it) or observes the key and skips. A torn
+// interleaving (put commits between putnx's check and write) would leave the
+// replayed value on top. Run with -race to also catch data races on the path.
+func TestKVPutNx_AtomicWithPut(t *testing.T) {
+	srv := newTestService(t)
+	ctx := t.Context()
+	hash := "putnx-race-instance"
+	handle, err := srv.load(hash)
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+
+	for i := 0; i < 64; i++ {
+		key := fmt.Sprintf("k-%d", i)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			if _, err := srv.kvPut(ctx, handle, hash, putBody(key, []byte("live"))); err != nil {
+				t.Errorf("put %s failed: %v", key, err)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if _, err := srv.kvPutNx(ctx, handle, hash, putnxBody(key, []byte("replay"))); err != nil {
+				t.Errorf("putnx %s failed: %v", key, err)
+			}
+		}()
+		wg.Wait()
+
+		got, err := srv.kvGet(ctx, handle, command.Body{hoarderSpecs.BodyKey: key})
+		if err != nil {
+			t.Fatalf("get %s failed: %v", key, err)
+		}
+		if v, _ := maps.ByteArray(got, hoarderSpecs.BodyValue); string(v) != "live" {
+			t.Fatalf("key %s: replayed value shadowed a live write (got %q)", key, v)
+		}
+	}
+}

--- a/services/hoarder/service.go
+++ b/services/hoarder/service.go
@@ -84,6 +84,11 @@ func New(ctx context.Context, cfg tauConfig.Config) (service hoarderIface.Servic
 		return nil, fmt.Errorf("starting reconcile failed with: %w", err)
 	}
 
+	// Adopt TNS-published assets that lack stash claims (see assets.go). Joined
+	// by Close via loopsWG like the other loops.
+	s.loopsWG.Add(1)
+	go func() { defer s.loopsWG.Done(); s.assetSweepLoop(loopCtx) }()
+
 	sc, err := seerClient.New(ctx, clientNode, cfg.SensorsRegistry())
 	if err != nil {
 		return nil, fmt.Errorf("new seer client failed with: %w", err)

--- a/services/hoarder/stream.go
+++ b/services/hoarder/stream.go
@@ -45,9 +45,64 @@ func (srv *Service) ServiceHandler(ctx context.Context, conn streams.Connection,
 		return srv.loadHandler(ctx, body)
 	case hoarderSpecs.ActionUnload:
 		return srv.unloadHandler(body)
+	case hoarderSpecs.ActionMetas:
+		return srv.metasHandler(ctx, body)
+	case hoarderSpecs.ActionStashStatus:
+		return srv.stashStatusHandler(ctx, body)
 	}
 
 	return nil, fmt.Errorf("action %s unknown", action)
+}
+
+// metasHandler resolves instance hashes to their placement identity records
+// (absent hashes are omitted). Read-only: a node that knows only a data-path
+// hash recovers the instance's (kind, project, app, match, branch) here.
+func (srv *Service) metasHandler(ctx context.Context, body command.Body) (cr.Response, error) {
+	hashes, err := maps.StringArray(body, hoarderSpecs.BodyHashes)
+	if err != nil {
+		return nil, fmt.Errorf("missing hashes: %w", err)
+	}
+	out := make(map[string]interface{}, len(hashes))
+	for _, h := range hashes {
+		meta, err := srv.getMeta(ctx, h)
+		if err != nil {
+			continue
+		}
+		out[h] = map[string]interface{}{
+			hoarderSpecs.BodyKind:    int(meta.Kind),
+			hoarderSpecs.BodyConfig:  meta.ConfigId,
+			hoarderSpecs.BodyProject: meta.ProjectId,
+			hoarderSpecs.BodyApp:     meta.ApplicationId,
+			hoarderSpecs.BodyMatch:   meta.Match,
+			hoarderSpecs.BodyBranch:  meta.Branch,
+		}
+	}
+	return cr.Response{hoarderSpecs.BodyMetas: out}, nil
+}
+
+// stashStatusHandler reports the LIVE stash claim count per requested CID
+// (0 when unknown) plus the current fleet-clamped stash target. Read-only: a
+// byte holder checks a CID reached its replica target before dropping its
+// local copy — claims by dead peers don't count toward durability, and the
+// holder can't compute the target itself (it doesn't see the hoarder fleet).
+func (srv *Service) stashStatusHandler(ctx context.Context, body command.Body) (cr.Response, error) {
+	cids, err := maps.StringArray(body, hoarderSpecs.BodyCids)
+	if err != nil {
+		return nil, fmt.Errorf("missing cids: %w", err)
+	}
+	out := make(map[string]interface{}, len(cids))
+	for _, cid := range cids {
+		claims, err := srv.listStashClaims(ctx, cid)
+		if err != nil {
+			out[cid] = 0
+			continue
+		}
+		out[cid] = len(srv.liveClaimants(claims))
+	}
+	return cr.Response{
+		hoarderSpecs.BodyClaims: out,
+		hoarderSpecs.BodyTarget: stashTarget(srv.fleetSize()),
+	}, nil
 }
 
 // instanceHashFromBody derives the instance hash from the {project, app, match}

--- a/services/hoarder/tests/assets_test.go
+++ b/services/hoarder/tests/assets_test.go
@@ -1,0 +1,95 @@
+//go:build dreaming
+
+package tests
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	commonIface "github.com/taubyte/tau/core/common"
+	"github.com/taubyte/tau/dream"
+	hoarderSpecs "github.com/taubyte/tau/pkg/specs/hoarder"
+	"github.com/taubyte/tau/pkg/specs/methods"
+	"gotest.tools/v3/assert"
+
+	_ "github.com/taubyte/tau/clients/p2p/tns/dream"
+	_ "github.com/taubyte/tau/services/tns/dream"
+)
+
+// TestAssetSweep_Dreaming: an asset CID recorded in TNS whose bytes sit
+// un-replicated on a non-hoarder node (no stash claims — the shape a failed or
+// pre-data-plane build leaves behind) is adopted by the recurring sweep:
+// fetched over bitswap, pinned, claimed to the stash target.
+func TestAssetSweep_Dreaming(t *testing.T) {
+	fastConvergence(t)
+	origInterval := hoarderSpecs.AssetSweepInterval
+	origRetry := hoarderSpecs.AssetSweepRetryInterval
+	hoarderSpecs.AssetSweepInterval = 3 * time.Second
+	hoarderSpecs.AssetSweepRetryInterval = 2 * time.Second
+	t.Cleanup(func() {
+		hoarderSpecs.AssetSweepInterval = origInterval
+		hoarderSpecs.AssetSweepRetryInterval = origRetry
+	})
+
+	m, err := dream.New(t.Context())
+	assert.NilError(t, err)
+	defer m.Close()
+
+	u, err := m.New(dream.UniverseConfig{Name: t.Name()})
+	assert.NilError(t, err)
+
+	assert.NilError(t, u.StartWithConfig(&dream.Config{
+		Services: map[string]commonIface.ServiceConfig{
+			"seer":    {},
+			"tns":     {},
+			"hoarder": {},
+		},
+		Simples: map[string]dream.SimpleConfig{
+			"client": {Clients: dream.SimpleConfigClients{
+				TNS:     &commonIface.ClientConfig{},
+				Hoarder: &commonIface.ClientConfig{},
+			}.Compat()},
+		},
+	}))
+	u.Mesh()
+
+	simple, err := u.Simple("client")
+	assert.NilError(t, err)
+
+	// The bytes live only on the client node — no stash claims anywhere.
+	data := bytes.Repeat([]byte("built artifact "), 128)
+	cid, err := simple.PeerNode().AddFile(bytes.NewReader(data))
+	assert.NilError(t, err)
+
+	// Record the asset in TNS the way a build does.
+	tns, err := simple.TNS()
+	assert.NilError(t, err)
+	assetKey, err := methods.GetTNSAssetPath("someproject", "someresource", "main")
+	assert.NilError(t, err)
+	assert.NilError(t, tns.Push(assetKey.Slice(), cid))
+
+	// The recurring sweep must adopt it: claims reach the fleet target.
+	hoarder, err := simple.Hoarder()
+	assert.NilError(t, err)
+	deadline := time.Now().Add(90 * time.Second)
+	for {
+		claims, target, err := hoarder.StashStatus(cid)
+		if err == nil && claims[cid] >= target && target >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("asset never adopted: claims=%v err=%v", claims, err)
+		}
+		time.Sleep(time.Second)
+	}
+
+	// The hoarder holds the bytes locally now (not just a claim).
+	f, err := u.Hoarder().Node().GetFile(u.Context(), cid)
+	assert.NilError(t, err)
+	got := make([]byte, len(data))
+	_, err = f.Read(got)
+	f.Close()
+	assert.NilError(t, err)
+	assert.DeepEqual(t, got, data)
+}

--- a/services/substrate/methods.go
+++ b/services/substrate/methods.go
@@ -3,6 +3,7 @@ package substrate
 import (
 	"github.com/taubyte/tau/core/vm"
 	protocolCommon "github.com/taubyte/tau/services/common"
+	"github.com/taubyte/tau/services/substrate/migration"
 )
 
 // TODO: Rename to Satellites
@@ -20,6 +21,12 @@ func (srv *Service) Close() error {
 		}
 	}
 
+	// Stop and join background migration work before tearing down the store
+	// and clients it uses.
+	if srv.migrator != nil {
+		srv.migrator.Close()
+	}
+
 	srv.tns.Close()
 	srv.components.close()
 
@@ -30,4 +37,10 @@ func (srv *Service) Close() error {
 
 func (srv *Service) Dev() bool {
 	return srv.dev
+}
+
+// Migrator exposes the node-local data migration for tests and ops: a pass can
+// be re-run at any time and is idempotent.
+func (srv *Service) Migrator() *migration.Migrator {
+	return srv.migrator
 }

--- a/services/substrate/migration/enumerate.go
+++ b/services/substrate/migration/enumerate.go
@@ -1,0 +1,115 @@
+package migration
+
+import (
+	"context"
+	"sort"
+
+	"github.com/ipfs/boxo/blockservice"
+	"github.com/ipfs/boxo/blockstore"
+	offline "github.com/ipfs/boxo/exchange/offline"
+	"github.com/ipfs/boxo/ipld/merkledag"
+	ds "github.com/ipfs/go-datastore"
+	query "github.com/ipfs/go-datastore/query"
+	crdt "github.com/ipfs/go-ds-crdt"
+	ipld "github.com/ipfs/go-ipld-format"
+)
+
+// crdtPrefix is where every kvdb namespace lives in the node's datastore
+// (pkg/kvdb opens path p at /crdt/<p>).
+const crdtPrefix = "/crdt/"
+
+// namespaces enumerates the distinct kvdb namespaces held in the node's local
+// datastore. On a migrated (or fresh) node this is one empty prefix query.
+func (m *Migrator) namespaces(ctx context.Context) ([]string, error) {
+	return namespacesOf(ctx, m.node.Store())
+}
+
+func namespacesOf(ctx context.Context, store ds.Batching) ([]string, error) {
+	res, err := store.Query(ctx, query.Query{Prefix: crdtPrefix, KeysOnly: true})
+	if err != nil {
+		return nil, err
+	}
+	defer res.Close()
+
+	set := make(map[string]struct{})
+	for e := range res.Next() {
+		if e.Error != nil {
+			return nil, e.Error
+		}
+		if h := splitNamespaceKey(e.Key); h != "" {
+			set[h] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(set))
+	for h := range set {
+		out = append(out, h)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// openLegacyView opens a READ-side view of a node-local kvdb namespace with a
+// nil broadcaster (go-ds-crdt's offline mode) and an offline-exchange DAG
+// service. Reading must never announce heads or fetch remote blocks: the local
+// copy joining the live CRDT of the same path would merge data around the
+// hoarder write path (and around its at-rest cipher). This is the only place
+// the package touches go-ds-crdt.
+func openLegacyView(store ds.Batching, hash string) (*crdt.Datastore, error) {
+	opts := crdt.DefaultOptions()
+	opts.Logger = logger
+	return crdt.New(store, ds.NewKey(crdtPrefix+hash), offlineDAG(store), nil, opts)
+}
+
+// offlineDAG is a local-only DAG service over the node's datastore, mirroring
+// how the node itself wraps it (blocks under /blocks, identity CIDs inlined) —
+// reads that miss locally fail instead of touching the network.
+func offlineDAG(store ds.Batching) ipld.DAGService {
+	bs := blockstore.NewIdStore(blockstore.NewBlockstore(store))
+	return merkledag.NewDAGService(blockservice.New(bs, offline.Exchange(bs)))
+}
+
+// Namespaces enumerates the kvdb namespaces held in a node datastore — the
+// offline-inspection entry point (tools) over the same logic the boot pass
+// uses.
+func Namespaces(ctx context.Context, store ds.Batching) ([]string, error) {
+	return namespacesOf(ctx, store)
+}
+
+// Entries reads every logical key/value of one namespace through the offline
+// view — never announcing heads, never touching the network.
+func Entries(ctx context.Context, store ds.Batching, hash string) (map[string][]byte, error) {
+	view, err := openLegacyView(store, hash)
+	if err != nil {
+		return nil, err
+	}
+	defer view.Close()
+	return localEntries(ctx, view)
+}
+
+// FileCids extracts the file content CIDs a storage-shaped namespace's
+// metadata records.
+func FileCids(entries map[string][]byte) []string {
+	return fileCidsOf(entries)
+}
+
+// localEntries lists every logical key/value of a namespace through its
+// offline view (tombstone-correct, unlike scanning raw set keys).
+func localEntries(ctx context.Context, view *crdt.Datastore) (map[string][]byte, error) {
+	res, err := view.Query(ctx, query.Query{})
+	if err != nil {
+		return nil, err
+	}
+	defer res.Close()
+
+	out := make(map[string][]byte)
+	for e := range res.Next() {
+		if e.Error != nil {
+			return nil, e.Error
+		}
+		v := make([]byte, len(e.Value))
+		copy(v, e.Value)
+		out[e.Key] = v
+	}
+	return out, nil
+}

--- a/services/substrate/migration/migration.go
+++ b/services/substrate/migration/migration.go
@@ -1,0 +1,193 @@
+// Package migration moves node-local project data — per-instance kvdbs under
+// /crdt/<hash> and locally-held storage file bytes — into hoarder-hosted
+// instances and the hoarder stash, then scrubs the local copies. It runs at
+// substrate boot (bounded, then background) and is idempotent: every pass
+// re-enumerates what is still local, replays it conditionally (putnx — a value
+// written through the live path is never overwritten), verifies by read-back,
+// and only then deletes. Source data is never deleted before verified
+// read-back; unresolvable namespaces are left intact and reported.
+package migration
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ipfs/go-log/v2"
+	hoarderIface "github.com/taubyte/tau/core/services/hoarder"
+	tnsIface "github.com/taubyte/tau/core/services/tns"
+	"github.com/taubyte/tau/p2p/peer"
+)
+
+var logger = log.Logger("tau.substrate.migration")
+
+// Tunables — exported so tests can shrink them.
+var (
+	// BootTimeout bounds the synchronous boot-time pass; work left when it
+	// expires continues in the background (the node serves meanwhile).
+	BootTimeout = 10 * time.Minute
+
+	// DrainInterval is the background retry period while local data remains —
+	// it picks up instances that become resolvable later (a hoarder meta
+	// appears when live traffic first-touches a regex-matched instance) and
+	// retries transient failures.
+	DrainInterval = 30 * time.Second
+
+	// ReplayWorkers is the per-instance bound on in-flight key replays.
+	ReplayWorkers = 8
+)
+
+// Migrator owns the migration lifecycle for one substrate node.
+type Migrator struct {
+	node    peer.Node
+	hoarder hoarderIface.Client
+	tns     tnsIface.Client
+
+	passMu sync.Mutex // one pass at a time
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	drainMu sync.Mutex
+	drainOn bool
+}
+
+// New builds a Migrator. ctx is the service lifetime: Close cancels its child
+// and joins any background work before returning.
+func New(ctx context.Context, node peer.Node, hoarder hoarderIface.Client, tns tnsIface.Client) *Migrator {
+	m := &Migrator{node: node, hoarder: hoarder, tns: tns}
+	m.ctx, m.cancel = context.WithCancel(ctx)
+	return m
+}
+
+// Boot runs the synchronous boot-time pass, bounded by BootTimeout. A node
+// with no local project data pays one prefix query. Work left at the bound —
+// or instances that need live traffic to become resolvable — continues on the
+// background drain.
+func (m *Migrator) Boot() *Report {
+	hashes, err := m.namespaces(m.ctx)
+	if err != nil {
+		logger.Errorf("enumerating local data failed with: %s", err)
+		return &Report{}
+	}
+	if len(hashes) == 0 {
+		return &Report{}
+	}
+
+	logger.Infof("found %d node-local data namespace(s), migrating to hoarders", len(hashes))
+	bctx, cancel := context.WithTimeout(m.ctx, BootTimeout)
+	defer cancel()
+
+	report := m.Migrate(bctx)
+	if report.RemainingCount() > 0 {
+		logger.Errorf("data migration incomplete: %s — continuing in background", report.Summary())
+		m.armDrain()
+	} else {
+		logger.Infof("data migration complete: %s", report.Summary())
+	}
+	return report
+}
+
+// Migrate runs one full pass: enumerate → resolve → replay → verify → scrub →
+// sweep. Safe to re-run at any time; passes serialize. Nothing local is
+// deleted unless its instance verified read-back through the hoarder path and
+// (for storage bytes) the stash reached its replica target.
+func (m *Migrator) Migrate(ctx context.Context) *Report {
+	m.passMu.Lock()
+	defer m.passMu.Unlock()
+
+	report := &Report{Instances: make(map[string]*InstanceReport)}
+
+	hashes, err := m.namespaces(ctx)
+	if err != nil {
+		report.Err = fmt.Sprintf("enumerate: %s", err)
+		return report
+	}
+	if len(hashes) == 0 {
+		return report
+	}
+
+	resolved, unresolved, err := m.resolve(ctx, hashes)
+	if err != nil {
+		// Resolution is all-or-nothing per source: a failed TNS/hoarder listing
+		// carries every namespace over to the next pass — never classified,
+		// never touched.
+		report.Err = fmt.Sprintf("resolve: %s", err)
+		report.Unresolved = hashes
+		return report
+	}
+	report.Unresolved = unresolved
+
+	order := make([]string, 0, len(resolved))
+	for h := range resolved {
+		order = append(order, h)
+	}
+	sort.Strings(order)
+
+	for _, hash := range order {
+		if ctx.Err() != nil {
+			report.Err = ctx.Err().Error()
+			break
+		}
+		report.Instances[hash] = m.replayInstance(ctx, resolved[hash])
+	}
+
+	m.scrubAndSweep(ctx, report, hashes)
+	return report
+}
+
+// armDrain starts (once) the background loop that re-runs Migrate until
+// nothing local remains.
+func (m *Migrator) armDrain() {
+	m.drainMu.Lock()
+	defer m.drainMu.Unlock()
+	if m.drainOn {
+		return
+	}
+	m.drainOn = true
+
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		defer func() {
+			m.drainMu.Lock()
+			m.drainOn = false
+			m.drainMu.Unlock()
+		}()
+		ticker := time.NewTicker(DrainInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-m.ctx.Done():
+				return
+			case <-ticker.C:
+				report := m.Migrate(m.ctx)
+				if report.Err == "" && report.RemainingCount() == 0 {
+					logger.Info("data migration drained: nothing local remains")
+					return
+				}
+				logger.Infof("data migration drain: %s", report.Summary())
+			}
+		}
+	}()
+}
+
+// Close stops background work and joins it — a canceled drain must not touch
+// the node's store or the clients while the service tears them down.
+func (m *Migrator) Close() {
+	m.cancel()
+	m.wg.Wait()
+}
+
+// splitNamespaceKey returns the namespace hash of a raw /crdt/... datastore key.
+func splitNamespaceKey(key string) string {
+	rest := strings.TrimPrefix(key, crdtPrefix)
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		return rest[:i]
+	}
+	return rest
+}

--- a/services/substrate/migration/migration_test.go
+++ b/services/substrate/migration/migration_test.go
@@ -1,0 +1,574 @@
+package migration
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	peerCore "github.com/libp2p/go-libp2p/core/peer"
+	coreKvdb "github.com/taubyte/tau/core/kvdb"
+	hoarderIface "github.com/taubyte/tau/core/services/hoarder"
+	tnsIface "github.com/taubyte/tau/core/services/tns"
+	"github.com/taubyte/tau/p2p/peer"
+	"github.com/taubyte/tau/pkg/kvdb"
+	structureSpec "github.com/taubyte/tau/pkg/specs/structure"
+	mh "github.com/taubyte/tau/utils/multihash"
+)
+
+// --- fakes ------------------------------------------------------------------
+
+// fakeNx is an in-memory NxKVDB standing in for the hoarder-hosted instance.
+type fakeNx struct {
+	coreKvdb.KVDB // panics on anything not overridden
+	mu            sync.Mutex
+	data          map[string][]byte
+	failPut       bool
+	dropOnVerify  string // key Get pretends is missing
+}
+
+func newFakeNx() *fakeNx { return &fakeNx{data: make(map[string][]byte)} }
+
+func (f *fakeNx) PutNx(_ context.Context, key string, v []byte) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failPut {
+		return false, errors.New("injected put failure")
+	}
+	if _, ok := f.data[key]; ok {
+		return true, nil
+	}
+	f.data[key] = append([]byte{}, v...)
+	return false, nil
+}
+
+func (f *fakeNx) Get(_ context.Context, key string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if key == f.dropOnVerify {
+		return nil, errors.New("key not found")
+	}
+	v, ok := f.data[key]
+	if !ok {
+		return nil, errors.New("key not found")
+	}
+	return v, nil
+}
+
+func (f *fakeNx) Close() {}
+
+// fakeHoarder implements the hoarder client over in-memory state.
+type fakeHoarder struct {
+	hoarderIface.Client
+	mu       sync.Mutex
+	kvs      map[string]*fakeNx // instance hash → store
+	stashed  map[string][]byte  // cid → bytes
+	claims   map[string]int
+	target   int
+	metas    map[string]hoarderIface.InstanceInfo
+	metasErr error
+}
+
+func newFakeHoarder() *fakeHoarder {
+	return &fakeHoarder{
+		kvs:     make(map[string]*fakeNx),
+		stashed: make(map[string][]byte),
+		claims:  make(map[string]int),
+		target:  1,
+		metas:   make(map[string]hoarderIface.InstanceInfo),
+	}
+}
+
+func (f *fakeHoarder) instance(hash string) *fakeNx {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if kv, ok := f.kvs[hash]; ok {
+		return kv
+	}
+	kv := newFakeNx()
+	f.kvs[hash] = kv
+	return kv
+}
+
+func (f *fakeHoarder) KVDB(kind hoarderIface.ResourceKind, project, app, match, _ string) (coreKvdb.KVDB, error) {
+	m := match
+	if kind == hoarderIface.Global {
+		m = "global"
+	}
+	return f.instance(mh.Hash(project + app + m)), nil
+}
+
+func (f *fakeHoarder) Stash(cid string, data io.Reader, _ ...hoarderIface.StashOption) error {
+	b, err := io.ReadAll(data)
+	if err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stashed[cid] = b
+	if f.claims[cid] == 0 {
+		f.claims[cid] = 1
+	}
+	return nil
+}
+
+func (f *fakeHoarder) StashStatus(cids ...string) (map[string]int, int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[string]int, len(cids))
+	for _, c := range cids {
+		out[c] = f.claims[c]
+	}
+	return out, f.target, nil
+}
+
+func (f *fakeHoarder) Metas(hashes ...string) ([]hoarderIface.InstanceInfo, error) {
+	if f.metasErr != nil {
+		return nil, f.metasErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]hoarderIface.InstanceInfo, 0)
+	for _, h := range hashes {
+		if info, ok := f.metas[h]; ok {
+			out = append(out, info)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeHoarder) ReplicasOf(hoarderIface.ResourceKind, string, string, string) ([]peerCore.ID, error) {
+	return nil, nil
+}
+func (f *fakeHoarder) Close() {}
+
+// fakeTns serves a canned projects index and per-scope config lists.
+type fakeTns struct {
+	tnsIface.Client
+	indexKeys []string
+	dbs       map[string]map[string]*structureSpec.Database // "pid/aid" → configs
+	storages  map[string]map[string]*structureSpec.Storage
+	lookupErr error
+}
+
+func (f *fakeTns) Lookup(tnsIface.Query) (interface{}, error) {
+	if f.lookupErr != nil {
+		return nil, f.lookupErr
+	}
+	return f.indexKeys, nil
+}
+
+func (f *fakeTns) Database() tnsIface.StructureIface[*structureSpec.Database] {
+	return fakeStruct[*structureSpec.Database]{scoped: f.dbs}
+}
+func (f *fakeTns) Storage() tnsIface.StructureIface[*structureSpec.Storage] {
+	return fakeStruct[*structureSpec.Storage]{scoped: f.storages}
+}
+
+type fakeStruct[T structureSpec.Structure] struct {
+	tnsIface.StructureIface[T]
+	scoped map[string]map[string]T
+}
+
+func (f fakeStruct[T]) All(pid, aid string, _ ...string) tnsIface.StructureGetter[T] {
+	return fakeGetter[T]{list: f.scoped[pid+"/"+aid]}
+}
+
+type fakeGetter[T structureSpec.Structure] struct {
+	tnsIface.StructureGetter[T]
+	list map[string]T
+}
+
+func (f fakeGetter[T]) List() (map[string]T, string, string, error) {
+	if f.list == nil {
+		return nil, "", "", errors.New("no configs")
+	}
+	return f.list, "commit", "main", nil
+}
+
+// --- helpers ----------------------------------------------------------------
+
+// seedLegacy writes a node-local kvdb namespace the way the previous
+// architecture did — through pkg/kvdb (broadcaster and all), then closed.
+func seedLegacy(t *testing.T, node peer.Node, hash string, entries map[string][]byte, deletes ...string) {
+	t.Helper()
+	factory := kvdb.New(node)
+	db, err := factory.New(logger, hash, 5)
+	if err != nil {
+		t.Fatalf("seeding kvdb failed: %v", err)
+	}
+	ctx := context.Background()
+	for k, v := range entries {
+		if err := db.Put(ctx, k, v); err != nil {
+			t.Fatalf("seed put failed: %v", err)
+		}
+	}
+	for _, k := range deletes {
+		if err := db.Delete(ctx, k); err != nil {
+			t.Fatalf("seed delete failed: %v", err)
+		}
+	}
+	db.Close()
+}
+
+func newTestMigrator(t *testing.T) (*Migrator, *fakeHoarder, *fakeTns) {
+	t.Helper()
+	node := peer.Mock(t.Context())
+	h := newFakeHoarder()
+	tns := &fakeTns{
+		dbs:      map[string]map[string]*structureSpec.Database{},
+		storages: map[string]map[string]*structureSpec.Storage{},
+	}
+	return New(t.Context(), node, h, tns), h, tns
+}
+
+func countPrefix(t *testing.T, m *Migrator, prefix string) int {
+	t.Helper()
+	keys, err := m.rawKeys(t.Context(), prefix)
+	if err != nil {
+		t.Fatalf("rawKeys(%s) failed: %v", prefix, err)
+	}
+	return len(keys)
+}
+
+// --- tests ------------------------------------------------------------------
+
+func TestNamespacesAndLegacyView(t *testing.T) {
+	m, _, _ := newTestMigrator(t)
+	hash := mh.Hash("proj" + "" + "users")
+	seedLegacy(t, m.node, hash, map[string][]byte{"a": []byte("1"), "b": []byte("2")}, "b")
+
+	// Through the exported inspection surface (what tools use).
+	hashes, err := Namespaces(t.Context(), m.node.Store())
+	if err != nil || len(hashes) != 1 || hashes[0] != hash {
+		t.Fatalf("namespaces = %v, err %v", hashes, err)
+	}
+
+	entries, err := Entries(t.Context(), m.node.Store(), hash)
+	if err != nil {
+		t.Fatalf("entries failed: %v", err)
+	}
+	if len(entries) != 1 || string(entries["/a"]) != "1" {
+		t.Fatalf("tombstone semantics broken: %v", entries)
+	}
+	if got := FileCids(map[string][]byte{"/file/x/1": []byte("cid1"), "/other": []byte("x")}); len(got) != 1 || got[0] != "cid1" {
+		t.Fatalf("FileCids wrong: %v", got)
+	}
+}
+
+func TestBootDrainAndClose(t *testing.T) {
+	m, h, tns := newTestMigrator(t)
+
+	// Empty store: Boot is a no-op prefix query.
+	if rep := m.Boot(); !rep.Empty() {
+		t.Fatalf("boot on empty store not empty: %s", rep.Summary())
+	}
+
+	// An unresolvable namespace leaves Boot incomplete and arms the drain;
+	// once the hoarder learns the identity (live first-touch), the drain
+	// migrates it without further intervention.
+	restore := DrainInterval
+	DrainInterval = 50 * time.Millisecond
+	defer func() { DrainInterval = restore }()
+
+	hash := mh.Hash("p1" + "" + "runtime-only")
+	seedLegacy(t, m.node, hash, map[string][]byte{"k": []byte("v")})
+	tns.indexKeys = []string{"/projects/p1/x"}
+
+	rep := m.Boot()
+	if rep.RemainingCount() != 1 {
+		t.Fatalf("boot should leave the unresolvable namespace: %s", rep.Summary())
+	}
+	if rep.Summary() == "" {
+		t.Fatal("summary must not be empty")
+	}
+
+	h.metas[hash] = hoarderIface.InstanceInfo{
+		Hash: hash, Kind: hoarderIface.Database,
+		Meta: hoarderIface.MetaData{ProjectId: "p1", Match: "runtime-only"},
+	}
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if n := countPrefix(t, m, crdtPrefix+hash+"/"); n == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("drain never migrated the instance")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	m.Close() // joins the drain
+
+	if v, ok := h.instance(hash).data["/k"]; !ok || string(v) != "v" {
+		t.Fatalf("drained value wrong: %q ok=%v", v, ok)
+	}
+}
+
+func TestMigrate_ReplayFailureKeepsEverything(t *testing.T) {
+	m, h, tns := newTestMigrator(t)
+
+	hash := mh.Hash("p1" + "" + "users")
+	seedLegacy(t, m.node, hash, map[string][]byte{"k1": []byte("v1")})
+	tns.indexKeys = []string{"/projects/p1/x"}
+	tns.dbs["p1/"] = map[string]*structureSpec.Database{"cfg": {Match: "users"}}
+	h.instance(hash).failPut = true
+
+	report := m.Migrate(t.Context())
+	rep := report.Instances[hash]
+	if rep == nil || rep.Err == "" || rep.Scrubbed {
+		t.Fatalf("failed replay must keep the namespace: %+v", rep)
+	}
+	if n := countPrefix(t, m, crdtPrefix+hash+"/"); n == 0 {
+		t.Fatal("namespace scrubbed despite replay failure")
+	}
+	if s := report.Summary(); s == "" {
+		t.Fatal("summary must not be empty")
+	}
+
+	// Report error path in Summary too.
+	errRep := &Report{Err: "boom"}
+	if s := errRep.Summary(); !strings.Contains(s, "boom") {
+		t.Fatalf("summary must carry the error: %s", s)
+	}
+}
+
+func TestKindName(t *testing.T) {
+	for kind, want := range map[hoarderIface.ResourceKind]string{
+		hoarderIface.Database:        "database",
+		hoarderIface.Storage:         "storage",
+		hoarderIface.Global:          "global",
+		hoarderIface.ResourceKind(9): "kind-9",
+	} {
+		if got := kindName(kind); got != want {
+			t.Fatalf("kindName(%d) = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+func TestResolve_Sources(t *testing.T) {
+	m, h, tns := newTestMigrator(t)
+
+	dbHash := mh.Hash("p1" + "" + "users")
+	regexHash := mh.Hash("p1" + "" + "runtime-name")
+	oldGlobal := mh.Hash("global" + "p1")
+	tns.indexKeys = []string{"/projects/p1/somedb"}
+	tns.dbs["p1/"] = map[string]*structureSpec.Database{
+		"cfg-db": {Match: "users"},
+		"cfg-rx": {Match: "^run.*", Regex: true},
+	}
+
+	resolved, unresolved, err := m.resolve(t.Context(), []string{dbHash, regexHash, oldGlobal})
+	if err != nil {
+		t.Fatalf("resolve failed: %v", err)
+	}
+	if info := resolved[dbHash]; info.Kind != hoarderIface.Database || info.Meta.Match != "users" || info.Meta.Branch != "main" {
+		t.Fatalf("db identity wrong: %+v", info)
+	}
+	if info := resolved[oldGlobal]; info.Kind != hoarderIface.Global || info.Meta.ProjectId != "p1" {
+		t.Fatalf("global identity wrong: %+v", info)
+	}
+	if len(unresolved) != 1 || unresolved[0] != regexHash {
+		t.Fatalf("regex instance should be unresolved: %v", unresolved)
+	}
+
+	// Live traffic first-touched the regex instance: the hoarder now knows it.
+	h.metas[regexHash] = hoarderIface.InstanceInfo{
+		Hash: regexHash, Kind: hoarderIface.Database,
+		Meta: hoarderIface.MetaData{ProjectId: "p1", Match: "runtime-name"},
+	}
+	resolved, unresolved, err = m.resolve(t.Context(), []string{regexHash})
+	if err != nil || len(unresolved) != 0 {
+		t.Fatalf("metas fallback failed: %v / %v", resolved, err)
+	}
+
+	// An outage carries everything over — nothing classified, error returned.
+	tns.lookupErr = errors.New("tns down")
+	if _, _, err = m.resolve(t.Context(), []string{dbHash}); err == nil {
+		t.Fatal("lookup outage must abort the pass")
+	}
+}
+
+func TestMigrate_DatabaseEndToEnd(t *testing.T) {
+	m, h, tns := newTestMigrator(t)
+
+	hash := mh.Hash("p1" + "" + "users")
+	seedLegacy(t, m.node, hash, map[string][]byte{"k1": []byte("v1"), "k2": []byte("v2")})
+	tns.indexKeys = []string{"/projects/p1/x"}
+	tns.dbs["p1/"] = map[string]*structureSpec.Database{"cfg": {Match: "users"}}
+
+	// A live write landed before the replay: it must win.
+	h.instance(hash).data["/k1"] = []byte("live")
+
+	report := m.Migrate(t.Context())
+	rep := report.Instances[hash]
+	if rep == nil || !rep.Verified || !rep.Scrubbed {
+		t.Fatalf("instance not migrated: %+v (report err %q)", rep, report.Err)
+	}
+	if rep.Written != 1 || rep.Superseded != 1 {
+		t.Fatalf("counts wrong: %+v", rep)
+	}
+	if got := h.instance(hash).data["/k1"]; !bytes.Equal(got, []byte("live")) {
+		t.Fatalf("replay overwrote a live value: %q", got)
+	}
+	if got := h.instance(hash).data["/k2"]; !bytes.Equal(got, []byte("v2")) {
+		t.Fatalf("replayed value wrong: %q", got)
+	}
+	if n := countPrefix(t, m, crdtPrefix+hash+"/"); n != 0 {
+		t.Fatalf("namespace not scrubbed: %d keys left", n)
+	}
+	if report.RemainingCount() != 0 {
+		t.Fatalf("nothing should remain: %s", report.Summary())
+	}
+
+	// Idempotency: a re-run finds nothing.
+	if again := m.Migrate(t.Context()); !again.Empty() {
+		t.Fatalf("re-run not empty: %s", again.Summary())
+	}
+}
+
+func TestMigrate_StorageBytesGateAndSweep(t *testing.T) {
+	m, h, tns := newTestMigrator(t)
+	ctx := t.Context()
+
+	// File bytes on the node, named by storage metadata.
+	cid, err := m.node.AddFile(bytes.NewReader(bytes.Repeat([]byte("payload"), 100)))
+	if err != nil {
+		t.Fatalf("AddFile failed: %v", err)
+	}
+	hash := mh.Hash("p1" + "" + "files")
+	seedLegacy(t, m.node, hash, map[string][]byte{
+		"file/data/1": []byte(cid),
+		"v/data":      []byte("1"),
+	})
+	tns.indexKeys = []string{"/projects/p1/x"}
+	tns.storages["p1/"] = map[string]*structureSpec.Storage{"cfg": {Match: "files"}}
+
+	// Fleet target of 2: one stash ack is not enough to drop local bytes.
+	h.target = 2
+
+	report := m.Migrate(ctx)
+	rep := report.Instances[hash]
+	if rep == nil || !rep.Verified {
+		t.Fatalf("instance not verified: %+v (err %q)", rep, report.Err)
+	}
+	if rep.FilesStashed != 1 || !bytes.Equal(h.stashed[cid], bytes.Repeat([]byte("payload"), 100)) {
+		t.Fatalf("bytes not stashed: %+v", rep)
+	}
+	if rep.Scrubbed || rep.FilesAwaitingRepl != 1 {
+		t.Fatalf("under-replicated bytes must block scrub: %+v", rep)
+	}
+	if _, err := m.node.GetFile(ctx, cid); err != nil {
+		t.Fatalf("local bytes must survive the sweep while under-replicated: %v", err)
+	}
+
+	// Fan-out completed: now the scrub and sweep may proceed.
+	h.claims[cid] = 2
+	report = m.Migrate(ctx)
+	rep = report.Instances[hash]
+	if rep == nil || !rep.Scrubbed {
+		t.Fatalf("instance not scrubbed after claims reached target: %+v", rep)
+	}
+	if n := countPrefix(t, m, crdtPrefix); n != 0 {
+		t.Fatalf("namespaces left: %d", n)
+	}
+	if n := countPrefix(t, m, blocksPrefix); n != 0 {
+		t.Fatalf("blocks left after sweep: %d", n)
+	}
+}
+
+func TestMigrate_UnresolvedKeptAndProtected(t *testing.T) {
+	m, h, tns := newTestMigrator(t)
+	ctx := t.Context()
+
+	// A storage-shaped namespace nothing can name yet (regex, never touched):
+	// its metadata AND its file bytes must survive every pass.
+	cid, err := m.node.AddFile(bytes.NewReader([]byte("do not lose me")))
+	if err != nil {
+		t.Fatalf("AddFile failed: %v", err)
+	}
+	hash := mh.Hash("p1" + "" + "mystery")
+	seedLegacy(t, m.node, hash, map[string][]byte{"file/x/1": []byte(cid)})
+	tns.indexKeys = []string{"/projects/p1/x"}
+
+	report := m.Migrate(ctx)
+	if len(report.Unresolved) != 1 || report.Unresolved[0] != hash {
+		t.Fatalf("expected 1 unresolved: %+v", report)
+	}
+	if n := countPrefix(t, m, crdtPrefix+hash+"/"); n == 0 {
+		t.Fatal("unresolved namespace was touched")
+	}
+	if _, err := m.node.GetFile(ctx, cid); err != nil {
+		t.Fatalf("unresolved instance's bytes were swept: %v", err)
+	}
+
+	// First-touch happened: the drain pass resolves and migrates it.
+	h.metas[hash] = hoarderIface.InstanceInfo{
+		Hash: hash, Kind: hoarderIface.Storage,
+		Meta: hoarderIface.MetaData{ProjectId: "p1", Match: "mystery"},
+	}
+	report = m.Migrate(ctx)
+	if rep := report.Instances[hash]; rep == nil || !rep.Scrubbed {
+		t.Fatalf("drained instance not scrubbed: %+v (err %q)", rep, report.Err)
+	}
+}
+
+func TestMigrate_VerifyFailureBlocksScrub(t *testing.T) {
+	m, h, tns := newTestMigrator(t)
+
+	hash := mh.Hash("p1" + "" + "users")
+	seedLegacy(t, m.node, hash, map[string][]byte{"k1": []byte("v1")})
+	tns.indexKeys = []string{"/projects/p1/x"}
+	tns.dbs["p1/"] = map[string]*structureSpec.Database{"cfg": {Match: "users"}}
+
+	h.instance(hash).dropOnVerify = "/k1"
+
+	report := m.Migrate(t.Context())
+	rep := report.Instances[hash]
+	if rep == nil || rep.Verified || rep.Scrubbed {
+		t.Fatalf("verify failure must block scrub: %+v", rep)
+	}
+	if n := countPrefix(t, m, crdtPrefix+hash+"/"); n == 0 {
+		t.Fatal("unverified namespace was scrubbed")
+	}
+	if report.RemainingCount() != 1 {
+		t.Fatalf("instance must remain: %s", report.Summary())
+	}
+}
+
+// TestNoKvdbImport guards the broadcaster-leak hazard structurally: the
+// migration package must never open a namespace through pkg/kvdb — its
+// broadcaster would announce the plaintext local heads to any live replica of
+// the same path.
+func TestNoKvdbImport(t *testing.T) {
+	fset := token.NewFileSet()
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		parsed, err := parser.ParseFile(fset, f, src, parser.ImportsOnly)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, imp := range parsed.Imports {
+			if strings.Contains(imp.Path.Value, "github.com/taubyte/tau/pkg/kvdb") {
+				t.Fatalf("%s imports pkg/kvdb — reads must go through the offline view (%s)", f, imp.Path.Value)
+			}
+		}
+	}
+}

--- a/services/substrate/migration/replay.go
+++ b/services/substrate/migration/replay.go
@@ -1,0 +1,200 @@
+package migration
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/ipfs/boxo/blockstore"
+	"github.com/ipfs/go-cid"
+	hoarderClient "github.com/taubyte/tau/clients/p2p/hoarder"
+	hoarderIface "github.com/taubyte/tau/core/services/hoarder"
+	storageSpec "github.com/taubyte/tau/pkg/specs/storage"
+)
+
+// replayInstance moves one instance: replay every local key through the
+// hoarder data plane conditionally (putnx — a live write is never
+// overwritten), push locally-held storage file bytes to the stash, then
+// verify every local key reads back through the hoarder path. It deletes
+// nothing — scrub decisions happen after the pass, over verified instances.
+func (m *Migrator) replayInstance(ctx context.Context, info hoarderIface.InstanceInfo) *InstanceReport {
+	rep := &InstanceReport{Match: info.Meta.Match, Kind: kindName(info.Kind)}
+
+	view, err := openLegacyView(m.node.Store(), info.Hash)
+	if err != nil {
+		rep.Err = fmt.Sprintf("opening local view: %s", err)
+		return rep
+	}
+	defer view.Close()
+
+	entries, err := localEntries(ctx, view)
+	if err != nil {
+		rep.Err = fmt.Sprintf("listing local keys: %s", err)
+		return rep
+	}
+
+	remote, err := m.hoarder.KVDB(info.Kind, info.Meta.ProjectId, info.Meta.ApplicationId, info.Meta.Match, info.Meta.Branch)
+	if err != nil {
+		rep.Err = fmt.Sprintf("opening hoarder kvdb: %s", err)
+		return rep
+	}
+	defer remote.Close()
+	nx, ok := remote.(hoarderIface.NxKVDB)
+	if !ok {
+		rep.Err = "hoarder kvdb handle lacks conditional writes"
+		return rep
+	}
+
+	keys := make([]string, 0, len(entries))
+	for k := range entries {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Replay: bounded worker pool — per-key round trips dominate the pass.
+	var (
+		mu       sync.Mutex
+		firstErr error
+		sem      = make(chan struct{}, ReplayWorkers)
+		wg       sync.WaitGroup
+	)
+	for _, k := range keys {
+		if ctx.Err() != nil {
+			break
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(key string, value []byte) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			existed, err := nx.PutNx(ctx, key, value)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("putnx %s: %w", key, err)
+				}
+				return
+			}
+			if !existed {
+				rep.Written++
+			}
+		}(k, entries[k])
+	}
+	wg.Wait()
+	if firstErr != nil {
+		rep.Err = firstErr.Error()
+		return rep
+	}
+	if ctx.Err() != nil {
+		rep.Err = ctx.Err().Error()
+		return rep
+	}
+
+	if info.Kind == hoarderIface.Storage {
+		m.stashInstanceFiles(ctx, info.Hash, entries, rep)
+	}
+
+	// Verify: every local key must read back through the hoarder path. A
+	// differing value is a live write superseding the replay — expected, and
+	// the local copy is then strictly older. A missing key fails verification.
+	equal := 0
+	for _, k := range keys {
+		if ctx.Err() != nil {
+			rep.Err = ctx.Err().Error()
+			return rep
+		}
+		got, err := remote.Get(ctx, k)
+		if err != nil {
+			if errors.Is(err, hoarderClient.ErrNotFound) {
+				rep.Err = fmt.Sprintf("verify: key %s missing after replay", k)
+			} else {
+				rep.Err = fmt.Sprintf("verify: reading %s: %s", k, err)
+			}
+			return rep
+		}
+		if bytes.Equal(got, entries[k]) {
+			equal++
+		} else {
+			rep.Superseded++
+		}
+	}
+	// Keys we wrote read back equal too; Existed is the pre-existing remainder.
+	if rep.Existed = equal - rep.Written; rep.Existed < 0 {
+		rep.Existed = 0
+	}
+	rep.Verified = true
+	return rep
+}
+
+// stashInstanceFiles pushes the storage instance's locally-held file bytes to
+// the hoarder stash. CIDs this node has no blocks for are another holder's to
+// push (counted, reported); a failed push leaves the local bytes protected by
+// the sweep keep-set.
+func (m *Migrator) stashInstanceFiles(ctx context.Context, hash string, entries map[string][]byte, rep *InstanceReport) {
+	bs := blockstore.NewIdStore(blockstore.NewBlockstore(m.node.Store()))
+	pushed := make(map[string]struct{})
+
+	for _, cidStr := range fileCidsOf(entries) {
+		if _, done := pushed[cidStr]; done {
+			continue
+		}
+		pushed[cidStr] = struct{}{}
+
+		c, err := cid.Decode(cidStr)
+		if err != nil {
+			continue // not a CID — foreign metadata shape, nothing to push
+		}
+		if has, err := bs.Has(ctx, c); err != nil || !has {
+			rep.FilesElsewhere++
+			continue
+		}
+		rep.fileCids = append(rep.fileCids, cidStr)
+
+		// Online read on purpose: a locally-rooted file with a missing leaf
+		// heals from any fleet holder while we stream it out.
+		f, err := m.node.GetFile(ctx, cidStr)
+		if err != nil {
+			rep.Err = fmt.Sprintf("reading file %s: %s", cidStr, err)
+			return
+		}
+		err = m.hoarder.Stash(cidStr, f, hoarderIface.WithOwner(hash))
+		f.Close()
+		if err != nil {
+			rep.Err = fmt.Sprintf("stashing %s: %s", cidStr, err)
+			return
+		}
+		rep.FilesStashed++
+	}
+}
+
+// fileCidsOf extracts the file content CIDs recorded in a storage instance's
+// metadata (keys file/<name>/<version> → CID string).
+func fileCidsOf(entries map[string][]byte) []string {
+	prefix := "/" + storageSpec.FilePath.String() + "/"
+	out := make([]string, 0)
+	for k, v := range entries {
+		if strings.HasPrefix(k, prefix) {
+			out = append(out, string(v))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func kindName(k hoarderIface.ResourceKind) string {
+	switch k {
+	case hoarderIface.Database:
+		return "database"
+	case hoarderIface.Storage:
+		return "storage"
+	case hoarderIface.Global:
+		return "global"
+	default:
+		return fmt.Sprintf("kind-%d", int(k))
+	}
+}

--- a/services/substrate/migration/report.go
+++ b/services/substrate/migration/report.go
@@ -1,0 +1,74 @@
+package migration
+
+import "fmt"
+
+// InstanceReport is the per-instance outcome of one pass.
+type InstanceReport struct {
+	Match string
+	Kind  string
+
+	Written    int // keys replayed (absent remotely)
+	Existed    int // keys already present remotely with the same value
+	Superseded int // keys present remotely with a different value (live write wins)
+
+	FilesStashed      int // locally-held file bytes pushed to the stash this pass
+	FilesAwaitingRepl int // locally-held file bytes below the stash replica target
+	FilesElsewhere    int // file bytes this node never held (another holder pushes)
+
+	Verified bool // every local key read back through the hoarder path
+	Scrubbed bool // local namespace deleted (implies Verified + bytes at target)
+
+	Err string
+
+	// fileCids are this instance's file content CIDs whose bytes THIS node
+	// holds — the set gated on stash replication before local deletion.
+	fileCids []string
+}
+
+// Report is the outcome of one Migrate pass.
+type Report struct {
+	Instances   map[string]*InstanceReport
+	Unresolved  []string // namespaces with no identity yet — left intact, retried
+	SweptKeys   int      // raw namespace keys deleted
+	SweptBlocks int      // blockstore blocks deleted
+	Err         string
+}
+
+// RemainingCount is how many local namespaces still hold data after the pass.
+func (r *Report) RemainingCount() int {
+	n := len(r.Unresolved)
+	for _, ir := range r.Instances {
+		if !ir.Scrubbed {
+			n++
+		}
+	}
+	return n
+}
+
+// Empty reports a pass that found nothing to do.
+func (r *Report) Empty() bool {
+	return len(r.Instances) == 0 && len(r.Unresolved) == 0 && r.Err == ""
+}
+
+// Summary is a one-line operator-facing digest.
+func (r *Report) Summary() string {
+	var written, existed, superseded, stashed, scrubbed, failed int
+	for _, ir := range r.Instances {
+		written += ir.Written
+		existed += ir.Existed
+		superseded += ir.Superseded
+		stashed += ir.FilesStashed
+		if ir.Scrubbed {
+			scrubbed++
+		}
+		if ir.Err != "" {
+			failed++
+		}
+	}
+	s := fmt.Sprintf("%d instance(s): %d scrubbed, %d failed, %d unresolved; keys %d written / %d existing / %d superseded; %d file(s) stashed; swept %d keys, %d blocks",
+		len(r.Instances), scrubbed, failed, len(r.Unresolved), written, existed, superseded, stashed, r.SweptKeys, r.SweptBlocks)
+	if r.Err != "" {
+		s += "; error: " + r.Err
+	}
+	return s
+}

--- a/services/substrate/migration/resolve.go
+++ b/services/substrate/migration/resolve.go
@@ -1,0 +1,165 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	hoarderIface "github.com/taubyte/tau/core/services/hoarder"
+	tnsIface "github.com/taubyte/tau/core/services/tns"
+	spec "github.com/taubyte/tau/pkg/specs/common"
+	mh "github.com/taubyte/tau/utils/multihash"
+)
+
+// resolve maps local namespace hashes to instance identities. Two sources:
+//
+//  1. TNS — exact-match database/storage configs hash directly
+//     (mh.Hash(project+app+match)), and each project's node-local global kvdb
+//     lives at mh.Hash("global"+project) (the hoarder-hosted global for the
+//     same project is keyed mh.Hash(project+"global"), hence the remap).
+//  2. The hoarder registry — regex-matched instances have no derivable name
+//     until live traffic first-touches them, which records their identity;
+//     Metas recovers it by hash.
+//
+// Hashes neither source names are returned as unresolved: left intact,
+// reported, retried next pass. A failed listing aborts the pass (err != nil) —
+// an outage must carry everything over rather than classify anything.
+func (m *Migrator) resolve(ctx context.Context, hashes []string) (map[string]hoarderIface.InstanceInfo, []string, error) {
+	index, err := m.tnsIndex(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resolved := make(map[string]hoarderIface.InstanceInfo, len(hashes))
+	unmatched := make([]string, 0, len(hashes))
+	for _, h := range hashes {
+		if info, ok := index[h]; ok {
+			resolved[h] = info
+		} else {
+			unmatched = append(unmatched, h)
+		}
+	}
+
+	if len(unmatched) > 0 {
+		metas, err := m.hoarder.Metas(unmatched...)
+		if err != nil {
+			return nil, nil, fmt.Errorf("querying hoarder metas failed with: %w", err)
+		}
+		known := make(map[string]hoarderIface.InstanceInfo, len(metas))
+		for _, info := range metas {
+			known[info.Hash] = info
+		}
+		still := unmatched[:0]
+		for _, h := range unmatched {
+			if info, ok := known[h]; ok {
+				resolved[h] = info
+			} else {
+				still = append(still, h)
+			}
+		}
+		unmatched = still
+	}
+
+	return resolved, unmatched, nil
+}
+
+// tnsIndex builds hash → identity for everything TNS can name: exact-match
+// database/storage configs across all (project, application) scopes, plus the
+// per-project global remap.
+func (m *Migrator) tnsIndex(ctx context.Context) (map[string]hoarderIface.InstanceInfo, error) {
+	scopes, projects, err := m.tnsScopes()
+	if err != nil {
+		return nil, fmt.Errorf("listing TNS project scopes failed with: %w", err)
+	}
+
+	index := make(map[string]hoarderIface.InstanceInfo)
+
+	for _, pid := range projects {
+		// The node-local global kvdb of a project.
+		index[mh.Hash("global"+pid)] = hoarderIface.InstanceInfo{
+			Hash: mh.Hash("global" + pid),
+			Kind: hoarderIface.Global,
+			Meta: hoarderIface.MetaData{ProjectId: pid, Match: "global"},
+		}
+	}
+
+	for _, sc := range scopes {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		// A scope listing that fails contributes nothing this pass — its
+		// instances stay unresolved and are retried; nothing is classified on
+		// an error.
+		if dbs, _, branch, err := m.tns.Database().All(sc.project, sc.app, spec.DefaultBranches...).List(); err == nil {
+			for id, cfg := range dbs {
+				if cfg.Regex {
+					continue
+				}
+				h := mh.Hash(sc.project + sc.app + cfg.Match)
+				index[h] = hoarderIface.InstanceInfo{
+					Hash: h,
+					Kind: hoarderIface.Database,
+					Meta: hoarderIface.MetaData{ConfigId: id, ProjectId: sc.project, ApplicationId: sc.app, Match: cfg.Match, Branch: branch},
+				}
+			}
+		}
+		if sts, _, branch, err := m.tns.Storage().All(sc.project, sc.app, spec.DefaultBranches...).List(); err == nil {
+			for id, cfg := range sts {
+				if cfg.Regex {
+					continue
+				}
+				h := mh.Hash(sc.project + sc.app + cfg.Match)
+				index[h] = hoarderIface.InstanceInfo{
+					Hash: h,
+					Kind: hoarderIface.Storage,
+					Meta: hoarderIface.MetaData{ConfigId: id, ProjectId: sc.project, ApplicationId: sc.app, Match: cfg.Match, Branch: branch},
+				}
+			}
+		}
+	}
+
+	return index, nil
+}
+
+type tnsScope struct {
+	project string
+	app     string
+}
+
+// tnsScopes walks the TNS projects index and returns every (project, app)
+// scope plus the distinct project ids.
+func (m *Migrator) tnsScopes() ([]tnsScope, []string, error) {
+	keysIface, err := m.tns.Lookup(tnsIface.Query{Prefix: []string{"projects"}})
+	if err != nil {
+		return nil, nil, err
+	}
+	keys, ok := keysIface.([]string)
+	if !ok {
+		return nil, nil, fmt.Errorf("unexpected lookup result type %T", keysIface)
+	}
+
+	seen := make(map[tnsScope]struct{})
+	pids := make(map[string]struct{})
+	for _, k := range keys {
+		parts := strings.Split(strings.TrimPrefix(k, "/"), "/")
+		if len(parts) < 2 || parts[0] != "projects" {
+			continue
+		}
+		pid := parts[1]
+		pids[pid] = struct{}{}
+		seen[tnsScope{project: pid}] = struct{}{}
+		if len(parts) >= 4 && parts[2] == "applications" {
+			seen[tnsScope{project: pid, app: parts[3]}] = struct{}{}
+		}
+	}
+
+	scopes := make([]tnsScope, 0, len(seen))
+	for sc := range seen {
+		scopes = append(scopes, sc)
+	}
+	projects := make([]string, 0, len(pids))
+	for pid := range pids {
+		projects = append(projects, pid)
+	}
+	return scopes, projects, nil
+}

--- a/services/substrate/migration/sweep.go
+++ b/services/substrate/migration/sweep.go
@@ -1,0 +1,248 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ipfs/boxo/datastore/dshelp"
+	"github.com/ipfs/go-cid"
+	ds "github.com/ipfs/go-datastore"
+	query "github.com/ipfs/go-datastore/query"
+	ipld "github.com/ipfs/go-ipld-format"
+)
+
+const blocksPrefix = "/blocks/"
+
+// scrubAndSweep deletes what this pass proved safe to delete:
+//
+//   - Per instance: the /crdt/<hash> namespace goes once every key verified
+//     read-back AND (for storage) every locally-held file CID shows stash
+//     claims at the fleet target — a stash ack alone proves one copy, not the
+//     replica target.
+//   - Blocks: a mark-and-sweep over /blocks. The keep-set is everything
+//     reachable from the namespaces still present (their CRDT DAGs and their
+//     file content DAGs); all other blocks on a substrate node are
+//     re-fetchable cache by architecture. The sweep only runs while legacy
+//     namespaces exist(ed) at pass start, so steady-state nodes never touch
+//     their cache.
+func (m *Migrator) scrubAndSweep(ctx context.Context, report *Report, passHashes []string) {
+	if ctx.Err() != nil {
+		return
+	}
+
+	// Bytes gate: live stash claims per locally-held file CID, fleet target.
+	allCids := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, rep := range report.Instances {
+		for _, c := range rep.fileCids {
+			if _, ok := seen[c]; !ok {
+				seen[c] = struct{}{}
+				allCids = append(allCids, c)
+			}
+		}
+	}
+	claims := map[string]int{}
+	target := 1
+	claimsOk := true
+	if len(allCids) > 0 {
+		var err error
+		if claims, target, err = m.hoarder.StashStatus(allCids...); err != nil {
+			// Can't prove replication — keep every byte holder unscrubbed.
+			logger.Errorf("stash status failed with: %s — keeping local bytes", err)
+			claimsOk = false
+		}
+	}
+
+	for hash, rep := range report.Instances {
+		if !rep.Verified || rep.Err != "" {
+			continue
+		}
+		if len(rep.fileCids) > 0 {
+			if !claimsOk {
+				continue
+			}
+			pending := 0
+			for _, c := range rep.fileCids {
+				if claims[c] < target {
+					pending++
+				}
+			}
+			if rep.FilesAwaitingRepl = pending; pending > 0 {
+				continue
+			}
+		}
+		n, err := m.scrubNamespace(ctx, hash)
+		if err != nil {
+			rep.Err = fmt.Sprintf("scrub: %s", err)
+			continue
+		}
+		report.SweptKeys += n
+		rep.Scrubbed = true
+	}
+
+	if ctx.Err() != nil {
+		return
+	}
+
+	remaining := make([]string, 0, len(passHashes))
+	for _, h := range passHashes {
+		if rep, ok := report.Instances[h]; ok && rep.Scrubbed {
+			continue
+		}
+		remaining = append(remaining, h)
+	}
+
+	keep, err := m.keepSet(ctx, remaining)
+	if err != nil {
+		logger.Errorf("building sweep keep-set failed with: %s — skipping block sweep", err)
+		return
+	}
+	swept, err := m.sweepBlocks(ctx, keep)
+	if err != nil {
+		logger.Errorf("block sweep failed with: %s", err)
+	}
+	report.SweptBlocks = swept
+}
+
+// scrubNamespace deletes every raw datastore key of one /crdt/<hash>
+// namespace. The instance's data now lives hoarder-side; a crash mid-scrub
+// leaves keys the next pass re-verifies (already remote) and finishes.
+func (m *Migrator) scrubNamespace(ctx context.Context, hash string) (int, error) {
+	keys, err := m.rawKeys(ctx, crdtPrefix+hash+"/")
+	if err != nil {
+		return 0, err
+	}
+	if err := m.deleteKeys(ctx, keys); err != nil {
+		return 0, err
+	}
+	return len(keys), nil
+}
+
+// keepSet marks every block reachable from the still-present namespaces:
+// their CRDT DAG heads and — since file bytes are separate DAGs only named by
+// metadata values — every file CID their metadata records. Over-keeping is
+// safe; under-keeping never is, so unresolved namespaces contribute both.
+func (m *Migrator) keepSet(ctx context.Context, remaining []string) (map[string]struct{}, error) {
+	dag := offlineDAG(m.node.Store())
+	keep := make(map[string]struct{})
+
+	for _, hash := range remaining {
+		// CRDT DAG: walk from the namespace's heads (/crdt/<hash>/h/<mh>).
+		headKeys, err := m.rawKeys(ctx, crdtPrefix+hash+"/h/")
+		if err != nil {
+			return nil, err
+		}
+		for _, hk := range headKeys {
+			seg := strings.TrimPrefix(hk, crdtPrefix+hash+"/h")
+			c, err := dshelp.DsKeyToCidV1(ds.NewKey(seg), cid.DagProtobuf)
+			if err != nil {
+				continue
+			}
+			m.markReachable(ctx, dag, c, keep)
+		}
+
+		// File content DAGs named by this namespace's metadata.
+		view, err := openLegacyView(m.node.Store(), hash)
+		if err != nil {
+			return nil, err
+		}
+		entries, err := localEntries(ctx, view)
+		view.Close()
+		if err != nil {
+			return nil, err
+		}
+		for _, cidStr := range fileCidsOf(entries) {
+			if c, err := cid.Decode(cidStr); err == nil {
+				m.markReachable(ctx, dag, c, keep)
+			}
+		}
+	}
+	return keep, nil
+}
+
+// markReachable walks a DAG offline, adding every locally-present block's
+// multihash to the keep-set. Missing children are tolerated — what isn't here
+// can't be swept.
+func (m *Migrator) markReachable(ctx context.Context, dag ipld.DAGService, c cid.Cid, keep map[string]struct{}) {
+	key := string(c.Hash())
+	if _, ok := keep[key]; ok {
+		return
+	}
+	nd, err := dag.Get(ctx, c)
+	if err != nil {
+		return
+	}
+	keep[key] = struct{}{}
+	for _, l := range nd.Links() {
+		m.markReachable(ctx, dag, l.Cid, keep)
+	}
+}
+
+// sweepBlocks deletes every /blocks entry whose multihash is not in the
+// keep-set.
+func (m *Migrator) sweepBlocks(ctx context.Context, keep map[string]struct{}) (int, error) {
+	res, err := m.node.Store().Query(ctx, query.Query{Prefix: blocksPrefix, KeysOnly: true})
+	if err != nil {
+		return 0, err
+	}
+	defer res.Close()
+
+	doomed := make([]string, 0)
+	for e := range res.Next() {
+		if e.Error != nil {
+			return 0, e.Error
+		}
+		mhash, err := dshelp.DsKeyToMultihash(ds.NewKey(strings.TrimPrefix(e.Key, "/blocks")))
+		if err != nil {
+			continue // foreign key shape — not ours to touch
+		}
+		if _, ok := keep[string(mhash)]; !ok {
+			doomed = append(doomed, e.Key)
+		}
+	}
+	if err := m.deleteKeys(ctx, doomed); err != nil {
+		return 0, err
+	}
+	return len(doomed), nil
+}
+
+// rawKeys lists raw datastore keys under a prefix.
+func (m *Migrator) rawKeys(ctx context.Context, prefix string) ([]string, error) {
+	res, err := m.node.Store().Query(ctx, query.Query{Prefix: prefix, KeysOnly: true})
+	if err != nil {
+		return nil, err
+	}
+	defer res.Close()
+
+	out := make([]string, 0)
+	for e := range res.Next() {
+		if e.Error != nil {
+			return nil, e.Error
+		}
+		out = append(out, e.Key)
+	}
+	return out, nil
+}
+
+// deleteKeys removes raw keys in bounded batches.
+func (m *Migrator) deleteKeys(ctx context.Context, keys []string) error {
+	const chunk = 512
+	for len(keys) > 0 {
+		n := min(chunk, len(keys))
+		batch, err := m.node.Store().Batch(ctx)
+		if err != nil {
+			return err
+		}
+		for _, k := range keys[:n] {
+			if err := batch.Delete(ctx, ds.NewKey(k)); err != nil {
+				return err
+			}
+		}
+		if err := batch.Commit(ctx); err != nil {
+			return err
+		}
+		keys = keys[n:]
+	}
+	return nil
+}

--- a/services/substrate/migration/tests/migration_test.go
+++ b/services/substrate/migration/tests/migration_test.go
@@ -1,0 +1,310 @@
+//go:build dreaming
+
+package tests
+
+import (
+	"bytes"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-log/v2"
+	hoarderClient "github.com/taubyte/tau/clients/p2p/hoarder"
+	_ "github.com/taubyte/tau/clients/p2p/hoarder/dream"
+	_ "github.com/taubyte/tau/clients/p2p/tns/dream"
+	commonIface "github.com/taubyte/tau/core/common"
+	hoarderIface "github.com/taubyte/tau/core/services/hoarder"
+	"github.com/taubyte/tau/dream"
+	"github.com/taubyte/tau/pkg/kvdb"
+	hoarderSpecs "github.com/taubyte/tau/pkg/specs/hoarder"
+	structureSpec "github.com/taubyte/tau/pkg/specs/structure"
+	tccCompiler "github.com/taubyte/tau/pkg/tcc/taubyte/v1"
+	substrateSrv "github.com/taubyte/tau/services/substrate"
+	_ "github.com/taubyte/tau/services/substrate/dream"
+	"github.com/taubyte/tau/services/substrate/migration"
+	_ "github.com/taubyte/tau/services/tns/dream"
+	mh "github.com/taubyte/tau/utils/multihash"
+	tcc "github.com/taubyte/tau/utils/tcc"
+	"gotest.tools/v3/assert"
+
+	dsquery "github.com/ipfs/go-datastore/query"
+)
+
+const (
+	projectID  = "Qmc3WjpDvCaVY3jWmxranUY7roFhRj66SNqstiRbKxDbU4"
+	dbMatch    = "/mig/db1"
+	stMatch    = "/mig/st1"
+	rtPattern  = "^/rt/.*"
+	rtConcrete = "/rt/one"
+	branch     = "main"
+)
+
+var (
+	testLogger            = log.Logger("tau.migration.tests")
+	generatedDomainRegExp = regexp.MustCompile(`^[^.]+\.g\.tau\.link$`)
+	fileBytes             = bytes.Repeat([]byte("stored file payload "), 64)
+)
+
+func fastConvergence(t *testing.T) {
+	t.Helper()
+	origHB := hoarderSpecs.HeartbeatInterval
+	origBackstop := hoarderSpecs.ReconcileBackstop
+	origJitter := hoarderSpecs.ReconcileJitter
+	hoarderSpecs.HeartbeatInterval = 500 * time.Millisecond
+	hoarderSpecs.ReconcileBackstop = 3 * time.Second
+	hoarderSpecs.ReconcileJitter = 100 * time.Millisecond
+	t.Cleanup(func() {
+		hoarderSpecs.HeartbeatInterval = origHB
+		hoarderSpecs.ReconcileBackstop = origBackstop
+		hoarderSpecs.ReconcileJitter = origJitter
+	})
+}
+
+// publishGenerated compiles a virtual project holding the given resources and
+// publishes it to the universe's TNS.
+func publishGenerated(t *testing.T, u *dream.Universe, resources ...interface{}) {
+	t.Helper()
+	fs, _, err := tcc.GenerateProject(projectID, resources...)
+	assert.NilError(t, err)
+
+	compiler, err := tccCompiler.New(tccCompiler.WithVirtual(fs, "/"), tccCompiler.WithBranch(branch))
+	assert.NilError(t, err)
+	obj, validations, err := compiler.Compile(u.Context())
+	assert.NilError(t, err)
+	pid, err := tcc.ExtractProjectID(validations)
+	assert.NilError(t, err)
+	assert.NilError(t, tcc.ProcessDNSValidations(validations, generatedDomainRegExp, true, nil))
+
+	flat := obj.Flat()
+	object := flat["object"].(map[string]interface{})
+	indexes := flat["indexes"].(map[string]interface{})
+
+	simple, err := u.Simple("client")
+	assert.NilError(t, err)
+	tns, err := simple.TNS()
+	assert.NilError(t, err)
+	assert.NilError(t, tcc.Publish(tns, object, indexes, pid, branch, "migCommit1"))
+}
+
+// seedLocal writes a namespace into the substrate node's datastore the way the
+// node-local architecture did — through the kvdb layer, then closed.
+func seedLocal(t *testing.T, u *dream.Universe, hash string, entries map[string][]byte) {
+	t.Helper()
+	factory := kvdb.New(u.Substrate().Node())
+	db, err := factory.New(testLogger, hash, 5)
+	assert.NilError(t, err)
+	for k, v := range entries {
+		assert.NilError(t, db.Put(u.Context(), k, v))
+	}
+	db.Close()
+}
+
+func crdtKeyCount(t *testing.T, u *dream.Universe, prefix string) int {
+	t.Helper()
+	res, err := u.Substrate().Node().Store().Query(u.Context(), dsquery.Query{Prefix: prefix, KeysOnly: true})
+	assert.NilError(t, err)
+	entries, err := res.Rest()
+	assert.NilError(t, err)
+	return len(entries)
+}
+
+// TestMigration_Dreaming is the end-to-end keystone: seed node-local data in
+// every shape the old architecture produced (exact-match database, storage
+// metadata + file bytes, the project global under its old hash, and a
+// regex-matched instance), migrate, and prove everything is readable through
+// the hoarder path and gone locally — with a live write never clobbered and a
+// re-run finding nothing.
+func TestMigration_Dreaming(t *testing.T) {
+	fastConvergence(t)
+
+	m, err := dream.New(t.Context())
+	assert.NilError(t, err)
+	defer m.Close()
+
+	u, err := m.New(dream.UniverseConfig{Name: t.Name()})
+	assert.NilError(t, err)
+
+	assert.NilError(t, u.StartWithConfig(&dream.Config{
+		Services: map[string]commonIface.ServiceConfig{
+			"tns":       {},
+			"hoarder":   {},
+			"substrate": {},
+		},
+		Simples: map[string]dream.SimpleConfig{
+			"client": {Clients: dream.SimpleConfigClients{TNS: &commonIface.ClientConfig{}}.Compat()},
+		},
+	}))
+	u.Mesh()
+
+	publishGenerated(t, u,
+		&structureSpec.Database{Name: "migdb", Match: dbMatch, Size: 1000000},
+		&structureSpec.Database{Name: "migrt", Match: rtPattern, Regex: true, Size: 1000000},
+		&structureSpec.Storage{Name: "migst", Type: "object", Match: stMatch, Size: 1000000000},
+	)
+
+	// Let the substrate node discover the hoarder before driving remote ops.
+	time.Sleep(6 * time.Second)
+
+	// Seed the pre-hoarder shape on the substrate node.
+	cid, err := u.Substrate().Node().AddFile(bytes.NewReader(fileBytes))
+	assert.NilError(t, err)
+
+	dbHash := mh.Hash(projectID + "" + dbMatch)
+	stHash := mh.Hash(projectID + "" + stMatch)
+	rtHash := mh.Hash(projectID + "" + rtConcrete)
+	oldGlobal := mh.Hash("global" + projectID)
+
+	seedLocal(t, u, dbHash, map[string][]byte{"alpha": []byte("old"), "/nested/k": []byte("v2")})
+	seedLocal(t, u, stHash, map[string][]byte{"file/doc/1": []byte(cid), "v/doc": []byte("1")})
+	seedLocal(t, u, rtHash, map[string][]byte{"rk": []byte("rv")})
+	seedLocal(t, u, oldGlobal, map[string][]byte{"g": []byte("gv")})
+
+	hcli, err := hoarderClient.New(u.Context(), u.Substrate().Node())
+	assert.NilError(t, err)
+
+	// A live write through the data plane, racing ahead of the migration: it
+	// must win over the replayed value. First-touch may need the config to
+	// propagate — bounded retry.
+	liveKV, err := hcli.KVDB(hoarderIface.Database, projectID, "", dbMatch, branch)
+	assert.NilError(t, err)
+	deadline := time.Now().Add(90 * time.Second)
+	for {
+		if err = liveKV.Put(u.Context(), "alpha", []byte("live")); err == nil || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	assert.NilError(t, err)
+
+	sub, ok := u.Substrate().(*substrateSrv.Service)
+	assert.Assert(t, ok, "universe substrate is not the concrete service")
+
+	// Pass 1: everything TNS can name migrates; the regex instance has no
+	// durable name yet and must be left intact.
+	var report *migration.Report
+	deadline = time.Now().Add(90 * time.Second)
+	for {
+		report = sub.Migrator().Migrate(u.Context())
+		if len(report.Instances) == 3 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	assert.Equal(t, len(report.Instances), 3, report.Summary())
+	for _, h := range []string{dbHash, stHash, oldGlobal} {
+		rep := report.Instances[h]
+		assert.Assert(t, rep != nil && rep.Scrubbed, "instance %s not scrubbed: %s", h, report.Summary())
+	}
+	assert.Equal(t, len(report.Unresolved), 1, report.Summary())
+	assert.Equal(t, report.Unresolved[0], rtHash)
+
+	// The live write survived; the replayed keys read back via the hoarder.
+	v, err := liveKV.Get(u.Context(), "alpha")
+	assert.NilError(t, err)
+	assert.Equal(t, string(v), "live")
+	v, err = liveKV.Get(u.Context(), "/nested/k")
+	assert.NilError(t, err)
+	assert.Equal(t, string(v), "v2")
+
+	globalKV, err := hcli.KVDB(hoarderIface.Global, projectID, "", "global", "")
+	assert.NilError(t, err)
+	v, err = globalKV.Get(u.Context(), "g")
+	assert.NilError(t, err)
+	assert.Equal(t, string(v), "gv")
+
+	stKV, err := hcli.KVDB(hoarderIface.Storage, projectID, "", stMatch, branch)
+	assert.NilError(t, err)
+	v, err = stKV.Get(u.Context(), "file/doc/1")
+	assert.NilError(t, err)
+	assert.Equal(t, string(v), cid)
+
+	// File bytes are stash-claimed and served by the hoarder; the substrate
+	// node no longer holds the namespaces nor the blocks.
+	claims, target, err := hcli.StashStatus(cid)
+	assert.NilError(t, err)
+	assert.Assert(t, claims[cid] >= target, "cid claims %d < target %d", claims[cid], target)
+	f, err := u.Hoarder().Node().GetFile(u.Context(), cid)
+	assert.NilError(t, err)
+	got := make([]byte, len(fileBytes))
+	_, err = f.Read(got)
+	f.Close()
+	assert.NilError(t, err)
+	assert.DeepEqual(t, got, fileBytes)
+
+	for _, h := range []string{dbHash, stHash, oldGlobal} {
+		assert.Equal(t, crdtKeyCount(t, u, "/crdt/"+h), 0, "namespace %s not empty", h)
+	}
+	assert.Assert(t, crdtKeyCount(t, u, "/crdt/"+rtHash) > 0, "unresolved namespace must stay intact")
+
+	// Live traffic first-touches the regex instance, giving it a durable
+	// identity; the next pass drains it.
+	rtKV, err := hcli.KVDB(hoarderIface.Database, projectID, "", rtConcrete, branch)
+	assert.NilError(t, err)
+	if _, err = rtKV.Get(u.Context(), "rk"); err != nil {
+		assert.Assert(t, errors.Is(err, hoarderClient.ErrNotFound), "first-touch read: %v", err)
+	}
+
+	report = sub.Migrator().Migrate(u.Context())
+	rep := report.Instances[rtHash]
+	assert.Assert(t, rep != nil && rep.Scrubbed, "regex instance not drained: %s", report.Summary())
+	v, err = rtKV.Get(u.Context(), "rk")
+	assert.NilError(t, err)
+	assert.Equal(t, string(v), "rv")
+
+	// Nothing local remains; a re-run finds nothing to do.
+	assert.Equal(t, crdtKeyCount(t, u, "/crdt/"), 0)
+	report = sub.Migrator().Migrate(u.Context())
+	assert.Assert(t, report.Empty(), "re-run not empty: %s", report.Summary())
+}
+
+// TestMigrationFailClosed_Dreaming proves the never-delete-before-verified
+// rule under infrastructure failure: with the hoarders dead the replay fails
+// and the local data survives untouched; with TNS dead resolution carries
+// everything over without classifying anything.
+func TestMigrationFailClosed_Dreaming(t *testing.T) {
+	fastConvergence(t)
+
+	m, err := dream.New(t.Context())
+	assert.NilError(t, err)
+	defer m.Close()
+
+	u, err := m.New(dream.UniverseConfig{Name: t.Name()})
+	assert.NilError(t, err)
+
+	assert.NilError(t, u.StartWithConfig(&dream.Config{
+		Services: map[string]commonIface.ServiceConfig{
+			"tns":       {},
+			"hoarder":   {},
+			"substrate": {},
+		},
+		Simples: map[string]dream.SimpleConfig{
+			"client": {Clients: dream.SimpleConfigClients{TNS: &commonIface.ClientConfig{}}.Compat()},
+		},
+	}))
+	u.Mesh()
+
+	publishGenerated(t, u, &structureSpec.Database{Name: "migdb", Match: dbMatch, Size: 1000000})
+	time.Sleep(6 * time.Second)
+
+	dbHash := mh.Hash(projectID + "" + dbMatch)
+	seedLocal(t, u, dbHash, map[string][]byte{"alpha": []byte("v")})
+
+	sub, ok := u.Substrate().(*substrateSrv.Service)
+	assert.Assert(t, ok)
+
+	// Kill the hoarder: replay must fail and delete nothing.
+	assert.NilError(t, u.Kill("hoarder"))
+	report := sub.Migrator().Migrate(u.Context())
+	if rep := report.Instances[dbHash]; rep != nil {
+		assert.Assert(t, !rep.Scrubbed && rep.Err != "", "unreachable hoarders must fail the instance: %+v", rep)
+	}
+	assert.Assert(t, crdtKeyCount(t, u, "/crdt/"+dbHash) > 0, "local data must survive a dead fleet")
+
+	// Kill TNS too: resolution errors and everything carries over.
+	assert.NilError(t, u.Kill("tns"))
+	report = sub.Migrator().Migrate(u.Context())
+	assert.Assert(t, report.Err != "", "a dead TNS must abort the pass")
+	assert.Equal(t, len(report.Unresolved), 1)
+	assert.Assert(t, crdtKeyCount(t, u, "/crdt/"+dbHash) > 0, "local data must survive a TNS outage")
+}

--- a/services/substrate/new.go
+++ b/services/substrate/new.go
@@ -19,6 +19,7 @@ import (
 	orbit "github.com/taubyte/tau/pkg/vm-orbit/satellite/vm"
 	seer "github.com/taubyte/tau/pkg/yaseer"
 	protocolCommon "github.com/taubyte/tau/services/common"
+	"github.com/taubyte/tau/services/substrate/migration"
 )
 
 var (
@@ -65,6 +66,13 @@ func New(ctx context.Context, cfg tauConfig.Config) (*Service, error) {
 	if srv.hoarderClient, err = hoarderClient.New(ctx, clientNode); err != nil {
 		return nil, fmt.Errorf("creating hoarder client failed with %w", err)
 	}
+
+	// Move any node-local project data (an upgraded node's databases, storage
+	// metadata and file bytes) to the hoarders before serving: bounded
+	// synchronous pass, background continuation past the bound. Fresh nodes
+	// pay one empty prefix query.
+	srv.migrator = migration.New(ctx, srv.node, srv.hoarderClient, srv.tns)
+	srv.migrator.Boot()
 
 	if err = srv.startVm(); err != nil {
 		return nil, fmt.Errorf("starting vm failed with %w", err)

--- a/services/substrate/type.go
+++ b/services/substrate/type.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/taubyte/tau/p2p/peer"
 	http "github.com/taubyte/tau/pkg/http"
+	"github.com/taubyte/tau/services/substrate/migration"
 )
 
 var _ iface.Service = &Service{}
@@ -31,6 +32,7 @@ type Service struct {
 
 	hoarderClient hoarderIface.Client
 	tns           tns.Client
+	migrator      *migration.Migrator
 	orbitals      []vm.Plugin
 
 	cpuCount   int


### PR DESCRIPTION
Upgraded nodes can still hold project data written before the hoarder data plane existed: per-instance kvdbs under `/crdt/<hash>` in the substrate node's datastore, file bytes in its blockstore, and TNS-recorded build assets that never reached the stash. This adds the upgrade path that moves all of it to the hoarders with verified read-back, then scrubs the local copies. Source data is never deleted before it reads back through the hoarder path.

## substrate — `services/substrate/migration`

- **Boot pass**: runs synchronously before the node serves, bounded by `BootTimeout` (10m); leftovers continue on a background drain that `Close` cancels and joins. Fresh nodes pay one empty prefix query.
- **Identity**: TNS names exact-match database/storage configs and each project's global (the node-local hash `mh.Hash("global"+project)` remaps to the hosted `project+"global"` instance). Regex-matched instances resolve at runtime: the first live touch records their identity in the hoarder registry, and the drain picks them up via the new `metas` query. Namespaces neither source names are left intact and reported; a failed listing carries everything over untouched.
- **Replay**: conditional per-key writes (`putnx`, bounded worker pool) so a value written through the live path is never overwritten by the replay. Every key must read back through the hoarder path before anything is deleted.
- **Storage bytes**: locally-held file CIDs stream to the stash; local deletion additionally requires live stash claims at the fleet-clamped replica target.
- **Scrub**: verified namespaces are deleted and the blockstore is mark-and-swept — the keep-set is everything reachable from the namespaces still present (their CRDT DAGs and file content DAGs); the rest of a substrate blockstore is re-fetchable cache. Local reads use a nil-broadcaster offline CRDT view so nothing announces heads or merges around the hoarder write path (guarded by a lint-style test).

## hoarder

- **`putnx` kvop**: put-if-absent under a per-instance write lock shared with put/delete/batch — held across the local commit only, the K=2 barrier runs outside the lock. Exposed on the remote KVDB handle as `PutNx`.
- **`metas` / `stashStatus` actions**: read-only lookups resolving instance hashes to placement identity records, and CIDs to live stash claim counts plus the fleet-clamped target.
- **Asset sweep**: each hoarder lists the TNS assets index (at boot and on a slow recurring interval) and stash-replicates any CID below the live claim target — one adopter per CID, additive-only; a TNS outage just retries.

## cli

- **`tau export {list,dump,file}`**: read-only inspection and export of the data still held in a stopped node's datastore (`<root>/<service>`, default substrate; refuses a running node's locked store) — the operator action path for anything the migration reports but cannot move.

## Testing

- Unit + `-race`: putnx atomicity against concurrent puts, replay semantics (absent/equal/superseded), verify-blocks-scrub, mark-and-sweep keep-set (shared blocks, under-replicated CIDs), drain lifecycle joined by Close, resolver outage discipline, offline-view tombstone correctness, `tau export` round-trips.
- Dreaming E2E (`services/substrate/migration/tests`): seed every node-local shape (exact db, storage metadata + bytes, old-hash global, regex instance) → migrate → all readable through the hoarder client, `/crdt` empty locally, live write survives, regex instance drains after first-touch, re-run is a no-op. Fail-closed: dead hoarder fleet and dead TNS both delete nothing. Asset sweep adoption from a non-hoarder holder.
- `tools/coverage-gate.sh`: all touched packages ≥ 80%.
- Full `GOMEMLIMIT=4GiB go test -p 1` sweeps green with both `-tags dreaming` and `-tags raft_integration`, including the existing K=2 durability keystone.
