### PR TITLE
fix(substrate): repair websocket Close/In race test fixture

### DIFF
--- a/services/substrate/components/pubsub/websocket/datastream_test.go
+++ b/services/substrate/components/pubsub/websocket/datastream_test.go
@@ -710,26 +710,32 @@ func TestDataStreamHandler_Out_DefaultCase(t *testing.T) {
 // Test for race conditions and closed channel writes
 func TestDataStreamHandler_RaceConditions(t *testing.T) {
 	t.Run("concurrent close and channel operations", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		// The interesting schedule is In()'s first iteration racing Close()'s
+		// cancel, so run many interleavings and join the goroutines each time
+		// (a wedged In/Out shows up as a test timeout).
+		var handler *dataStreamHandler
+		for i := 0; i < 100; i++ {
+			ctx, cancel := context.WithCancel(context.Background())
 
-		// Create handler with small buffer to increase chance of race conditions
-		handler := &dataStreamHandler{
-			ctx:   ctx,
-			ctxC:  cancel,
-			ch:    make(chan pubsubIface.Message, 1),
-			errCh: make(chan error, 1),
-			conn:  &mockWebSocketConnection{},
-			srv:   &mockLocalService{},
+			handler = createTestHandler(ctx, cancel, &mockWebSocketConnection{}, createMockService(nil))
+
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				handler.In()
+			}()
+			go func() {
+				defer wg.Done()
+				handler.Out()
+			}()
+
+			// Try to close while goroutines are running
+			// This should not panic or cause issues
+			handler.Close()
+			wg.Wait()
+			cancel()
 		}
-
-		// Start In and Out goroutines
-		go handler.In()
-		go handler.Out()
-
-		// Try to close while goroutines are running
-		// This should not panic or cause issues
-		handler.Close()
 
 		// Verify channels are closed
 		verifyChannelsClosed(t, handler)


### PR DESCRIPTION
## What

`TestDataStreamHandler_RaceConditions/concurrent_close_and_channel_operations` panicked ~1 in 20 runs under load with a nil-pointer dereference at `h.matcher.String()`.

Root cause: the subtest hand-rolled its `dataStreamHandler` and forgot the `matcher` field. Whenever `In()`'s first iteration won the race past the context-done check before `Close()`'s cancel landed, it reached the publish call and dereferenced the nil matcher. The flake rate was purely the scheduler deciding that race.

**The handler itself is sound** — verified: `createWsHandler` populates `matcher` before returning, `Handler()` returns nil on every error path, and the production spawn site (`pkg/http/basic/websocket.go`) nil-checks before starting `In()`/`Out()`.

Fix: the subtest now uses the shared `createTestHandler` fixture (complete, like every other subtest) and runs 100 interleavings with goroutine joins — a wedged `In`/`Out` shows up as a timeout, and before this fix the loop panics deterministically.

## Verification

- Pre-fix: `go test -count=100 -race -run '.../concurrent_close_and_channel_operations'` panics within one run.
- Post-fix: same command clean (1.35s); package green `-race -count=5` and plain `-count=2`.