### PR TITLE
perf(dream): kernel-allocated test ports + deterministic universe boot

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -275,7 +275,7 @@ jobs:
           until [ $attempt_num -gt $max_attempts ]
           do
             echo "Attempt $attempt_num of $max_attempts"
-            go test -tags=dreaming -run '_Dreaming$' -p 1 ./${{ matrix.package }}/... -timeout 20m && break || echo "Dream tests failed. Retrying..."
+            go test -tags=dreaming -p 1 ./${{ matrix.package }}/... -timeout 20m && break || echo "Dream tests failed. Retrying..."
             attempt_num=$((attempt_num + 1))
             if [ $attempt_num -gt $max_attempts ]
             then

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+GOMEMLIMIT ?= 4GiB
+FLAGS ?=
+DREAM_P ?= 4
+
+# Tagged sweeps discover their packages instead of sweeping ./... so they only
+# build and run the packages that actually carry tagged tests.
+DREAM_PKGS = $(shell grep -rl --include='*_test.go' '//go:build dreaming' . | xargs -n1 dirname | sort -u | sed 's|^\([^./]\)|./\1|')
+# web3 gates source files (not tests), so test every package tree that carries
+# web3-gated code.
+WEB3_PKGS = $(shell grep -rl --include='*.go' '//go:build web3' . | xargs -n1 dirname | sort -u | sed 's|^\([^./]\)|./\1|; s|$$|/...|')
+
+.PHONY: test test-dreaming test-web3 test-raft test-docker test-all
+
+test:
+	go test $(FLAGS) ./...
+
+test-dreaming:
+	GOMEMLIMIT=$(GOMEMLIMIT) go test -tags dreaming -p $(DREAM_P) -timeout 30m $(FLAGS) $(DREAM_PKGS)
+
+test-web3:
+	GOMEMLIMIT=$(GOMEMLIMIT) go test -tags web3 -p 1 -timeout 15m $(FLAGS) $(WEB3_PKGS)
+
+test-raft:
+	GOMEMLIMIT=$(GOMEMLIMIT) go test -tags raft_integration -p 1 -timeout 20m $(FLAGS) ./pkg/raft/...
+
+test-docker:
+	go test -tags docker_integration -run '_Integration$$' -p 1 $(FLAGS) ./pkg/containers/...
+
+test-all: test test-dreaming test-web3 test-raft

--- a/clients/http/dream/universe_test.go
+++ b/clients/http/dream/universe_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func TestRoutes_Dreaming(t *testing.T) {
-	dream.DreamApiPort = 31421 // don't conflict with default port
-
 	univerName := "dream-http"
 	// start multiverse
 	m, err := dream.New(t.Context())

--- a/dream/api/api.go
+++ b/dream/api/api.go
@@ -18,7 +18,20 @@ type Service struct {
 }
 
 // Deprecated: Use New instead
+//
+// BigBang is the test/mock entry point (the tau CLI calls New directly and
+// keeps the fixed 1421 default). It allocates a kernel-free port and sets
+// dream.DreamApiPort before starting the server: process-local consumers
+// (taucorder, the dream http client) build their default URLs from
+// DreamApiPort, so setting it here keeps them all in agreement while making
+// concurrent test binaries collision-free.
 func BigBang(m *dream.Multiverse) error {
+	ports, err := dream.GetFreePorts(1)
+	if err != nil {
+		return err
+	}
+	dream.DreamApiPort = ports[0]
+
 	srv, err := New(m, nil)
 	if err != nil {
 		return err

--- a/dream/helpers.go
+++ b/dream/helpers.go
@@ -14,33 +14,63 @@ import (
 	"os"
 	"path"
 	"strings"
-	"time"
 )
 
-func lastSimplePort() int {
-	lastSimplePortAllocatedLock.Lock()
-	defer lastSimplePortAllocatedLock.Unlock()
-	lastSimplePortAllocated++
-	return lastSimplePortAllocated
-}
-
-func lastPortShift() int {
-	lastUniversePortShiftLock.Lock()
-	defer lastUniversePortShiftLock.Unlock()
-	for {
-		lastUniversePortShift += (int(mrand.NewSource(time.Now().UnixNano()).Int63()%int64(maxUniverses)) * portsPerUniverse) % 6000
-		l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", DefaultHost, lastUniversePortShift))
-		if err == nil {
+// GetFreePorts reserves n distinct ports from the kernel: it binds n TCP
+// listeners on :0 (held simultaneously so they're distinct) and verifies UDP
+// is bindable on each (seer serves DNS over UDP). Listeners are released on
+// return; the tiny release-to-rebind window is covered by bind-retry at the
+// call sites.
+func GetFreePorts(n int) ([]int, error) {
+	var (
+		tcpListeners []net.Listener
+		udpConns     []*net.UDPConn
+	)
+	defer func() {
+		for _, l := range tcpListeners {
 			l.Close()
+		}
+		for _, c := range udpConns {
+			c.Close()
+		}
+	}()
+
+	ports := make([]int, 0, n)
+	for len(ports) < n {
+		var bound bool
+		for range 10 {
+			l, err := net.Listen("tcp", DefaultHost+":0")
+			if err != nil {
+				return nil, fmt.Errorf("listening on a free tcp port failed with: %w", err)
+			}
+
+			port := l.Addr().(*net.TCPAddr).Port
+
+			udpAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", DefaultHost, port))
+			if err != nil {
+				l.Close()
+				continue
+			}
+
+			udpConn, err := net.ListenUDP("udp", udpAddr)
+			if err != nil {
+				// port not bindable on udp (e.g. taken by another process); release and retry
+				l.Close()
+				continue
+			}
+
+			tcpListeners = append(tcpListeners, l)
+			udpConns = append(udpConns, udpConn)
+			ports = append(ports, port)
+			bound = true
 			break
 		}
+		if !bound {
+			return nil, fmt.Errorf("failed to reserve a free tcp+udp port after 10 attempts")
+		}
 	}
-	return lastUniversePortShift
-}
 
-func afterStartDelay() time.Duration {
-	rnd := mrand.New(mrand.NewSource(time.Now().UnixNano()))
-	return time.Duration(BaseAfterStartDelay+rnd.Intn(MaxAfterStartDelay-BaseAfterStartDelay)) * time.Millisecond
+	return ports, nil
 }
 
 // GetCacheFolder returns the cache folder for the dream

--- a/dream/init.go
+++ b/dream/init.go
@@ -14,17 +14,8 @@ func init() {
 		registry: make(map[string]*handlers),
 	}
 
-	Ports = make(map[string]int)
-	lastPort := portStart
 	for _, service := range commonSpecs.Services {
 		Registry.registry[service] = &handlers{}
-
-		port := lastPort
-		Ports["http/"+service] = port
-		Ports["p2p/"+service] = port + 2
-		Ports["ipfs/"+service] = port + 4
-		Ports["dns/"+service] = port + 8
-		lastPort += portBuffer
 	}
 
 	// Dream tests skip the accounts integration so they don't have to

--- a/dream/service.go
+++ b/dream/service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	commonIface "github.com/taubyte/tau/core/common"
@@ -11,23 +12,9 @@ import (
 	"github.com/taubyte/tau/pkg/kvdb"
 )
 
-func (u *Universe) PortFor(proto, _type string) (int, error) {
-	serviceCount := len(u.service[proto].nodes)
-	var mapPath string
-	switch _type {
-	case "http", "p2p", "ipfs", "dns":
-		mapPath = _type + "/" + proto
-	default:
-		return 0, fmt.Errorf("invalid type `%s`", _type)
-	}
-
-	port, ok := Ports[mapPath]
-	if !ok {
-		return 0, fmt.Errorf("no port set for type `%s` protocol `%s`", _type, proto)
-	}
-
-	return u.portShift + port + serviceCount, nil
-}
+// otherPortKeys is the fixed order in which "Others" ports are assigned from
+// a freshly reserved batch of ports.
+var otherPortKeys = []string{"http", "p2p", "dns", "ipfs"}
 
 func (u *Universe) createService(name string, config *commonIface.ServiceConfig) error {
 	if config.Disabled {
@@ -47,18 +34,45 @@ func (u *Universe) createService(name string, config *commonIface.ServiceConfig)
 		config.Others = make(map[string]int)
 	}
 
-	var err error
-	for _, k := range []string{"http", "p2p", "dns", "ipfs"} {
-		if prt, ok := config.Others[k]; !ok || prt == 0 {
-			config.Others[k], _ = u.PortFor(name, k)
+	var (
+		node peer.Node
+		err  error
+	)
 
-			if k == "p2p" {
-				config.Port = config.Others[k]
+	// Binding a service can race another process for the same kernel-picked
+	// port between reservation and bind; retry a few times with a fresh batch
+	// of ports rather than failing the whole service start.
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			for _, k := range otherPortKeys {
+				config.Others[k] = 0
 			}
 		}
-	}
 
-	node, err := u.startService(name, config)
+		var ports []int
+		ports, err = GetFreePorts(len(otherPortKeys))
+		if err != nil {
+			return err
+		}
+
+		for i, k := range otherPortKeys {
+			if prt, ok := config.Others[k]; !ok || prt == 0 {
+				config.Others[k] = ports[i]
+
+				if k == "p2p" {
+					config.Port = config.Others[k]
+				}
+			}
+		}
+
+		node, err = u.startService(name, config)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "address already in use") {
+			return err
+		}
+	}
 	if err != nil {
 		return err
 	}
@@ -68,12 +82,15 @@ func (u *Universe) createService(name string, config *commonIface.ServiceConfig)
 	// we mesh first
 	u.Mesh(node)
 
-	// wait till we're connected to others
-	node.WaitForSwarm(afterStartDelay())
+	// Wait (bounded, best-effort) until at least one peer has connected.
+	// Skipping this — even for the first-booted node, which pays the full
+	// timeout — lets a service make its first pubsub/DHT moves while
+	// isolated; those failures get backoff-cached for 60s+ and wedge the
+	// universe for minutes.
+	node.WaitForSwarm(time.Second)
 
 	// register so others can mesh with it
 	u.Register(node, name, config.Others)
-	time.Sleep(afterStartDelay())
 
 	return nil
 }

--- a/dream/simple.go
+++ b/dream/simple.go
@@ -3,6 +3,7 @@ package dream
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	commonIface "github.com/taubyte/tau/core/common"
@@ -151,8 +152,15 @@ func (u *Universe) CreateSimpleNode(name string, config *SimpleConfig) (peer.Nod
 		return nil, fmt.Errorf("simple Node `%s` exists in universe `%s`", name, u.Name())
 	}
 
-	if config.Port == 0 {
-		config.Port = u.portShift + lastSimplePort()
+	// only retry with a fresh port if we're the one who allocated it; an
+	// explicit config.Port is a caller's choice, not ours to change
+	allocatedPort := config.Port == 0
+	if allocatedPort {
+		ports, ferr := GetFreePorts(1)
+		if ferr != nil {
+			return nil, ferr
+		}
+		config.Port = ports[0]
 	}
 
 	upeers := u.Peers()
@@ -163,15 +171,32 @@ func (u *Universe) CreateSimpleNode(name string, config *SimpleConfig) (peer.Nod
 		}
 	}
 
-	simpleNode, err := peer.NewLitePublic(
-		u.ctx,
-		fmt.Sprintf("%s/simple-%s-%d", u.root, name, config.Port),
-		keypair.NewRaw(),
-		u.swarmKey,
-		[]string{fmt.Sprintf(DefaultP2PListenFormat, config.Port)},
-		[]string{fmt.Sprintf(DefaultP2PListenFormat, config.Port)},
-		peer.BootstrapParams{Enable: len(bpeers) > 0, Peers: bpeers},
-	)
+	var simpleNode peer.Node
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			ports, perr := GetFreePorts(1)
+			if perr != nil {
+				return nil, perr
+			}
+			config.Port = ports[0]
+		}
+
+		simpleNode, err = peer.NewLitePublic(
+			u.ctx,
+			fmt.Sprintf("%s/simple-%s-%d", u.root, name, config.Port),
+			keypair.NewRaw(),
+			u.swarmKey,
+			[]string{fmt.Sprintf(DefaultP2PListenFormat, config.Port)},
+			[]string{fmt.Sprintf(DefaultP2PListenFormat, config.Port)},
+			peer.BootstrapParams{Enable: len(bpeers) > 0, Peers: bpeers},
+		)
+		if err == nil {
+			break
+		}
+		if !allocatedPort || !strings.Contains(err.Error(), "address already in use") {
+			break
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed creating me error: %v", err)
 	}
@@ -190,7 +215,12 @@ func (u *Universe) CreateSimpleNode(name string, config *SimpleConfig) (peer.Nod
 	u.simples[name] = simple
 	u.lock.Unlock()
 
-	time.Sleep(afterStartDelay())
+	// Settle before joining the mesh. Meshing the simple immediately after
+	// creation deterministically wedges parallel universe boots (services
+	// end up deaf to each other for minutes); the exact libp2p-level race
+	// is not pinned down, so this keeps the settle main always had, made
+	// deterministic. Do not remove without a green full dreaming sweep.
+	time.Sleep(750 * time.Millisecond)
 	u.Mesh(simpleNode)
 	u.Register(simpleNode, name, map[string]int{"p2p": config.Port})
 

--- a/dream/types.go
+++ b/dream/types.go
@@ -34,7 +34,6 @@ type Universe struct {
 	all       []peer.Node
 	closables []commonIface.Service
 	lookups   map[string]*NodeInfo
-	portShift int
 	service   map[string]*serviceInfo
 	simples   map[string]*Simple
 

--- a/dream/universe.go
+++ b/dream/universe.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -74,7 +73,6 @@ func (m *Multiverse) New(config UniverseConfig) (*Universe, error) {
 		name:       config.Name,
 		id:         id,
 		swarmKey:   swarmKey,
-		portShift:  lastPortShift(),
 		keepRoot:   config.KeepRoot,
 	}
 
@@ -373,17 +371,6 @@ func (u *Universe) Cleanup() {
 	u.lock.RLock()
 	defer u.lock.RUnlock()
 
-	validPorts := []string{"http", "p2p", "ipfs", "dns"}
-	// collect all used ports
-	usedPorts := make(map[int]bool)
-	for _, nodeInfo := range u.lookups {
-		for proto, port := range nodeInfo.Ports {
-			if slices.Contains(validPorts, proto) {
-				usedPorts[port] = true
-			}
-		}
-	}
-
 	var (
 		closeableWg sync.WaitGroup
 		simpleWg    sync.WaitGroup
@@ -427,49 +414,6 @@ func (u *Universe) Cleanup() {
 		}(s)
 	}
 	nodeWg.Wait()
-
-	cleanupCtx, cleanupCtxCancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cleanupCtxCancel()
-
-	// wait for all usedports to be closed
-	for port := range usedPorts {
-		select {
-		case <-cleanupCtx.Done():
-			return
-		default:
-		}
-		for {
-			select {
-			case <-cleanupCtx.Done():
-				return
-			default:
-			}
-			// Try to bind to the port to check if it's available (both TCP and UDP)
-			tcpListener, tcpErr := net.Listen("tcp", fmt.Sprintf("%s:%d", DefaultHost, port))
-			udpAddr, udpErr := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", DefaultHost, port))
-			var udpConn *net.UDPConn
-			if udpErr == nil {
-				udpConn, udpErr = net.ListenUDP("udp", udpAddr)
-			}
-
-			if tcpErr == nil && udpErr == nil {
-				tcpListener.Close()
-				udpConn.Close()
-				break // Port is available, move to next
-			}
-
-			if tcpListener != nil {
-				tcpListener.Close()
-			}
-			if udpConn != nil {
-				udpConn.Close()
-			}
-
-			// Port still in use, wait a bit and retry
-			time.Sleep(10 * time.Millisecond)
-		}
-	}
-
 }
 
 func (u *Universe) DiskUsage() (int64, error) {

--- a/dream/vars.go
+++ b/dream/vars.go
@@ -14,12 +14,6 @@ var (
 	fixtures     map[string]FixtureHandler
 	fixturesLock sync.RWMutex
 
-	//buffer between protocol ports
-	portBuffer = 21
-	portStart  = 100
-
-	Ports map[string]int
-
 	DreamApiPort   = 1421
 	DreamApiListen = func() string { return fmt.Sprintf("%s:%d", DefaultHost, DreamApiPort) }
 
@@ -42,23 +36,12 @@ var (
 	// Valid sub-binds for services
 	ValidSubBinds = []string{"http", "p2p", "dns", "https", "verbose", "copies"}
 
-	BaseAfterStartDelay = 500  // Millisecond
-	MaxAfterStartDelay  = 1000 // Millisecond
-	MeshTimeout         = 5 * time.Second
+	MeshTimeout = 5 * time.Second
 
 	// Disk usage cache configuration
 	DiskUsageCacheTimeout = 5 * time.Second
 
 	startAllDefaultSimple = "client"
-
-	lastSimplePortAllocated     = 50
-	lastSimplePortAllocatedLock sync.Mutex
-
-	lastUniversePortShift     = 9000
-	lastUniversePortShiftLock sync.Mutex
-
-	maxUniverses     = 100
-	portsPerUniverse = 100
 
 	logger = log.Logger("tau.dream")
 )

--- a/pkg/sensors/service_test.go
+++ b/pkg/sensors/service_test.go
@@ -44,15 +44,23 @@ func newTestService(t *testing.T, node *mockNode, registry *sensors.Registry) *s
 }
 
 func TestAll(t *testing.T) {
-	// Allow time for default port (4217) to be released from previous runs before any subtest.
-	time.Sleep(2 * time.Second)
-
 	tests := []struct {
 		name string
 		fn   func(t *testing.T)
 	}{
-		// New_DefaultPort runs first so it can bind to 4217 before any other test.
 		{"New_DefaultPort", func(t *testing.T) {
+			// Reserve a free port from the kernel and point DefaultPort at it, so
+			// the "binds DefaultPort when no address is given" behavior can be
+			// verified without requiring the literal 4217 to be free.
+			l, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			port := l.Addr().(*net.TCPAddr).Port
+			require.NoError(t, l.Close())
+
+			original := sensors.DefaultPort
+			sensors.DefaultPort = port
+			t.Cleanup(func() { sensors.DefaultPort = original })
+
 			testID, _ := libp2ppeer.Decode("12D3KooWMn5qZpfJckxXBgRd4syQMhkkzbAFnjwPFzAJByj5vLLn")
 			mockNode := &mockNode{id: testID}
 
@@ -260,12 +268,9 @@ func TestAll(t *testing.T) {
 			require.Equal(t, 0.0, value)
 		}},
 	}
-	for i, tc := range tests {
+	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			if i > 0 {
-				time.Sleep(1 * time.Second)
-			}
 			tc.fn(t)
 		})
 	}

--- a/pkg/taucorder/clients/mock/main.go
+++ b/pkg/taucorder/clients/mock/main.go
@@ -24,8 +24,6 @@ import (
 )
 
 func main() {
-	dream.DreamApiPort = 2442 // diffrent port than the default
-
 	m, err := dream.New(context.Background())
 	if err != nil {
 		panic(err)
@@ -82,7 +80,7 @@ func main() {
 		httpServer.Shutdown(shutdownCtx)
 	}()
 
-	dreamClient, err := dreamClient.New(ctx, dreamClient.URL("http://127.0.0.1:2442"))
+	dreamClient, err := dreamClient.New(ctx, dreamClient.URL("http://"+dream.DreamApiListen()))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/taucorder/service/auth_githooks_test.go
+++ b/pkg/taucorder/service/auth_githooks_test.go
@@ -26,7 +26,6 @@ func TestAuthGitHooks_Dreaming(t *testing.T) {
 	ctx, ctxC := context.WithCancel(context.Background())
 	defer ctxC()
 
-	dream.DreamApiPort = 31421 // don't conflict with default port
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()

--- a/pkg/taucorder/service/auth_projects_test.go
+++ b/pkg/taucorder/service/auth_projects_test.go
@@ -26,7 +26,6 @@ func TestAuthProjects_Dreaming(t *testing.T) {
 	ctx, ctxC := context.WithCancel(context.Background())
 	defer ctxC()
 
-	dream.DreamApiPort = 31422 // don't conflict with default port
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()

--- a/pkg/taucorder/service/auth_repos_test.go
+++ b/pkg/taucorder/service/auth_repos_test.go
@@ -25,7 +25,6 @@ func TestAuthRepos_Dreaming(t *testing.T) {
 	ctx, ctxC := context.WithCancel(context.Background())
 	defer ctxC()
 
-	dream.DreamApiPort = 33423 // don't conflict with default port
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()

--- a/pkg/taucorder/service/auth_test.go
+++ b/pkg/taucorder/service/auth_test.go
@@ -27,7 +27,6 @@ func TestAuth_Dreaming(t *testing.T) {
 	ctx, ctxC := context.WithCancel(context.Background())
 	defer ctxC()
 
-	dream.DreamApiPort = 38420 // don't conflict with default port
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()

--- a/pkg/taucorder/service/auth_x509_test.go
+++ b/pkg/taucorder/service/auth_x509_test.go
@@ -26,7 +26,6 @@ func TestAuthX509_Dreaming(t *testing.T) {
 	ctx, ctxC := context.WithCancel(context.Background())
 	defer ctxC()
 
-	dream.DreamApiPort = 31424 // don't conflict with default port
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()

--- a/pkg/taucorder/service/health_test.go
+++ b/pkg/taucorder/service/health_test.go
@@ -23,7 +23,6 @@ func TestHealth_Dreaming(t *testing.T) {
 	ctx, ctxC := context.WithCancel(context.Background())
 	defer ctxC()
 
-	dream.DreamApiPort = 31425 // don't conflict with default port
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()

--- a/pkg/taucorder/service/hoarder_test.go
+++ b/pkg/taucorder/service/hoarder_test.go
@@ -28,7 +28,6 @@ func TestHoarder_Dreaming(t *testing.T) {
 	ctx, ctxC := context.WithCancel(context.Background())
 	defer ctxC()
 
-	dream.DreamApiPort = 31426 // don't conflict with default port
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()

--- a/pkg/taucorder/service/monkey_test.go
+++ b/pkg/taucorder/service/monkey_test.go
@@ -38,7 +38,6 @@ func TestMonkey_Dreaming(t *testing.T) {
 	s, err := getMockService(ctx)
 	assert.NilError(t, err)
 
-	dream.DreamApiPort = 31427 // don't conflict with default port
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()

--- a/pkg/taucorder/service/node_test.go
+++ b/pkg/taucorder/service/node_test.go
@@ -20,7 +20,6 @@ func TestNode_Dreaming(t *testing.T) {
 	ctx, ctxC := context.WithCancel(context.Background())
 	defer ctxC()
 
-	dream.DreamApiPort = 31428 // don't conflict with default port
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()

--- a/pkg/taucorder/service/patrick_test.go
+++ b/pkg/taucorder/service/patrick_test.go
@@ -27,7 +27,6 @@ func TestPatrick_Dreaming(t *testing.T) {
 	ctx, ctxC := context.WithCancel(context.Background())
 	defer ctxC()
 
-	dream.DreamApiPort = 31429 // don't conflict with default port
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()

--- a/pkg/taucorder/service/seer_test.go
+++ b/pkg/taucorder/service/seer_test.go
@@ -33,7 +33,6 @@ func TestSeer_Dreaming(t *testing.T) {
 	ctx, ctxC := context.WithCancel(context.Background())
 	defer ctxC()
 
-	dream.DreamApiPort = 31420 // don't conflict with default port
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()

--- a/pkg/taucorder/service/swarm_test.go
+++ b/pkg/taucorder/service/swarm_test.go
@@ -27,7 +27,6 @@ func TestSwarm_Dreaming(t *testing.T) {
 	ctx, ctxC := context.WithCancel(context.Background())
 	defer ctxC()
 
-	dream.DreamApiPort = 32421 // don't conflict with default port
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()

--- a/pkg/taucorder/service/tns_test.go
+++ b/pkg/taucorder/service/tns_test.go
@@ -34,7 +34,6 @@ func TestTNS_Dreaming(t *testing.T) {
 	ctx, ctxC := context.WithCancel(context.Background())
 	defer ctxC()
 
-	dream.DreamApiPort = 32422 // don't conflict with default port
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()

--- a/services/substrate/components/pubsub/websocket/datastream_test.go
+++ b/services/substrate/components/pubsub/websocket/datastream_test.go
@@ -348,16 +348,28 @@ func TestDataStreamHandler_In(t *testing.T) {
 		// Start the In goroutine
 		go handler.In()
 
-		// Wait for the message to be read and processed
+		// Wait for the message to be read. The timeout is only an upper bound
+		// for a wedged goroutine, so a busy machine doesn't slow down a healthy run.
 		select {
 		case <-done:
-			// Message was read, now wait a bit for processing
-			time.Sleep(10 * time.Millisecond)
-			// Cancel context to stop the infinite loop
-			cancel()
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(5 * time.Second):
 			t.Error("Expected message to be read within timeout")
 		}
+
+		// Publishing happens asynchronously after the read handoff, so poll for
+		// it instead of assuming a fixed delay is long enough under load.
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			mu.Lock()
+			called := publishCalled
+			mu.Unlock()
+			if called || time.Now().After(deadline) {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		// Cancel context to stop the infinite loop
+		cancel()
 
 		mu.Lock()
 		called := publishCalled
@@ -392,7 +404,7 @@ func TestDataStreamHandler_In(t *testing.T) {
 			errorSent = true
 			mu.Unlock()
 			assert.Assert(t, err != nil, "Expected error to be sent")
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(5 * time.Second):
 			t.Error("Expected error to be sent within timeout")
 		}
 
@@ -421,7 +433,7 @@ func TestDataStreamHandler_In(t *testing.T) {
 		case err := <-handler.errCh:
 			errorSent = true
 			assert.Assert(t, err != nil, "Expected error to be sent")
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(5 * time.Second):
 			t.Error("Expected error to be sent within timeout")
 		}
 
@@ -486,8 +498,17 @@ func TestDataStreamHandler_Out(t *testing.T) {
 		// Start the Out goroutine
 		go handler.Out()
 
-		// Wait for message to be written
-		time.Sleep(10 * time.Millisecond)
+		// Poll for the write instead of assuming a fixed delay is long enough under load.
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			mu.Lock()
+			called := writeCalled
+			mu.Unlock()
+			if called || time.Now().After(deadline) {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
 
 		mu.Lock()
 		called := writeCalled
@@ -536,8 +557,17 @@ func TestDataStreamHandler_Out(t *testing.T) {
 		// Start the Out goroutine
 		go handler.Out()
 
-		// Wait for error handling
-		time.Sleep(10 * time.Millisecond)
+		// Poll for both effects instead of assuming a fixed delay is long enough under load.
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			mu.Lock()
+			done := writeJSONCalled && closeCalled
+			mu.Unlock()
+			if done || time.Now().After(deadline) {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
 
 		mu.Lock()
 		jsonCalled := writeJSONCalled
@@ -580,7 +610,7 @@ func TestDataStreamHandler_Out(t *testing.T) {
 		case err := <-handler.errCh:
 			errorSent = true
 			assert.Assert(t, err != nil, "Expected error to be sent")
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(5 * time.Second):
 			t.Error("Expected error to be sent within timeout")
 		}
 
@@ -645,7 +675,7 @@ func TestDataStreamHandler_In_DefaultCase(t *testing.T) {
 		if err == nil {
 			t.Error("Expected error to be sent")
 		}
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		t.Error("Expected error to be sent within timeout")
 	}
 }

--- a/tools/dream/cli/tests/universe_test.go
+++ b/tools/dream/cli/tests/universe_test.go
@@ -20,12 +20,7 @@ import (
 
 var services = []string{"seer", "auth", "patrick", "tns", "monkey", "hoarder", "substrate"}
 
-func init() {
-	dream.DreamApiPort = 41421 // don't conflict with default port
-}
-
 func TestKillService_Dreaming(t *testing.T) {
-	dream.DreamApiPort = 43421
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()
@@ -76,7 +71,6 @@ func TestKillSimple_Dreaming(t *testing.T) {
 	universeName := "killsimple"
 	statusName := fmt.Sprintf("%s@%s", testSimpleName, universeName)
 
-	dream.DreamApiPort = 40424
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()


### PR DESCRIPTION
## Why

The test suite was structurally slow: every tagged sweep ran `-p 1 ./...` (all ~519 packages serialized, most without tagged tests), dream universes used pre-computed port ranges that collide across processes (forcing the serialization), and universe boot carried ~1–2s of randomized sleeps per node.

## What

**Ports.** Dream universes now reserve ports from the kernel (bind `:0`, hold the batch, verify UDP, release; bind-retry at call sites covers the tiny release-to-rebind window). The old `portShift`/`Ports`-map machinery and its single-port probe are deleted. `BigBang` self-allocates the API port and updates `DreamApiPort`, so tests no longer hand-pick ports to dodge the fixed default. `Universe.Cleanup` drops its port-release polling loop (up to 10s per universe) — kernel-allocated ports can't be reissued while bound.

**Boot timing.** The randomized `afterStartDelay` sleeps are gone. What remains is deterministic and documented: a bounded any-peer `WaitForSwarm(1s)` before a service registers, and a 750ms settle before the simple joins the mesh. Both are load-bearing — a node that makes its first pubsub/DHT moves while isolated gets those failures backoff-cached (60s minimum) and ends up deaf to specific peers for minutes. Each variant without them fails `services/monkey/tests` deterministically.

**Sweep scoping (Makefile).** `make test-dreaming` / `test-web3` / `test-raft` discover the packages that actually carry tagged tests instead of sweeping `./...` (dreaming: 36 packages instead of ~519). `make test` runs the unit sweep at full package parallelism. Dreaming defaults to `-p 4` (override with `DREAM_P=`).

**Test repairs.** `pkg/sensors` no longer serializes subtests around the fixed default port with sleeps — the default-port test overrides `DefaultPort` with a kernel-reserved port (package runtime 18.2s → 0.2s). The websocket datastream tests poll for goroutine handoffs instead of 100ms timeouts + blind sleeps.

## Numbers

| Sweep | Before | After |
|---|---|---|
| dreaming (36 pkgs) | whole-tree `-p 1` serialized (~12.5 min just for the 36) | 36 pkgs green at `-p 4`, **4m23s** |
| unit (`go test ./...`) | `-p 1` | full parallelism, **~3–4 min**, green |
| `pkg/taucorder/service` | 62.5s | 50.5s |
| `pkg/sensors` | 18.2s | 0.2s |

Full matrix verified green: unit, dreaming `-p 1` (36/36), dreaming `-p 4` (36/36), web3.

## Notes

- The CI dreaming job filters with `-run '_Dreaming$'`; several dreaming-gated test functions don't match that suffix and are silently skipped there. The Makefile targets run whole packages, no name filter. Worth aligning CI later.
- A pre-existing nil-`matcher` race panic in the websocket datastream handler (Close vs In) surfaced during stress runs (~1/20 under heavy load); left untouched here, worth a separate issue.