### PR TITLE
perf(substrate): serving-path optimizations, profiling benchmarks, websocket revival

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DREAM_PKGS = $(shell grep -rl --include='*_test.go' '//go:build dreaming' . | xa
 # web3-gated code.
 WEB3_PKGS = $(shell grep -rl --include='*.go' '//go:build web3' . | xargs -n1 dirname | sort -u | sed 's|^\([^./]\)|./\1|; s|$$|/...|')
 
-.PHONY: test test-dreaming test-web3 test-raft test-docker test-all
+.PHONY: test test-dreaming test-web3 test-raft test-docker test-all bench-dreaming
 
 test:
 	go test $(FLAGS) ./...
@@ -27,3 +27,11 @@ test-docker:
 	go test -tags docker_integration -run '_Integration$$' -p 1 $(FLAGS) ./pkg/containers/...
 
 test-all: test test-dreaming test-web3 test-raft
+
+# Profiling benchmarks over a live dream universe (dream/benchmarks).
+# Examples:
+#   make bench-dreaming BENCH=HTTPFunction FLAGS="-cpuprofile=/tmp/cpu.prof -memprofile=/tmp/mem.prof"
+#   make bench-dreaming BENCH=UniverseBoot FLAGS="-benchtime=5x -cpuprofile=/tmp/boot.prof"
+BENCH ?= .
+bench-dreaming:
+	GOMEMLIMIT=$(GOMEMLIMIT) go test -tags dreaming -run '^$$' -bench '$(BENCH)' -benchmem -timeout 30m $(FLAGS) ./dream/benchmarks

--- a/dream/benchmarks/bench_data_test.go
+++ b/dream/benchmarks/bench_data_test.go
@@ -1,0 +1,214 @@
+//go:build dreaming
+
+package benchmarks
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	hoarderClient "github.com/taubyte/tau/clients/p2p/hoarder"
+	db "github.com/taubyte/tau/core/services/substrate/components/database"
+	storageIface "github.com/taubyte/tau/core/services/substrate/components/storage"
+	dbsvc "github.com/taubyte/tau/services/substrate/components/database"
+	storages "github.com/taubyte/tau/services/substrate/components/storage"
+)
+
+var (
+	dataOnce sync.Once
+	dataErr  error
+
+	dbService      db.Service
+	storageService storageIface.Service
+)
+
+// bootData lazily meshes the shared universe's substrate node to the hoarder
+// (in production the pnet swarm links them for the data plane; dream needs
+// an explicit Mesh() call) and constructs the database/storage service
+// handles used by the benchmarks below. Shared by BenchmarkDatabase* and
+// BenchmarkStorage* so the mesh + connectedness poll only happens once.
+func bootData(b *testing.B) (db.Service, storageIface.Service) {
+	b.Helper()
+	u := sharedUniverse(b)
+
+	dataOnce.Do(func() {
+		u.Mesh()
+
+		hcli, err := hoarderClient.New(u.Context(), u.Substrate().Node())
+		if err != nil {
+			dataErr = err
+			return
+		}
+
+		discovered := false
+		for deadline := time.Now().Add(20 * time.Second); time.Now().Before(deadline); {
+			if u.Substrate().Node().Peer().Network().Connectedness(u.Hoarder().Node().ID()) == network.Connected {
+				discovered = true
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		if !discovered {
+			dataErr = fmt.Errorf("substrate node did not discover the hoarder in time")
+			return
+		}
+
+		dsrv, err := dbsvc.New(u.Substrate(), hcli)
+		if err != nil {
+			dataErr = fmt.Errorf("creating database service failed with: %w", err)
+			return
+		}
+		dbService = dsrv
+
+		ssrv, err := storages.New(u.Substrate(), hcli)
+		if err != nil {
+			dataErr = fmt.Errorf("creating storage service failed with: %w", err)
+			return
+		}
+		storageService = ssrv
+	})
+	if dataErr != nil {
+		b.Fatal(dataErr)
+	}
+
+	return dbService, storageService
+}
+
+// benchDatabaseKV resolves the shared benchdb database's KV handle, polling
+// since the config published by bootShared's injectProject takes a moment to
+// propagate through TNS to the substrate's view.
+func benchDatabaseKV(b *testing.B) db.KV {
+	b.Helper()
+	dsrv, _ := bootData(b)
+
+	ctx := db.Context{
+		ProjectId: testProjectId,
+		Matcher:   databaseMatch,
+	}
+
+	var (
+		database db.Database
+		err      error
+	)
+	for deadline := time.Now().Add(90 * time.Second); time.Now().Before(deadline); {
+		database, err = dsrv.Database(ctx)
+		if err == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	return database.KV()
+}
+
+// BenchmarkDatabasePut measures the remote hoarder-backed KV write path.
+func BenchmarkDatabasePut(b *testing.B) {
+	u := sharedUniverse(b)
+	kv := benchDatabaseKV(b)
+	ctx := u.Context()
+	value := bytes.Repeat([]byte("d"), 1024)
+
+	b.ReportAllocs()
+	n := 0
+	for b.Loop() {
+		// strconv.Itoa (not fmt.Sprintf) so unique-key generation stays a
+		// negligible slice of the timed write path rather than a reflection-
+		// backed hot spot.
+		key := "put-bench/" + strconv.Itoa(n)
+		n++
+		if err := kv.Put(ctx, key, value); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkDatabaseGet measures the remote hoarder-backed KV read path.
+func BenchmarkDatabaseGet(b *testing.B) {
+	u := sharedUniverse(b)
+	kv := benchDatabaseKV(b)
+	ctx := u.Context()
+
+	value := bytes.Repeat([]byte("g"), 1024)
+	key := "get-bench/key"
+	if err := kv.Put(ctx, key, value); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		got, err := kv.Get(ctx, key)
+		if err != nil {
+			b.Fatal(err)
+		}
+		// full content check (cheap memcmp of 1KiB) so a truncated or wrong
+		// value fails the benchmark instead of silently mismeasuring the path.
+		if !bytes.Equal(got, value) {
+			b.Fatalf("read mismatch: expected %d bytes got %d", len(value), len(got))
+		}
+	}
+}
+
+// storageBlob is a fixed 256KiB deterministic payload for the storage
+// benchmarks below.
+var storageBlob = func() []byte {
+	blob := make([]byte, 256*1024)
+	for i := range blob {
+		blob[i] = byte(i)
+	}
+	return blob
+}()
+
+// BenchmarkStorageAdd measures the raw blob-add path. Add/GetFile operate
+// directly against the node's blockstore with no project config or TNS
+// lookup involved (see services/substrate/components/storage/methods.go).
+func BenchmarkStorageAdd(b *testing.B) {
+	_, stsrv := bootData(b)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		c, err := stsrv.Add(bytes.NewReader(storageBlob))
+		if err != nil {
+			b.Fatal(err)
+		}
+		// fail fast if Add ever returns a nil/undefined cid with no error,
+		// which would mean we're timing a no-op rather than the add path.
+		if !c.Defined() {
+			b.Fatal("Add returned an undefined cid")
+		}
+	}
+}
+
+// BenchmarkStorageGet measures the raw blob-fetch path.
+func BenchmarkStorageGet(b *testing.B) {
+	u := sharedUniverse(b)
+	_, stsrv := bootData(b)
+
+	cid, err := stsrv.Add(bytes.NewReader(storageBlob))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		file, err := stsrv.GetFile(u.Context(), cid)
+		if err != nil {
+			b.Fatal(err)
+		}
+		n, err := io.Copy(io.Discard, file)
+		if err != nil {
+			b.Fatal(err)
+		}
+		file.Close()
+		if n != int64(len(storageBlob)) {
+			b.Fatalf("expected %d bytes got %d", len(storageBlob), n)
+		}
+	}
+}

--- a/dream/benchmarks/bench_p2p_test.go
+++ b/dream/benchmarks/bench_p2p_test.go
@@ -1,0 +1,231 @@
+//go:build dreaming
+
+package benchmarks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"sync"
+	"testing"
+	"time"
+
+	commonIface "github.com/taubyte/tau/core/common"
+	nodeIface "github.com/taubyte/tau/core/services/substrate"
+	"github.com/taubyte/tau/dream"
+	structureSpec "github.com/taubyte/tau/pkg/specs/structure"
+	"github.com/taubyte/tau/services/monkey/fixtures/compile"
+	"github.com/taubyte/tau/services/substrate/components/p2p"
+	tcc "github.com/taubyte/tau/utils/tcc"
+
+	_ "github.com/taubyte/tau/services/seer/dream"
+)
+
+// BenchmarkP2PFunction needs its own universe rather than sharedUniverse's:
+// the p2p client (p2p/streams/client) resolves the target peer by
+// discovering *other* peers advertising the protocol (it explicitly skips
+// its own node — see refreshFromPeerStore in p2p/streams/client/client.go),
+// so a lone substrate node can never dispatch a p2p command to itself; every
+// send blocks for SendToPeerTimeout (10s) and fails with "i/o timeout"
+// (confirmed empirically). services/substrate/components/p2p/test's own
+// TestFail_Dreaming uses the same two-node shape for the same reason.
+//
+// A second substrate copy could instead be added to the shared universe's
+// Services config, but dream.Universe.Substrate()/GetPortHttp() etc. pick
+// the "first" node out of a map, and Go's map iteration order is randomized
+// per range (confirmed empirically) — with two copies, every other
+// benchmark that calls sharedUniverse(b) would risk racing between the
+// warmed and cold node. A dedicated universe avoids that entirely.
+var (
+	p2pUOnce sync.Once
+	p2pNodeA nodeIface.Service
+	p2pNodeB nodeIface.Service
+	p2pUErr  error
+)
+
+const (
+	p2pProtocol    = "/testproto/v1"
+	p2pCommand     = "someCommand"
+	p2pServiceName = "benchP2PService"
+	p2pFuncName    = "benchP2PFunc"
+	p2pFunctionId  = "QmZY4u91d1YALDN2LTbpVtgwW8iT5cK9PE1bHZqX9J5789"
+
+	// p2pResponse is the exact payload the prebuilt artifact.zwasm binary
+	// returns (confirmed empirically): the checked-in .zwasm predates the
+	// current p2p_method.go source, which now writes a lowercase "hello
+	// from the other side" but the compiled artifact still returns this
+	// capitalized string (matching TestFail_Dreaming's assertion).
+	p2pResponse = "Hello from the other side"
+)
+
+func p2pUniverse(b *testing.B) (nodeIface.Service, nodeIface.Service) {
+	b.Helper()
+	p2pUOnce.Do(func() { p2pNodeA, p2pNodeB, p2pUErr = bootP2P() })
+	if p2pUErr != nil {
+		b.Fatal(p2pUErr)
+	}
+	return p2pNodeA, p2pNodeB
+}
+
+func bootP2P() (nodeIface.Service, nodeIface.Service, error) {
+	m, err := dream.New(context.Background())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	u, err := m.New(dream.UniverseConfig{Name: "bench-p2p"})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = u.StartWithConfig(&dream.Config{
+		Services: map[string]commonIface.ServiceConfig{
+			"tns":       {},
+			"substrate": {Others: map[string]int{"copies": 2}},
+			"hoarder":   {},
+		},
+		Simples: map[string]dream.SimpleConfig{
+			"client": {
+				Clients: dream.SimpleConfigClients{
+					TNS:     &commonIface.ClientConfig{},
+					Hoarder: &commonIface.ClientConfig{},
+				}.Compat(),
+			},
+		},
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// The two substrate copies need to know about each other before the p2p
+	// client's peer discovery can find one from the other.
+	u.Mesh()
+
+	fs, _, err := tcc.GenerateProject(testProjectId,
+		&structureSpec.Service{
+			Name:     p2pServiceName,
+			Protocol: p2pProtocol,
+		},
+		&structureSpec.Function{
+			Id:       p2pFunctionId,
+			Name:     p2pFuncName,
+			Type:     "p2p",
+			Call:     "methodP2P",
+			Command:  p2pCommand,
+			Protocol: p2pProtocol,
+			Memory:   20 * 1024 * 1024,
+			Source:   ".",
+			Timeout:  1000000000,
+		},
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err = u.RunFixture("injectProject", fs); err != nil {
+		return nil, nil, err
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	zwasm := path.Join(wd, "..", "..", "services", "substrate", "components", "p2p", "test", "assets", "artifact.zwasm")
+	if err = u.RunFixture("compileFor", compile.BasicCompileFor{
+		ProjectId:  testProjectId,
+		ResourceId: p2pFunctionId,
+		Paths:      []string{zwasm},
+	}); err != nil {
+		return nil, nil, err
+	}
+
+	pids, err := u.GetServicePids("substrate")
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(pids) != 2 {
+		return nil, nil, fmt.Errorf("expected 2 substrate copies, got %d", len(pids))
+	}
+
+	nodeA, ok := u.SubstrateByPid(pids[0])
+	if !ok {
+		return nil, nil, errors.New("substrate node A not found")
+	}
+	nodeB, ok := u.SubstrateByPid(pids[1])
+	if !ok {
+		return nil, nil, errors.New("substrate node B not found")
+	}
+
+	return nodeA, nodeB, nil
+}
+
+// BenchmarkP2PFunction measures the warm p2p-triggered serving path: stream
+// command -> peer discovery -> service/function lookup -> cached wasm
+// instance call -> response. The stream and command are created once outside
+// the timed loop since Command.Send opens a fresh libp2p connection per call
+// (see services/substrate/components/p2p/stream/command.go), so repeated
+// Send on one Command is safe and representative of the steady-state path.
+func BenchmarkP2PFunction(b *testing.B) {
+	nodeA, _ := p2pUniverse(b)
+
+	srv, err := p2p.New(nodeA)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	stream, err := srv.Stream(nodeA.Context(), testProjectId, "", p2pProtocol)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	cmd, err := stream.Command(p2pCommand)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	ctx := nodeA.Context()
+
+	// The function config needs to propagate through TNS, node B needs to be
+	// discoverable, and the wasm instance needs to warm up before the p2p
+	// dispatch resolves - retry until the first Send succeeds.
+	var lastErr error
+	for i := 0; ; i++ {
+		resp, sendErr := cmd.Send(ctx, map[string]interface{}{"data": []byte("Hello, world")})
+		if sendErr == nil {
+			val, getErr := resp.Get("data")
+			if getErr == nil {
+				if string(val.([]byte)) == p2pResponse {
+					lastErr = nil
+					break
+				}
+				lastErr = fmt.Errorf("unexpected response %q", val)
+			} else {
+				lastErr = getErr
+			}
+		} else {
+			lastErr = sendErr
+		}
+		if i >= 60 {
+			b.Fatalf("p2p function never came up: %v", lastErr)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		resp, err := cmd.Send(ctx, map[string]interface{}{"data": []byte("Hello, world")})
+		if err != nil {
+			b.Fatal(err)
+		}
+		val, err := resp.Get("data")
+		if err != nil {
+			b.Fatal(err)
+		}
+		if string(val.([]byte)) != p2pResponse {
+			b.Fatalf("expected %q got %q", p2pResponse, val)
+		}
+	}
+}

--- a/dream/benchmarks/bench_test.go
+++ b/dream/benchmarks/bench_test.go
@@ -45,6 +45,19 @@ var (
 	testFunction2Id = "QmZY4u91d1YALDN2LTbpVtgwW8iT5cK9PE1bHZqX9J5456"
 )
 
+// Shared config for the websocket and database surfaces, injected once into
+// the shared project alongside the HTTP functions above. (The p2p function
+// benchmark boots its own separate 2-node universe — see bench_p2p_test.go
+// for why a single shared node can't serve it.)
+const (
+	messagingName    = "benchMessaging"
+	messagingChannel = "benchchannel"
+
+	databaseName  = "benchDatabase"
+	databaseMatch = "benchdb"
+	databaseSize  = 1 * 1024 * 1024 * 1024 // 1GiB
+)
+
 var benchServices = map[string]commonIface.ServiceConfig{
 	"tns":       {},
 	"substrate": {},
@@ -128,6 +141,21 @@ func bootShared() error {
 		&structureSpec.Domain{
 			Name: "someDomain",
 			Fqdn: testFqdn,
+		},
+		// websocket<->pubsub channel, exercised by BenchmarkWebsocketEcho (bench_ws_test.go).
+		&structureSpec.Messaging{
+			Name:      messagingName,
+			Match:     messagingChannel,
+			Regex:     false,
+			WebSocket: true,
+		},
+		// KV database, exercised by BenchmarkDatabasePut/Get (bench_data_test.go).
+		&structureSpec.Database{
+			Name:  databaseName,
+			Match: databaseMatch,
+			Regex: false,
+			Local: false,
+			Size:  databaseSize,
 		},
 	)
 	if err != nil {

--- a/dream/benchmarks/bench_test.go
+++ b/dream/benchmarks/bench_test.go
@@ -1,0 +1,312 @@
+//go:build dreaming
+
+// Profiling benchmarks over a live dream universe. Run with:
+//
+//	make bench-dreaming BENCH=HTTPFunction FLAGS="-cpuprofile=/tmp/cpu.prof -memprofile=/tmp/mem.prof"
+//
+// then `go tool pprof -top /tmp/cpu.prof` / `go tool pprof -top -alloc_space /tmp/mem.prof`.
+package benchmarks
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"sync"
+	"testing"
+	"time"
+
+	commonIface "github.com/taubyte/tau/core/common"
+	"github.com/taubyte/tau/dream"
+	commonTest "github.com/taubyte/tau/dream/helpers"
+	"github.com/taubyte/tau/pkg/specs/common"
+	functionSpec "github.com/taubyte/tau/pkg/specs/function"
+	"github.com/taubyte/tau/pkg/specs/methods"
+	structureSpec "github.com/taubyte/tau/pkg/specs/structure"
+	"github.com/taubyte/tau/services/monkey/fixtures/compile"
+	tcc "github.com/taubyte/tau/utils/tcc"
+
+	_ "github.com/taubyte/tau/clients/p2p/hoarder/dream"
+	_ "github.com/taubyte/tau/clients/p2p/tns/dream"
+	_ "github.com/taubyte/tau/dream/fixtures"
+	_ "github.com/taubyte/tau/pkg/tcc/taubyte/v1/fixtures"
+	_ "github.com/taubyte/tau/services/hoarder/dream"
+	_ "github.com/taubyte/tau/services/substrate/dream"
+	_ "github.com/taubyte/tau/services/tns/dream"
+)
+
+const testFqdn = "hal.computers.com"
+
+var (
+	testProjectId   = "QmegMKBQmDTU9FUGKdhPFn1ZEtwcNaCA2wmyLW8vJn7wZN"
+	testFunctionId  = "QmZY4u91d1YALDN2LTbpVtgwW8iT5cK9PE1bHZqX9J51Tv"
+	testFunction2Id = "QmZY4u91d1YALDN2LTbpVtgwW8iT5cK9PE1bHZqX9J5456"
+)
+
+var benchServices = map[string]commonIface.ServiceConfig{
+	"tns":       {},
+	"substrate": {},
+	"hoarder":   {},
+}
+
+var (
+	sharedOnce sync.Once
+	sharedU    *dream.Universe
+	sharedErr  error
+)
+
+// sharedUniverse boots one universe serving the prebuilt ping.zwasm function
+// and reuses it across benchmarks — boot is measured separately by
+// BenchmarkUniverseBoot.
+func sharedUniverse(b *testing.B) *dream.Universe {
+	b.Helper()
+	sharedOnce.Do(func() { sharedErr = bootShared() })
+	if sharedErr != nil {
+		b.Fatal(sharedErr)
+	}
+	return sharedU
+}
+
+func bootShared() error {
+	m, err := dream.New(context.Background())
+	if err != nil {
+		return err
+	}
+
+	u, err := m.New(dream.UniverseConfig{Name: "bench"})
+	if err != nil {
+		return err
+	}
+
+	err = u.StartWithConfig(&dream.Config{
+		Services: benchServices,
+		Simples: map[string]dream.SimpleConfig{
+			"client": {
+				Clients: dream.SimpleConfigClients{
+					TNS:     &commonIface.ClientConfig{},
+					Hoarder: &commonIface.ClientConfig{},
+				}.Compat(),
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	fs, _, err := tcc.GenerateProject(testProjectId,
+		// well-provisioned: plenty of headroom over the wasm linear memory
+		// (≥128KiB), so instances pool and /ping measures the warm path.
+		&structureSpec.Function{
+			Id:      testFunctionId,
+			Name:    "someFunc",
+			Type:    "http",
+			Call:    "ping",
+			Memory:  20 * 1024 * 1024,
+			Source:  ".",
+			Timeout: 1000000000,
+			Method:  "GET",
+			Domains: []string{"someDomain"},
+			Paths:   []string{"/ping"},
+		},
+		// under-provisioned: the wasm linear memory already fills the 2-page
+		// cap, so every instance is retired on Free and /ping2 measures the
+		// full cold-start path (fetch, unzip, decompress, compile, attach).
+		&structureSpec.Function{
+			Id:      testFunction2Id,
+			Name:    "someColdFunc",
+			Type:    "http",
+			Call:    "ping",
+			Memory:  100000,
+			Source:  ".",
+			Timeout: 1000000000,
+			Method:  "GET",
+			Domains: []string{"someDomain"},
+			Paths:   []string{"/ping2"},
+		},
+		&structureSpec.Domain{
+			Name: "someDomain",
+			Fqdn: testFqdn,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	if err = u.RunFixture("injectProject", fs); err != nil {
+		return err
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	zwasm := path.Join(wd, "..", "..", "services", "monkey", "fixtures", "compile", "assets", "ping.zwasm")
+	for _, id := range []string{testFunctionId, testFunction2Id} {
+		err = u.RunFixture("compileFor", compile.BasicCompileFor{
+			ProjectId:  testProjectId,
+			ResourceId: id,
+			Paths:      []string{zwasm},
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// warm until both functions resolve and serve
+	client := commonTest.CreateHttpClient()
+	for _, route := range []string{"/ping", "/ping2"} {
+		for i := 0; ; i++ {
+			body, err := callRoute(u, client, route)
+			if err == nil && string(body) == "PONG" {
+				break
+			}
+			if i >= 60 {
+				return fmt.Errorf("function on %s never came up: %v (body: %q)", route, err, body)
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+
+	sharedU = u
+	return nil
+}
+
+func routeURL(u *dream.Universe, route string) (string, error) {
+	port, err := u.GetPortHttp(u.Substrate().Node())
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("http://%s:%d%s", testFqdn, port, route), nil
+}
+
+func callRoute(u *dream.Universe, client *http.Client, route string) ([]byte, error) {
+	url, err := routeURL(u, route)
+	if err != nil {
+		return nil, err
+	}
+	res, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	return io.ReadAll(res.Body)
+}
+
+// BenchmarkHTTPFunction measures the warm serving path: HTTP router → domain/
+// TNS lookup → cached wasm instance call → response.
+func BenchmarkHTTPFunction(b *testing.B) {
+	benchRoute(b, "/ping")
+}
+
+// BenchmarkHTTPFunctionColdStart measures the full per-request cold-start
+// path (fetch, unzip, decompress, compile, attach): someColdFunc's memory
+// config leaves no growth headroom, so every instance is retired on Free.
+func BenchmarkHTTPFunctionColdStart(b *testing.B) {
+	benchRoute(b, "/ping2")
+}
+
+func benchRoute(b *testing.B, route string) {
+	b.Helper()
+	u := sharedUniverse(b)
+	client := commonTest.CreateHttpClient()
+	url, err := routeURL(u, route)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		res, err := client.Get(url)
+		if err != nil {
+			b.Fatal(err)
+		}
+		body, err := io.ReadAll(res.Body)
+		res.Body.Close()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if string(body) != "PONG" {
+			b.Fatalf("expected PONG got %q", body)
+		}
+	}
+}
+
+// BenchmarkHTTPFunctionParallel exposes lock contention in the serving path.
+func BenchmarkHTTPFunctionParallel(b *testing.B) {
+	u := sharedUniverse(b)
+	url, err := routeURL(u, "/ping")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		client := commonTest.CreateHttpClient()
+		for pb.Next() {
+			res, err := client.Get(url)
+			if err != nil {
+				b.Fatal(err)
+			}
+			body, err := io.ReadAll(res.Body)
+			res.Body.Close()
+			if err != nil {
+				b.Fatal(err)
+			}
+			if string(body) != "PONG" {
+				b.Fatalf("expected PONG got %q", body)
+			}
+		}
+	})
+}
+
+// BenchmarkTNSFetch measures the p2p TNS resolution path substrate hits on
+// every cache miss.
+func BenchmarkTNSFetch(b *testing.B) {
+	u := sharedUniverse(b)
+	tnsClient := u.Substrate().Tns()
+
+	httpPath, err := methods.HttpPath(testFqdn, functionSpec.PathVariable)
+	if err != nil {
+		b.Fatal(err)
+	}
+	linksPath := httpPath.Versioning().Links()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		obj, err := tnsClient.Fetch(linksPath)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err = obj.Current(common.DefaultBranches); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkUniverseBoot measures cold start of a tns+substrate+hoarder
+// universe (keypair gen, libp2p swarm, service init). Teardown is untimed.
+// Run with -benchtime=5x — each iteration takes seconds.
+func BenchmarkUniverseBoot(b *testing.B) {
+	m, err := dream.New(context.Background())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer m.Close()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		u, err := m.New(dream.UniverseConfig{Name: fmt.Sprintf("boot-%d", i)})
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err = u.StartWithConfig(&dream.Config{Services: benchServices}); err != nil {
+			b.Fatal(err)
+		}
+		b.StopTimer()
+		u.Stop()
+		b.StartTimer()
+	}
+}

--- a/dream/benchmarks/bench_ws_test.go
+++ b/dream/benchmarks/bench_ws_test.go
@@ -65,15 +65,6 @@ const wsPayloadSize = 256
 // B (the other subscriber on the same channel) reads it back. See the file
 // comment above for why there is no pubsub-function benchmark alongside it.
 func BenchmarkWebsocketEcho(b *testing.B) {
-	// Skipped: the pubsub websocket serviceable is currently dead code — its
-	// construction is commented out in
-	// services/substrate/components/pubsub/lookup.go, so every WebSocket-matcher
-	// Lookup returns "no pub-sub matches found" and the dial below can never
-	// complete. Keeping the full benchmark under the skip so it starts measuring
-	// the websocket<->pubsub bridge the day that path is revived (just delete
-	// this line). Until then, this keeps `make bench-dreaming BENCH=.` green.
-	b.Skip("pubsub websocket serviceable disabled: websocket append commented out in services/substrate/components/pubsub/lookup.go")
-
 	u := sharedUniverse(b)
 	url, err := wsURL(u)
 	if err != nil {

--- a/dream/benchmarks/bench_ws_test.go
+++ b/dream/benchmarks/bench_ws_test.go
@@ -1,0 +1,150 @@
+//go:build dreaming
+
+package benchmarks
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/taubyte/tau/dream"
+	multihash "github.com/taubyte/tau/utils/multihash"
+)
+
+// The prebuilt wasm fixtures in this suite only cover http and p2p triggers
+// (see bootShared in bench_test.go and bench_p2p_test.go). No fixture exists
+// for a pubsub-triggered wasm function, so there is no BenchmarkPubsubFunction
+// here — a wasm pubsub-function benchmark would need a new compile fixture
+// analogous to artifact.zwasm, wired to a "pubsub" trigger. BenchmarkWebsocketEcho
+// below instead covers the pubsub publish->deliver transport directly: two
+// websocket clients on the same channel, one writes, the other reads what
+// the server republished over the pubsub topic — exercising the HTTP
+// upgrade, channel lookup, and websocket<->pubsub bridging without wasm.
+
+// wsDialer maps the test fqdn to localhost, mirroring
+// dream/helpers.CreateHttpClient's DialContext trick for the plain HTTP
+// client used by the other benchmarks in this suite.
+var wsDialer = &websocket.Dialer{
+	NetDial: func(network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		if host == testFqdn {
+			host = "127.0.0.1"
+		}
+		return net.Dial(network, net.JoinHostPort(host, port))
+	},
+	HandshakeTimeout: 5 * time.Second,
+}
+
+// wsURL builds the /ws-{hash}/{channel} URL for the shared project's global
+// (application-less) benchchannel messaging resource. The hash mirrors what
+// services/substrate/components/pubsub/websocket/handler.go derives via
+// pkg/specs/messaging/tns.go's WebSocketHashPath: multihash.Hash(project+app).
+func wsURL(u *dream.Universe) (string, error) {
+	port, err := u.GetPortHttp(u.Substrate().Node())
+	if err != nil {
+		return "", err
+	}
+	hash := multihash.Hash(testProjectId + "")
+	return fmt.Sprintf("ws://%s:%d/ws-%s/%s", testFqdn, port, hash, messagingChannel), nil
+}
+
+func dialWS(url string) (*websocket.Conn, error) {
+	conn, _, err := wsDialer.Dial(url, nil)
+	return conn, err
+}
+
+const wsPayloadSize = 256
+
+// BenchmarkWebsocketEcho measures the websocket<->pubsub bridge: A writes a
+// binary frame, the server republishes it on the channel's pubsub topic, and
+// B (the other subscriber on the same channel) reads it back. See the file
+// comment above for why there is no pubsub-function benchmark alongside it.
+func BenchmarkWebsocketEcho(b *testing.B) {
+	// Skipped: the pubsub websocket serviceable is currently dead code — its
+	// construction is commented out in
+	// services/substrate/components/pubsub/lookup.go, so every WebSocket-matcher
+	// Lookup returns "no pub-sub matches found" and the dial below can never
+	// complete. Keeping the full benchmark under the skip so it starts measuring
+	// the websocket<->pubsub bridge the day that path is revived (just delete
+	// this line). Until then, this keeps `make bench-dreaming BENCH=.` green.
+	b.Skip("pubsub websocket serviceable disabled: websocket append commented out in services/substrate/components/pubsub/lookup.go")
+
+	u := sharedUniverse(b)
+	url, err := wsURL(u)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	payload := make([]byte, wsPayloadSize)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	var (
+		connA, connB *websocket.Conn
+		lastErr      error
+	)
+
+	// The messaging config needs to propagate through TNS before the
+	// websocket handler's channel lookup resolves - the first dial(s) may
+	// 404/error, or connect and immediately receive an error JSON frame,
+	// until it does. Retry a full dial+roundtrip in a bounded poll.
+	for i := 0; ; i++ {
+		if connA != nil {
+			connA.Close()
+		}
+		if connB != nil {
+			connB.Close()
+		}
+
+		var mt int
+		var msg []byte
+
+		connA, lastErr = dialWS(url)
+		if lastErr == nil {
+			connB, lastErr = dialWS(url)
+		}
+		if lastErr == nil {
+			lastErr = connA.WriteMessage(websocket.BinaryMessage, payload)
+		}
+		if lastErr == nil {
+			connB.SetReadDeadline(time.Now().Add(2 * time.Second))
+			mt, msg, lastErr = connB.ReadMessage()
+		}
+		if lastErr == nil && mt == websocket.BinaryMessage && len(msg) == len(payload) {
+			connB.SetReadDeadline(time.Time{})
+			break
+		}
+		if lastErr == nil {
+			lastErr = fmt.Errorf("unexpected frame type=%d len=%d body=%q", mt, len(msg), msg)
+		}
+		if i >= 60 {
+			b.Fatalf("websocket echo never came up: %v", lastErr)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	defer connA.Close()
+	defer connB.Close()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := connA.WriteMessage(websocket.BinaryMessage, payload); err != nil {
+			b.Fatal(err)
+		}
+		// Any non-payload read (e.g. the server's error JSON frame) is
+		// fatal - see dataStreamHandler.In/Out in
+		// services/substrate/components/pubsub/websocket/datastream.go.
+		mt, msg, err := connB.ReadMessage()
+		if err != nil {
+			b.Fatalf("reading echo failed with: %v", err)
+		}
+		if mt != websocket.BinaryMessage || len(msg) != len(payload) {
+			b.Fatalf("expected a %d-byte binary frame, got type=%d len=%d body=%q", len(payload), mt, len(msg), msg)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7
 	go.starlark.net v0.0.0-20251109183026-be02852a5e1f
 	golang.org/x/mod v0.35.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.37.0
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.10
@@ -329,7 +330,6 @@ require (
 	go.uber.org/fx v1.24.0 // indirect
 	go.uber.org/mock v0.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa // indirect
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect

--- a/pkg/vm-low-orbit/instance.go
+++ b/pkg/vm-low-orbit/instance.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/taubyte/tau/core/vm"
 )
@@ -15,19 +16,44 @@ type pluginInstance struct {
 	factories []vm.Factory
 }
 
+// factoryWMethods caches, per factory type, the W_-prefixed method indexes/names
+// discovered via reflection. Discovery is the same for every instance of a given
+// factory type, and reflection is expensive enough to matter on wasm cold start.
+var factoryWMethods sync.Map // reflect.Type -> []struct{ index int; name string }
+
 func (i *pluginInstance) LoadFactory(factory vm.Factory, hm vm.HostModule) error {
-	defs := make([]*vm.HostModuleFunctionDefinition, 0)
-	m := reflect.ValueOf(factory)
 	mT := reflect.TypeOf(factory)
-	for i := 0; i < m.NumMethod(); i++ {
-		mt := m.Method(i)
-		mtT := mT.Method(i)
-		if strings.HasPrefix(mtT.Name, "W_") {
-			defs = append(defs, &vm.HostModuleFunctionDefinition{
-				Name:    mtT.Name[2:],
-				Handler: mt.Interface(),
-			})
+
+	var entries []struct {
+		index int
+		name  string
+	}
+	if cached, ok := factoryWMethods.Load(mT); ok {
+		entries = cached.([]struct {
+			index int
+			name  string
+		})
+	} else {
+		for i := 0; i < mT.NumMethod(); i++ {
+			mtT := mT.Method(i)
+			if strings.HasPrefix(mtT.Name, "W_") {
+				entries = append(entries, struct {
+					index int
+					name  string
+				}{index: i, name: mtT.Name[2:]})
+			}
 		}
+		// two goroutines racing the same type both compute the same value; last store wins
+		factoryWMethods.Store(mT, entries)
+	}
+
+	m := reflect.ValueOf(factory)
+	defs := make([]*vm.HostModuleFunctionDefinition, 0, len(entries))
+	for _, entry := range entries {
+		defs = append(defs, &vm.HostModuleFunctionDefinition{
+			Name:    entry.name,
+			Handler: m.Method(entry.index).Interface(),
+		})
 	}
 
 	return hm.Functions(defs...)

--- a/pkg/vm-low-orbit/instance_test.go
+++ b/pkg/vm-low-orbit/instance_test.go
@@ -1,0 +1,113 @@
+package taubyte
+
+import (
+	"testing"
+
+	"github.com/taubyte/tau/core/vm"
+)
+
+type wDiscoveryTestFactory struct{}
+
+func (f *wDiscoveryTestFactory) Close() error { return nil }
+func (f *wDiscoveryTestFactory) Name() string { return "wDiscoveryTestFactory" }
+
+func (f *wDiscoveryTestFactory) W_hello() string      { return "hello" }
+func (f *wDiscoveryTestFactory) W_double(x int) int   { return x * 2 }
+func (f *wDiscoveryTestFactory) AlsoNotPrefixed() int { return 0 }
+
+var _ vm.Factory = &wDiscoveryTestFactory{}
+
+type mockHostModule struct {
+	defs []*vm.HostModuleFunctionDefinition
+}
+
+func (m *mockHostModule) Functions(defs ...*vm.HostModuleFunctionDefinition) error {
+	m.defs = append(m.defs, defs...)
+	return nil
+}
+
+func (m *mockHostModule) Memories(...*vm.HostModuleMemoryDefinition) error { return nil }
+func (m *mockHostModule) Globals(...*vm.HostModuleGlobalDefinition) error  { return nil }
+func (m *mockHostModule) Compile() (vm.ModuleInstance, error)              { return nil, nil }
+
+func TestLoadFactoryWDiscovery(t *testing.T) {
+	pi := &pluginInstance{}
+
+	hm := &mockHostModule{}
+	if err := pi.LoadFactory(&wDiscoveryTestFactory{}, hm); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(hm.defs) != 2 {
+		t.Fatalf("expected 2 discovered W_ methods, got %d", len(hm.defs))
+	}
+
+	names := make(map[string]*vm.HostModuleFunctionDefinition)
+	for _, def := range hm.defs {
+		names[def.Name] = def
+	}
+
+	helloDef, ok := names["hello"]
+	if !ok {
+		t.Fatal("expected `hello` (stripped from W_hello) to be discovered")
+	}
+	helloHandler, ok := helloDef.Handler.(func() string)
+	if !ok {
+		t.Fatalf("hello handler has unexpected type %T", helloDef.Handler)
+	}
+	if got := helloHandler(); got != "hello" {
+		t.Fatalf("hello handler returned %q, expected %q", got, "hello")
+	}
+
+	doubleDef, ok := names["double"]
+	if !ok {
+		t.Fatal("expected `double` (stripped from W_double) to be discovered")
+	}
+	doubleHandler, ok := doubleDef.Handler.(func(int) int)
+	if !ok {
+		t.Fatalf("double handler has unexpected type %T", doubleDef.Handler)
+	}
+	if got := doubleHandler(21); got != 42 {
+		t.Fatalf("double handler returned %d, expected %d", got, 42)
+	}
+
+	if _, ok := names["AlsoNotPrefixed"]; ok {
+		t.Fatal("AlsoNotPrefixed must not be discovered: no W_ prefix")
+	}
+}
+
+// TestLoadFactoryWDiscoveryCacheHit exercises a second LoadFactory call for the
+// same factory type (a different instance), which should hit the cached
+// discovery and still produce identical, correctly-bound defs.
+func TestLoadFactoryWDiscoveryCacheHit(t *testing.T) {
+	pi := &pluginInstance{}
+
+	hm1 := &mockHostModule{}
+	if err := pi.LoadFactory(&wDiscoveryTestFactory{}, hm1); err != nil {
+		t.Fatal(err)
+	}
+
+	hm2 := &mockHostModule{}
+	if err := pi.LoadFactory(&wDiscoveryTestFactory{}, hm2); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(hm1.defs) != len(hm2.defs) {
+		t.Fatalf("cache hit produced a different number of defs: %d vs %d", len(hm1.defs), len(hm2.defs))
+	}
+
+	for i := range hm1.defs {
+		if hm1.defs[i].Name != hm2.defs[i].Name {
+			t.Fatalf("cache hit produced defs in different order/names at %d: %s vs %s", i, hm1.defs[i].Name, hm2.defs[i].Name)
+		}
+	}
+
+	doubleDef, ok := (map[string]*vm.HostModuleFunctionDefinition{hm2.defs[0].Name: hm2.defs[0], hm2.defs[1].Name: hm2.defs[1]})["double"]
+	if !ok {
+		t.Fatal("expected `double` to be discovered on cache hit")
+	}
+	doubleHandler := doubleDef.Handler.(func(int) int)
+	if got := doubleHandler(10); got != 20 {
+		t.Fatalf("double handler (cache hit) returned %d, expected %d", got, 20)
+	}
+}

--- a/pkg/vm/backend/dfs/backend.go
+++ b/pkg/vm/backend/dfs/backend.go
@@ -2,6 +2,7 @@ package dfs
 
 import (
 	"archive/zip"
+	"bytes"
 	"compress/lzw"
 	"context"
 	"fmt"
@@ -19,7 +20,8 @@ import (
 
 func New(node peer.Node) vm.Backend {
 	return &backend{
-		node: node,
+		node:  node,
+		cache: newModuleCache(CacheSize),
 	}
 }
 
@@ -39,8 +41,32 @@ func (b *backend) Get(multiAddr ma.Multiaddr) (io.ReadCloser, error) {
 		return nil, err
 	}
 
+	// Content behind a CID is immutable, so decompressed bytes are safe to serve straight from cache.
+	if data, ok := b.cache.get(_cid); ok {
+		return io.NopCloser(bytes.NewReader(data)), nil
+	}
+
+	v, err, _ := b.group.Do(_cid, func() (any, error) {
+		data, err := b.fetch(_cid, __cid)
+		if err != nil {
+			return nil, err
+		}
+
+		b.cache.put(_cid, data)
+		return data, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return io.NopCloser(bytes.NewReader(v.([]byte))), nil
+}
+
+// fetch performs the actual DAG/zip/LZW retrieval and returns the fully
+// decompressed module bytes, closing all underlying readers along the way.
+func (b *backend) fetch(_cid string, __cid cid.Cid) ([]byte, error) {
 	ctx, ctxC := context.WithTimeout(b.node.Context(), vm.GetTimeout)
-	handleErr := func(err error) (io.ReadCloser, error) {
+	handleErr := func(err error) ([]byte, error) {
 		ctxC()
 		return nil, err
 	}
@@ -66,27 +92,43 @@ func (b *backend) Get(multiAddr ma.Multiaddr) (io.ReadCloser, error) {
 		readerutil.NewBufferingReaderAt(dagReader),
 		size,
 	)
+
+	var rc io.ReadCloser
 	if err != nil {
 		dagReader.Seek(0, io.SeekStart)
-		return &zWasmReadCloser{
+		rc = &zWasmReadCloser{
 			dag:        dagReader,
 			unCompress: lzw.NewReader(dagReader, lzw.LSB, 8),
-		}, nil
+		}
 	} else {
 		// Trying for both main/artifact.wasm
 		reader, err := zipReader.Open(wasm.WasmFile)
 		if err != nil {
 			reader, err = zipReader.Open(wasm.DeprecatedWasmFile)
 			if err != nil {
+				dagReader.Close()
 				return handleErr(fmt.Errorf("reading wasm file as aritfact and main failed with: %s", err))
 			}
 		}
 
-		return &zipReadCloser{
+		rc = &zipReadCloser{
 			parent:     dagReader,
 			ReadCloser: reader,
-		}, nil
+		}
 	}
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		rc.Close()
+		return handleErr(err)
+	}
+
+	if err := rc.Close(); err != nil {
+		return handleErr(err)
+	}
+
+	ctxC()
+	return data, nil
 }
 
 func (b *backend) Scheme() string {
@@ -95,5 +137,6 @@ func (b *backend) Scheme() string {
 
 func (b *backend) Close() error {
 	b.node = nil
+	b.cache = nil
 	return nil
 }

--- a/pkg/vm/backend/dfs/backend_test.go
+++ b/pkg/vm/backend/dfs/backend_test.go
@@ -45,6 +45,18 @@ func TestBackend(t *testing.T) {
 	err = dagReader.Close()
 	assert.NilError(t, err)
 
+	// Second Get for the same CID should be served from the in-process cache.
+	cachedReader, err := backend.Get(mAddr)
+	assert.NilError(t, err)
+
+	cachedData, err := io.ReadAll(cachedReader)
+	assert.NilError(t, err)
+
+	assert.DeepEqual(t, dfsData, cachedData)
+
+	err = cachedReader.Close()
+	assert.NilError(t, err)
+
 	// Missing Close coverage as dagReader Close does not seem to fail
 
 	backend.Close()

--- a/pkg/vm/backend/dfs/cache.go
+++ b/pkg/vm/backend/dfs/cache.go
@@ -1,0 +1,75 @@
+package dfs
+
+import (
+	"container/list"
+	"sync"
+)
+
+// moduleCache is a byte-size-capped LRU of decompressed wasm module bytes,
+// keyed by CID. Content behind a CID is immutable, so entries never go stale.
+type moduleCache struct {
+	lock     sync.Mutex
+	items    map[string]*list.Element
+	order    *list.List
+	size     uint64
+	capacity uint64
+}
+
+type cacheEntry struct {
+	cid  string
+	data []byte
+}
+
+func newModuleCache(capacity uint64) *moduleCache {
+	return &moduleCache{
+		items:    make(map[string]*list.Element),
+		order:    list.New(),
+		capacity: capacity,
+	}
+}
+
+func (c *moduleCache) get(cid string) ([]byte, bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	elem, ok := c.items[cid]
+	if !ok {
+		return nil, false
+	}
+
+	c.order.MoveToFront(elem)
+	return elem.Value.(*cacheEntry).data, true
+}
+
+func (c *moduleCache) put(cid string, data []byte) {
+	size := uint64(len(data))
+	if size > c.capacity {
+		// Blob alone can never fit; skip caching it rather than evicting everything else.
+		return
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if elem, ok := c.items[cid]; ok {
+		entry := elem.Value.(*cacheEntry)
+		c.size += size - uint64(len(entry.data))
+		entry.data = data
+		c.order.MoveToFront(elem)
+	} else {
+		c.items[cid] = c.order.PushFront(&cacheEntry{cid: cid, data: data})
+		c.size += size
+	}
+
+	for c.size > c.capacity {
+		oldest := c.order.Back()
+		if oldest == nil {
+			break
+		}
+
+		entry := oldest.Value.(*cacheEntry)
+		c.order.Remove(oldest)
+		delete(c.items, entry.cid)
+		c.size -= uint64(len(entry.data))
+	}
+}

--- a/pkg/vm/backend/dfs/cache_test.go
+++ b/pkg/vm/backend/dfs/cache_test.go
@@ -1,0 +1,124 @@
+package dfs
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestModuleCacheMiss(t *testing.T) {
+	c := newModuleCache(1024)
+
+	_, ok := c.get("missing")
+	assert.Equal(t, ok, false)
+}
+
+func TestModuleCacheHit(t *testing.T) {
+	c := newModuleCache(1024)
+
+	c.put("a", []byte("hello"))
+
+	data, ok := c.get("a")
+	assert.Equal(t, ok, true)
+	assert.DeepEqual(t, data, []byte("hello"))
+}
+
+func TestModuleCacheRecencyBump(t *testing.T) {
+	c := newModuleCache(15)
+
+	c.put("a", []byte("aaaaa")) // 5 bytes
+	c.put("b", []byte("bbbbb")) // 5 bytes
+	c.put("c", []byte("ccccc")) // 5 bytes, total 15 == cap
+
+	// touch "a" so it becomes the most recently used entry
+	_, ok := c.get("a")
+	assert.Equal(t, ok, true)
+
+	// pushes total size to 20, forcing an eviction; "b" is now the oldest
+	c.put("d", []byte("ddddd"))
+
+	_, ok = c.get("b")
+	assert.Equal(t, ok, false)
+
+	_, ok = c.get("a")
+	assert.Equal(t, ok, true)
+
+	_, ok = c.get("c")
+	assert.Equal(t, ok, true)
+
+	_, ok = c.get("d")
+	assert.Equal(t, ok, true)
+}
+
+func TestModuleCacheEvictsOldestFirstAndTracksSize(t *testing.T) {
+	c := newModuleCache(10)
+
+	c.put("a", []byte("aaaaa")) // 5 bytes
+	c.put("b", []byte("bbbbb")) // 5 bytes, total 10 == cap
+	assert.Equal(t, c.size, uint64(10))
+
+	// forces eviction of "a", the oldest entry
+	c.put("c", []byte("ccccc"))
+
+	_, ok := c.get("a")
+	assert.Equal(t, ok, false)
+
+	_, ok = c.get("b")
+	assert.Equal(t, ok, true)
+
+	_, ok = c.get("c")
+	assert.Equal(t, ok, true)
+
+	assert.Equal(t, c.size, uint64(10))
+}
+
+func TestModuleCacheOverwriteTracksSize(t *testing.T) {
+	c := newModuleCache(1024)
+
+	c.put("a", []byte("aaaaaaaaaa")) // 10 bytes
+	assert.Equal(t, c.size, uint64(10))
+
+	// grow the same key
+	c.put("a", []byte("bbbbbbbbbbbbbbb")) // 15 bytes
+	assert.Equal(t, c.size, uint64(15))
+
+	// shrink the same key (exercises the uint64 subtraction path)
+	c.put("a", []byte("cc")) // 2 bytes
+	assert.Equal(t, c.size, uint64(2))
+
+	data, ok := c.get("a")
+	assert.Equal(t, ok, true)
+	assert.DeepEqual(t, data, []byte("cc"))
+}
+
+func TestModuleCacheConcurrentAccess(t *testing.T) {
+	c := newModuleCache(64 << 10)
+
+	var wg sync.WaitGroup
+	for i := range 16 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := range 200 {
+				key := strconv.Itoa((i + j) % 8)
+				c.put(key, []byte(key))
+				c.get(key)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Assert(t, c.size <= c.capacity)
+}
+
+func TestModuleCacheOversizeBlobNotCached(t *testing.T) {
+	c := newModuleCache(4)
+
+	c.put("big", []byte("hello")) // 5 bytes > 4 byte cap
+
+	_, ok := c.get("big")
+	assert.Equal(t, ok, false)
+	assert.Equal(t, c.size, uint64(0))
+}

--- a/pkg/vm/backend/dfs/types.go
+++ b/pkg/vm/backend/dfs/types.go
@@ -3,6 +3,8 @@ package dfs
 import (
 	"io"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/taubyte/tau/core/vm"
 	peer "github.com/taubyte/tau/p2p/peer"
 )
@@ -10,7 +12,9 @@ import (
 var _ vm.Backend = &backend{}
 
 type backend struct {
-	node peer.Node
+	node  peer.Node
+	cache *moduleCache
+	group singleflight.Group
 }
 
 type zWasmReadCloser struct {

--- a/pkg/vm/backend/dfs/vars.go
+++ b/pkg/vm/backend/dfs/vars.go
@@ -5,4 +5,5 @@ import "time"
 var (
 	Scheme     = "dfs"
 	GetTimeout = 30 * time.Second
+	CacheSize  = uint64(256 << 20) // bytes of decompressed wasm modules kept in memory
 )

--- a/pkg/vm/helpers/wazero/runtime.go
+++ b/pkg/vm/helpers/wazero/runtime.go
@@ -20,7 +20,9 @@ func NewRuntime(ctx context.Context, config *vm.Config) wazero.Runtime {
 		ctx,
 		wazero.NewRuntimeConfig().
 			WithCloseOnContextDone(true).
-			WithDebugInfoEnabled(true).
+			// DWARF parsing slows every module compile and bloats memory; wasm error
+			// stack traces keep function names without it.
+			WithDebugInfoEnabled(false).
 			WithMemoryLimitPages(config.MemoryLimitPages).
 			WithCompilationCache(Cache),
 	)

--- a/pkg/vm/loaders/wazero/loader_test.go
+++ b/pkg/vm/loaders/wazero/loader_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	functionSpec "github.com/taubyte/tau/pkg/specs/function"
+	"github.com/taubyte/tau/pkg/vm/backend/dfs"
 	fixtures "github.com/taubyte/tau/pkg/vm/fixtures/wasm"
 	loaders "github.com/taubyte/tau/pkg/vm/loaders/wazero"
 	test "github.com/taubyte/tau/pkg/vm/test_utils"
@@ -15,6 +16,12 @@ import (
 
 func TestLoader(t *testing.T) {
 	test.ResetVars()
+
+	// this test deletes the backing file and expects loads to fail; the
+	// dfs backend's CID cache would (correctly) keep serving the bytes.
+	oldCacheSize := dfs.CacheSize
+	dfs.CacheSize = 0
+	defer func() { dfs.CacheSize = oldCacheSize }()
 
 	ctx, ctxC := context.WithCancel(context.Background())
 	defer ctxC()

--- a/pkg/vm/service/wazero/host_module.go
+++ b/pkg/vm/service/wazero/host_module.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/taubyte/tau/core/vm"
 	callBridge "github.com/taubyte/tau/pkg/vm/service/wazero/callBridge"
@@ -14,20 +15,30 @@ var _ vm.HostModule = &hostModule{}
 var moduleType = reflect.TypeOf((*vm.Module)(nil)).Elem()
 var wazeroModuleType = reflect.TypeOf((*api.Module)(nil)).Elem()
 
-func (hm *hostModule) convertToHandler(def *vm.HostModuleFunctionDefinition) (interface{}, error) {
-	if _, exists := hm.functions[def.Name]; exists {
-		return nil, fmt.Errorf("function `%s` @ `%s` already defined", def.Name, hm.name)
-	}
+// handlerSignature is the reflection work derivable once per handler func type:
+// the wazero-facing func type (vm.Module params swapped for api.Module), and
+// which of the first two params need that swap undone (wrapped back into a
+// vm.Module) on every call. Handler funcs are re-attached on every wasm cold
+// start, but their signatures repeat, so this is cached process-wide.
+type handlerSignature struct {
+	funcType reflect.Type
+	convert  [2]bool
+}
 
-	tp := reflect.TypeOf(def.Handler)
+var handlerSignatures sync.Map // reflect.Type (handler func type) -> *handlerSignature
 
+func buildHandlerSignature(tp reflect.Type) *handlerSignature {
 	count := tp.NumIn()
 	_in := make([]reflect.Type, count)
 
+	sig := &handlerSignature{}
 	for i := 0; i < count; i++ {
 		in := tp.In(i)
 		if in.Kind() == reflect.Interface && in.Implements(moduleType) {
 			_in[i] = wazeroModuleType
+			if i < 2 {
+				sig.convert[i] = true
+			}
 		} else {
 			_in[i] = in
 		}
@@ -39,17 +50,39 @@ func (hm *hostModule) convertToHandler(def *vm.HostModuleFunctionDefinition) (in
 		_out[i] = tp.Out(i)
 	}
 
-	_func := reflect.MakeFunc(
-		reflect.FuncOf(_in, _out, false),
-		func(args []reflect.Value) []reflect.Value {
+	sig.funcType = reflect.FuncOf(_in, _out, false)
 
+	return sig
+}
+
+func (hm *hostModule) convertToHandler(def *vm.HostModuleFunctionDefinition) (interface{}, error) {
+	if _, exists := hm.functions[def.Name]; exists {
+		return nil, fmt.Errorf("function `%s` @ `%s` already defined", def.Name, hm.name)
+	}
+
+	tp := reflect.TypeOf(def.Handler)
+
+	var sig *handlerSignature
+	if cached, ok := handlerSignatures.Load(tp); ok {
+		sig = cached.(*handlerSignature)
+	} else {
+		sig = buildHandlerSignature(tp)
+		// two goroutines racing the same type both compute the same value; last store wins
+		handlerSignatures.Store(tp, sig)
+	}
+
+	handlerVal := reflect.ValueOf(def.Handler)
+
+	_func := reflect.MakeFunc(
+		sig.funcType,
+		func(args []reflect.Value) []reflect.Value {
 			for i := 0; i < 2; i++ {
-				if len(args) > i && args[i].Kind() == reflect.Interface && args[i].Type().Implements(wazeroModuleType) {
+				if sig.convert[i] && len(args) > i {
 					args[i] = reflect.ValueOf(callBridge.New(args[i].Interface().(api.Module)))
 				}
 			}
 
-			return reflect.ValueOf(def.Handler).Call(args)
+			return handlerVal.Call(args)
 		})
 
 	return _func.Interface(), nil

--- a/pkg/vm/service/wazero/host_module_test.go
+++ b/pkg/vm/service/wazero/host_module_test.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/taubyte/tau/core/vm"
+	api "github.com/tetratelabs/wazero/api"
+	"gotest.tools/v3/assert"
+)
+
+// fakeWazeroModule satisfies api.Module for the single method our test handler
+// touches; the embedded nil interface is never invoked.
+type fakeWazeroModule struct {
+	api.Module
+	name string
+}
+
+func (f *fakeWazeroModule) Name() string { return f.name }
+
+// TestConvertToHandlerSignatureCache converts two handlers sharing the same Go
+// func type and asserts the cached signature (funcType) is reused, and that
+// both converted functions remain independently callable.
+func TestConvertToHandlerSignatureCache(t *testing.T) {
+	hm := &hostModule{
+		name:      "test",
+		functions: make(map[string]functionDef),
+	}
+
+	def1 := &vm.HostModuleFunctionDefinition{
+		Name: "same_sig_1",
+		Handler: func(ctx context.Context, val uint32) uint32 {
+			return val + 1
+		},
+	}
+	def2 := &vm.HostModuleFunctionDefinition{
+		Name: "same_sig_2",
+		Handler: func(ctx context.Context, val uint32) uint32 {
+			return val * 2
+		},
+	}
+
+	h1, err := hm.convertToHandler(def1)
+	assert.NilError(t, err)
+
+	h2, err := hm.convertToHandler(def2)
+	assert.NilError(t, err)
+
+	f1 := reflect.ValueOf(h1)
+	f2 := reflect.ValueOf(h2)
+
+	// identical handler signatures share one cached func type
+	if f1.Type() != f2.Type() {
+		t.Fatalf("expected same converted func type on cache hit, got %s vs %s", f1.Type(), f2.Type())
+	}
+
+	ret1 := f1.Call([]reflect.Value{reflect.ValueOf(context.TODO()), reflect.ValueOf(uint32(41))})
+	if got := ret1[0].Interface().(uint32); got != 42 {
+		t.Fatalf("handler 1 returned %d, expected 42", got)
+	}
+
+	ret2 := f2.Call([]reflect.Value{reflect.ValueOf(context.TODO()), reflect.ValueOf(uint32(21))})
+	if got := ret2[0].Interface().(uint32); got != 42 {
+		t.Fatalf("handler 2 returned %d, expected 42", got)
+	}
+}
+
+// TestConvertToHandlerModuleParam asserts a handler taking a vm.Module param
+// gets it swapped to the wazero api.Module type in the converted signature,
+// and that at call time it is converted back into a working vm.Module.
+func TestConvertToHandlerModuleParam(t *testing.T) {
+	hm := &hostModule{
+		name:      "test",
+		functions: make(map[string]functionDef),
+	}
+
+	def := &vm.HostModuleFunctionDefinition{
+		Name: "with_module",
+		Handler: func(ctx context.Context, module vm.Module, val uint32) string {
+			return fmt.Sprintf("%s:%d", module.Name(), val)
+		},
+	}
+
+	handler, err := hm.convertToHandler(def)
+	assert.NilError(t, err)
+
+	f := reflect.ValueOf(handler)
+
+	if f.Type().In(1) != wazeroModuleType {
+		t.Fatalf("expected param 1 to be swapped to the wazero api.Module type, got %s", f.Type().In(1))
+	}
+
+	fake := &fakeWazeroModule{name: "mock_module"}
+
+	ret := f.Call([]reflect.Value{
+		reflect.ValueOf(context.TODO()),
+		reflect.ValueOf(fake),
+		reflect.ValueOf(uint32(7)),
+	})
+
+	if got := ret[0].Interface().(string); got != "mock_module:7" {
+		t.Fatalf("handler returned %q, expected %q", got, "mock_module:7")
+	}
+}

--- a/services/seer/tests/hearbeat_test.go
+++ b/services/seer/tests/hearbeat_test.go
@@ -13,6 +13,7 @@ import (
 	commonIface "github.com/taubyte/tau/core/common"
 	iface "github.com/taubyte/tau/core/services/seer"
 	"github.com/taubyte/tau/dream"
+	streamsClient "github.com/taubyte/tau/p2p/streams/client"
 	"gotest.tools/v3/assert"
 
 	_ "github.com/taubyte/tau/clients/p2p/seer/dream"
@@ -23,6 +24,14 @@ import (
 var client_count = 16
 
 func TestHeartbeat_Dreaming(t *testing.T) {
+	// 16 clients heartbeat concurrently while sibling packages load the
+	// machine during the -p 4 dreaming sweep; the default 10s p2p send
+	// timeout can starve and fail the send with an i/o timeout before the
+	// swarm recovers from discovery backoff.
+	oldTimeout := streamsClient.SendToPeerTimeout
+	streamsClient.SendToPeerTimeout = 90 * time.Second
+	defer func() { streamsClient.SendToPeerTimeout = oldTimeout }()
+
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()

--- a/services/substrate/components/pubsub/common/messaging_map.go
+++ b/services/substrate/components/pubsub/common/messaging_map.go
@@ -29,9 +29,9 @@ type MessagingMapItem struct {
 }
 
 type MessagingMap struct {
-	Function MessagingMapItem
-	//WebSocket MessagingMapItem
-	HasAny bool
+	Function  MessagingMapItem
+	WebSocket MessagingMapItem
+	HasAny    bool
 }
 
 func (mmi *MessagingMapItem) Len() int {

--- a/services/substrate/components/pubsub/lookup.go
+++ b/services/substrate/components/pubsub/lookup.go
@@ -10,6 +10,7 @@ import (
 	matcherSpec "github.com/taubyte/tau/pkg/specs/matcher"
 	"github.com/taubyte/tau/services/substrate/components/pubsub/common"
 	"github.com/taubyte/tau/services/substrate/components/pubsub/function"
+	"github.com/taubyte/tau/services/substrate/components/pubsub/websocket"
 	"github.com/taubyte/tau/services/substrate/runtime/lookup"
 )
 
@@ -48,14 +49,14 @@ func (s *Service) CheckTns(_matcher commonIface.MatchDefinition) ([]commonIface.
 
 	var available = make([]commonIface.Serviceable, 0)
 	// get available websocket serviceables
-	// if messagingContext.WebSocket.Len() > 0 {
-	// 	serv, err := websocket.New(s, messagingContext.WebSocket, commit, branch, matcher)
-	// 	if err != nil {
-	// 		return nil, fmt.Errorf("creating websocket serviceable with `%v` failed with: %w", matcher, err)
-	// 	}
+	if messagingContext.WebSocket.Len() > 0 {
+		serv, err := websocket.New(s, messagingContext.WebSocket, commit, branch, matcher)
+		if err != nil {
+			return nil, fmt.Errorf("creating websocket serviceable with `%v` failed with: %w", matcher, err)
+		}
 
-	// 	available = append(available, serv)
-	// }
+		available = append(available, serv)
+	}
 
 	if messagingContext.Function.Len() == 0 || matcher.WebSocket {
 		if len(available) == 0 {

--- a/services/substrate/components/pubsub/lookup_regex_test.go
+++ b/services/substrate/components/pubsub/lookup_regex_test.go
@@ -30,13 +30,19 @@ func TestLookupRegex(t *testing.T) {
 	structure.RefreshTestVariables()
 	fakeFetch(msg, function)
 
+	// The messaging config matches on both the function and websocket path
+	// (WebSocket: true), so a plain Lookup - one that doesn't request
+	// WebSocket itself - picks up both: the function serviceable and the
+	// otherwise-harmless websocket serviceable (its HandleMessage is a
+	// no-op).
 	ret, err := s.Lookup(
 		&common.MatchDefinition{
 			Channel: testChannel + "/zing",
 			Project: testProject,
 		})
 	assert.NilError(t, err)
-	assert.Equal(t, len(ret), 1)
+	assert.Equal(t, len(ret), 2)
+	assertOneFunctionOneWebSocket(t, ret)
 
 	ret, err = s.Lookup(
 		&common.MatchDefinition{
@@ -44,6 +50,6 @@ func TestLookupRegex(t *testing.T) {
 			Project: testProject,
 		})
 	assert.NilError(t, err)
-	assert.Equal(t, len(ret), 1)
-
+	assert.Equal(t, len(ret), 2)
+	assertOneFunctionOneWebSocket(t, ret)
 }

--- a/services/substrate/components/pubsub/messaging.go
+++ b/services/substrate/components/pubsub/messaging.go
@@ -29,9 +29,9 @@ func (s *Service) getMessagingsMap(matcher *common.MatchDefinition) (*common.Mes
 
 		if foundMatch {
 			messagingsMap.HasAny = true
-			// if m.WebSocket {
-			// 	messagingsMap.WebSocket.Push(matcher.Project, "", m)
-			// }
+			if m.WebSocket {
+				messagingsMap.WebSocket.Push(matcher.Project, "", m)
+			}
 			messagingsMap.Function.Push(matcher.Project, "", m)
 		}
 	}

--- a/services/substrate/components/pubsub/socket_test.go
+++ b/services/substrate/components/pubsub/socket_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestSocketLookup(t *testing.T) {
-	t.Skip("Websocket as serviseable needs to be refactored")
 	testMessagingName := "someMessaging"
 	s := NewTestService(peer.Mock(t.Context()))
 
@@ -35,20 +34,22 @@ func TestSocketLookup(t *testing.T) {
 		WebSocket: true,
 	}}
 	fakeFetch(msg, nil)
-	// _, err = s.Lookup(
-	// 	&common.MatchDefinition{
-	// 		Channel: testChannel,
-	// 		Project: testProject,
-	// 	})
-	// if err != nil {
-	// 	t.Error(err)
-	// 	return
-	// }
+	_, err = s.Lookup(
+		&common.MatchDefinition{
+			Channel: testChannel,
+			Project: testProject,
+		})
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
-	// if len(structure.AttachedTestFunctions) != 0 {
-	// 	t.Errorf("Expected no functions to be attached got `%d` attached", len(structure.AttachedTestFunctions))
-	// 	return
-	// }
+	// No project functions were faked, so the websocket-only pick must not
+	// have dragged a function instantiation along with it.
+	if len(structure.AttachedTestFunctions) != 0 {
+		t.Errorf("Expected no functions to be attached got `%d` attached", len(structure.AttachedTestFunctions))
+		return
+	}
 
 	url, err := s.WebSocketURL(testProject, "", testChannel)
 	if err != nil {

--- a/services/substrate/components/pubsub/tests/assets/echo.go
+++ b/services/substrate/components/pubsub/tests/assets/echo.go
@@ -1,0 +1,38 @@
+package lib
+
+import (
+	"github.com/taubyte/go-sdk/event"
+	pubsubNode "github.com/taubyte/go-sdk/pubsub/node"
+)
+
+const replyChannel = "replychannel"
+
+//lint:ignore U1000 wasm export
+//export pubsubEcho
+func pubsubEcho(e event.Event) uint32 {
+	pubSubEvent, err := e.PubSub()
+	if err != nil {
+		return 1
+	}
+
+	data, err := pubSubEvent.Data()
+	if err != nil {
+		return 1
+	}
+
+	// exercise the channel accessor too, matching the incoming trigger channel
+	if _, err := pubSubEvent.Channel(); err != nil {
+		return 1
+	}
+
+	reply, err := pubsubNode.Channel(replyChannel)
+	if err != nil {
+		return 1
+	}
+
+	if err := reply.Publish(append([]byte("echo:"), data...)); err != nil {
+		return 1
+	}
+
+	return 0
+}

--- a/services/substrate/components/pubsub/tests/function_test.go
+++ b/services/substrate/components/pubsub/tests/function_test.go
@@ -1,0 +1,193 @@
+//go:build dreaming
+
+// Package pubsub_dreaming_test is the first end-to-end dreaming coverage for a
+// Type:"pubsub" wasm function: a published message travels through the real
+// substrate pubsub component (Subscribe/Publish/Lookup), into
+// function.HandleMessage, CreatePubsubEvent, and the wasm handler, which
+// republishes on a reply channel that the test observes directly.
+package pubsub_dreaming_test
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	gopubsub "github.com/libp2p/go-libp2p-pubsub"
+
+	_ "github.com/taubyte/tau/clients/p2p/hoarder/dream"
+	_ "github.com/taubyte/tau/clients/p2p/tns/dream"
+	commonIface "github.com/taubyte/tau/core/common"
+	"github.com/taubyte/tau/dream"
+	_ "github.com/taubyte/tau/dream/fixtures"
+	structureSpec "github.com/taubyte/tau/pkg/specs/structure"
+	_ "github.com/taubyte/tau/pkg/tcc/taubyte/v1/fixtures"
+	_ "github.com/taubyte/tau/services/hoarder/dream"
+	"github.com/taubyte/tau/services/monkey/fixtures/compile"
+	pubsubComponent "github.com/taubyte/tau/services/substrate/components/pubsub"
+	pubsubCommon "github.com/taubyte/tau/services/substrate/components/pubsub/common"
+	_ "github.com/taubyte/tau/services/substrate/dream"
+	_ "github.com/taubyte/tau/services/tns/dream"
+	tcc "github.com/taubyte/tau/utils/tcc"
+)
+
+const (
+	testProjectId  = "QmegMKBQmDTU9FUGKdhPFn1ZEtwcNaCA2wmyLW8vJn7wZN"
+	testFunctionId = "QmZY4u91d1YALDN2LTbpVtgwW8iT5cK9PE1bHZqX9J51Tv"
+
+	echoChannel  = "echochannel"
+	replyChannel = "replychannel"
+)
+
+// TestPubsubFunction_Dreaming publishes a message on echoChannel and expects
+// the compiled wasm function (assets/echo.go) to republish
+// "echo:"+data on replyChannel.
+func TestPubsubFunction_Dreaming(t *testing.T) {
+	m, err := dream.New(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	u, err := m.New(dream.UniverseConfig{Name: t.Name()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = u.StartWithConfig(&dream.Config{
+		Services: map[string]commonIface.ServiceConfig{
+			"tns":       {},
+			"substrate": {},
+			"hoarder":   {},
+		},
+		Simples: map[string]dream.SimpleConfig{
+			"client": {
+				Clients: dream.SimpleConfigClients{
+					TNS:     &commonIface.ClientConfig{},
+					Hoarder: &commonIface.ClientConfig{},
+				}.Compat(),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fs, _, err := tcc.GenerateProject(testProjectId,
+		&structureSpec.Messaging{
+			Name:  "echoMessaging",
+			Match: echoChannel,
+		},
+		// No function ever subscribes here - this channel only exists so the
+		// wasm function's reply-publish has somewhere to Lookup into. Marked
+		// WebSocket so CheckTns resolves a serviceable for it even though no
+		// function's Channel matches; see pubsub/lookup.go's CheckTns: a
+		// channel whose only match is a plain (non-websocket) Messaging entry
+		// with no listening function fails Lookup with "no pubsub matches".
+		&structureSpec.Messaging{
+			Name:      "replyMessaging",
+			Match:     replyChannel,
+			WebSocket: true,
+		},
+		&structureSpec.Function{
+			Id:      testFunctionId,
+			Name:    "pubsubEchoFunc",
+			Type:    "pubsub",
+			Channel: echoChannel,
+			Call:    "pubsubEcho",
+			Memory:  20 * 1024 * 1024,
+			Source:  ".",
+			Timeout: 1000000000,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = u.RunFixture("injectProject", fs); err != nil {
+		t.Fatal(err)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compileStart := time.Now()
+	err = u.RunFixture("compileFor", compile.BasicCompileFor{
+		ProjectId:  testProjectId,
+		ResourceId: testFunctionId,
+		Paths:      []string{path.Join(wd, "assets", "echo.go")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("compiled pubsub function fixture in %s", time.Since(compileStart))
+
+	// Reach the pubsub component the same way services/substrate/attach.go
+	// does (pubSub.New(srv)) rather than reflecting into the substrate
+	// service's private components struct. AddSubscription's subscription
+	// registry (websocket/handler.go) is keyed by topic name at package
+	// scope, and Node()/Tns()/Cache come from the shared substrate service,
+	// so this exercises the same wiring the attached component uses.
+	svc, err := pubsubComponent.New(u.Substrate())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Subscribe to the reply topic directly on the raw node before
+	// publishing, so the wasm function's reply can't race the test's
+	// listener.
+	replyMatcher := &pubsubCommon.MatchDefinition{Channel: replyChannel, Project: testProjectId}
+	replies := make(chan []byte, 4)
+	err = u.Substrate().Node().PubSubSubscribe(replyMatcher.String(),
+		func(msg *gopubsub.Message) {
+			message, err := pubsubCommon.NewMessage(msg, "")
+			if err != nil {
+				t.Logf("decoding reply message failed with: %s", err)
+				return
+			}
+			replies <- message.GetData()
+		},
+		func(err error) {
+			t.Logf("reply subscription error: %s", err)
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Bootstrap serving: nothing auto-subscribes substrate to a pubsub
+	// channel - in production this is done by the wasm SDK's subscribe()
+	// shim (pkg/vm-low-orbit/pubsub/subscribe.go) calling this same method
+	// from inside a running function. A test has no running function yet,
+	// so it calls Subscribe itself. TNS config propagation from
+	// injectProject/compileFor is async, so retry until it resolves.
+	var subErr error
+	for i := 0; i < 60; i++ {
+		subErr = svc.Subscribe(testProjectId, "", "test-subscriber", echoChannel)
+		if subErr == nil {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if subErr != nil {
+		t.Fatalf("subscribing to %q never succeeded: %v", echoChannel, subErr)
+	}
+
+	// resource must differ from Subscribe's "test-subscriber" above - both
+	// publish.go and subscribe.go key self-message filtering off it.
+	if err := svc.Publish(context.Background(), testProjectId, "", "test-publisher", echoChannel, []byte("hello")); err != nil {
+		t.Fatalf("publishing to %q failed with: %v", echoChannel, err)
+	}
+
+	select {
+	case data := <-replies:
+		if string(data) != "echo:hello" {
+			t.Fatalf("expected reply %q got %q", "echo:hello", data)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for echo reply on " + replyChannel)
+	}
+}

--- a/services/substrate/components/pubsub/utils_test.go
+++ b/services/substrate/components/pubsub/utils_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
 
+	iface "github.com/taubyte/tau/core/services/substrate/components/pubsub"
 	"github.com/taubyte/tau/core/services/tns"
 	"github.com/taubyte/tau/p2p/peer"
 	structureSpec "github.com/taubyte/tau/pkg/specs/structure"
@@ -44,4 +46,24 @@ func NewTestService(node peer.Node) *Service {
 	}
 
 	return s
+}
+
+// assertOneFunctionOneWebSocket checks a Lookup result holds exactly one
+// function serviceable (Config() != nil) and one websocket serviceable
+// (Config() == nil, per the websocket package's Config()).
+func assertOneFunctionOneWebSocket(t *testing.T, picks []iface.Serviceable) {
+	t.Helper()
+
+	var functions, webSockets int
+	for _, p := range picks {
+		if p.Config() != nil {
+			functions++
+		} else {
+			webSockets++
+		}
+	}
+
+	if functions != 1 || webSockets != 1 {
+		t.Errorf("expected 1 function and 1 websocket serviceable, got %d function(s) and %d websocket(s)", functions, webSockets)
+	}
 }

--- a/services/substrate/components/pubsub/websocket/serviceable.go
+++ b/services/substrate/components/pubsub/websocket/serviceable.go
@@ -1,0 +1,150 @@
+package websocket
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	commonIface "github.com/taubyte/tau/core/services/substrate/components"
+	iface "github.com/taubyte/tau/core/services/substrate/components/pubsub"
+	matcherSpec "github.com/taubyte/tau/pkg/specs/matcher"
+	structureSpec "github.com/taubyte/tau/pkg/specs/structure"
+	"github.com/taubyte/tau/services/substrate/components/pubsub/common"
+	"github.com/taubyte/tau/utils/id"
+)
+
+var _ commonIface.Serviceable = &WebSocket{}
+var _ iface.Serviceable = &WebSocket{}
+
+// WebSocket is a Serviceable that gates access to a messaging channel over a
+// websocket. It carries no runtime state of its own: the actual bridging
+// between the connection and pubsub happens in the handler/datastream layer,
+// this only exists so CheckTns/Cache can validate and cache a matching
+// configuration the same way function serviceables do.
+type WebSocket struct {
+	ctx  context.Context
+	ctxC context.CancelFunc
+
+	srv iface.Service
+	mmi common.MessagingMapItem
+
+	matcher *common.MatchDefinition
+	commit  string
+	branch  string
+
+	closeOnce sync.Once
+}
+
+func New(srv iface.Service, mmi common.MessagingMapItem, commit, branch string, matcher *common.MatchDefinition) (commonIface.Serviceable, error) {
+	if matcher == nil {
+		return nil, fmt.Errorf("matcher is nil")
+	}
+
+	ws := &WebSocket{
+		srv:     srv,
+		mmi:     mmi,
+		matcher: matcher,
+		commit:  commit,
+		branch:  branch,
+	}
+
+	ws.ctx, ws.ctxC = context.WithCancel(srv.Context())
+
+	if _, err := srv.Cache().Add(ws); err != nil {
+		return nil, fmt.Errorf("adding pubsub websocket serviceable failed with: %s", err)
+	}
+
+	if err := ws.Validate(matcher); err != nil {
+		return nil, fmt.Errorf("validating websocket with id `%s` failed with: %s", ws.Id(), err)
+	}
+
+	return ws, nil
+}
+
+// Id is deterministic on project/channel rather than the dead code's
+// hardcoded "". The runtime cache keys entries by
+// cacheMap[matcher.CachePrefix()][serviceable.Id()], and CachePrefix is just
+// the project - a constant Id would collide across every websocket channel
+// in the same project. Deterministic (vs random) so repeated CheckTns calls
+// for the same channel converge on one cache entry instead of piling up
+// duplicates.
+func (ws *WebSocket) Id() string {
+	return id.GenerateDeterministic(ws.matcher.Project, ws.matcher.Channel, "websocket")
+}
+
+func (ws *WebSocket) Ready() error {
+	return nil
+}
+
+func (ws *WebSocket) Project() string {
+	return ws.matcher.Project
+}
+
+func (ws *WebSocket) Application() string {
+	return ws.matcher.Application
+}
+
+func (ws *WebSocket) Commit() string {
+	return ws.commit
+}
+
+func (ws *WebSocket) Branch() string {
+	return ws.branch
+}
+
+func (ws *WebSocket) Matcher() commonIface.MatchDefinition {
+	return ws.matcher
+}
+
+func (ws *WebSocket) Service() commonIface.ServiceComponent {
+	return ws.srv
+}
+
+func (ws *WebSocket) Config() *structureSpec.Function {
+	return nil
+}
+
+func (ws *WebSocket) AssetId() string {
+	return ""
+}
+
+func (ws *WebSocket) Name() string {
+	return strings.Join(ws.mmi.Names(), ",")
+}
+
+// HandleMessage is a no-op: a websocket serviceable is a config/authorization
+// gate for CheckTns/Cache lookups, not a message consumer - the connection
+// itself is bridged to pubsub directly by the handler/datastream layer.
+func (ws *WebSocket) HandleMessage(msg iface.Message) (time.Time, error) {
+	return time.Now(), nil
+}
+
+func (ws *WebSocket) Match(matcher commonIface.MatchDefinition) matcherSpec.Index {
+	_matcher, ok := matcher.(*common.MatchDefinition)
+	if !ok {
+		return matcherSpec.NoMatch
+	}
+
+	if len(ws.mmi.Matches(_matcher.Channel)) > 0 {
+		return matcherSpec.HighMatch
+	}
+
+	return matcherSpec.NoMatch
+}
+
+func (ws *WebSocket) Validate(matcher commonIface.MatchDefinition) error {
+	if len(ws.mmi.Matches(ws.matcher.Channel)) == 0 {
+		return errors.New("websocket channels do not match")
+	}
+
+	return nil
+}
+
+func (ws *WebSocket) Close() {
+	ws.closeOnce.Do(func() {
+		ws.ctxC()
+	})
+}

--- a/services/substrate/components/pubsub/websocket/serviceable_test.go
+++ b/services/substrate/components/pubsub/websocket/serviceable_test.go
@@ -1,0 +1,117 @@
+package websocket
+
+import (
+	"context"
+	"testing"
+
+	commonIface "github.com/taubyte/tau/core/services/substrate/components"
+	matcherSpec "github.com/taubyte/tau/pkg/specs/matcher"
+	structureSpec "github.com/taubyte/tau/pkg/specs/structure"
+	"github.com/taubyte/tau/services/substrate/components/pubsub/common"
+)
+
+// foreignMatcher is a MatchDefinition that is not *common.MatchDefinition, used
+// to exercise Match's type-assertion guard.
+type foreignMatcher struct{}
+
+func (foreignMatcher) String() string      { return "" }
+func (foreignMatcher) CachePrefix() string { return "" }
+
+// newTestWS builds a WebSocket serviceable directly (white-box) so the
+// config-gate invariants can be checked without standing up a full Service
+// mock. It mirrors what New produces post-cache-add.
+func newTestWS(t *testing.T, project, channel string) *WebSocket {
+	t.Helper()
+
+	var mmi common.MessagingMapItem
+	mmi.Push(project, "", &structureSpec.Messaging{Match: channel, WebSocket: true})
+
+	ws := &WebSocket{
+		mmi:     mmi,
+		matcher: &common.MatchDefinition{Channel: channel, Project: project},
+		commit:  "commit",
+		branch:  "master",
+	}
+	ws.ctx, ws.ctxC = context.WithCancel(context.Background())
+
+	return ws
+}
+
+// TestWebSocketCloseIdempotent locks in the sync.Once guard: Close must be safe
+// to call repeatedly (cache.Remove can race with connection teardown).
+func TestWebSocketCloseIdempotent(t *testing.T) {
+	ws := newTestWS(t, "proj", "chan")
+
+	ws.Close()
+	ws.Close()
+	ws.Close()
+
+	select {
+	case <-ws.ctx.Done():
+	default:
+		t.Fatal("Close did not cancel the serviceable context")
+	}
+}
+
+// TestWebSocketHandleMessageNoop guards the mixed-pick contract: a websocket
+// serviceable can land in a non-websocket Lookup's picks, where subscribe.go's
+// handle calls HandleMessage on every pick. It must be an error-free no-op.
+func TestWebSocketHandleMessageNoop(t *testing.T) {
+	ws := newTestWS(t, "proj", "chan")
+
+	if _, err := ws.HandleMessage(nil); err != nil {
+		t.Fatalf("HandleMessage must be a no-op, got error: %v", err)
+	}
+}
+
+// TestWebSocketMatch covers the channel gate and the non-common matcher guard.
+func TestWebSocketMatch(t *testing.T) {
+	ws := newTestWS(t, "proj", "chan")
+
+	if got := ws.Match(&common.MatchDefinition{Channel: "chan", Project: "proj"}); got != matcherSpec.HighMatch {
+		t.Fatalf("expected HighMatch on matching channel, got %v", got)
+	}
+	if got := ws.Match(&common.MatchDefinition{Channel: "other", Project: "proj"}); got != matcherSpec.NoMatch {
+		t.Fatalf("expected NoMatch on non-matching channel, got %v", got)
+	}
+	var foreign commonIface.MatchDefinition = foreignMatcher{}
+	if got := ws.Match(foreign); got != matcherSpec.NoMatch {
+		t.Fatalf("expected NoMatch on foreign matcher type, got %v", got)
+	}
+}
+
+// TestWebSocketIdDeterministic verifies the cache key converges per
+// (project, channel) and separates distinct channels, so repeated CheckTns
+// calls reuse one cache entry instead of piling up duplicates.
+func TestWebSocketIdDeterministic(t *testing.T) {
+	a := newTestWS(t, "proj", "chan")
+	b := newTestWS(t, "proj", "chan")
+	if a.Id() != b.Id() {
+		t.Fatalf("same (project, channel) must produce same Id: %q != %q", a.Id(), b.Id())
+	}
+
+	c := newTestWS(t, "proj", "other")
+	if a.Id() == c.Id() {
+		t.Fatal("different channels must produce different Ids")
+	}
+	if a.Id() == "" {
+		t.Fatal("Id must not be empty")
+	}
+}
+
+// TestWebSocketConfigGate pins the sentinels the mixed-pick helpers rely on:
+// Config()==nil (distinguishes ws from function picks) and AssetId=="" (keeps
+// cache.validate's asset check harmless).
+func TestWebSocketConfigGate(t *testing.T) {
+	ws := newTestWS(t, "proj", "chan")
+
+	if ws.Config() != nil {
+		t.Fatal("websocket Config() must be nil")
+	}
+	if ws.AssetId() != "" {
+		t.Fatalf("websocket AssetId() must be empty, got %q", ws.AssetId())
+	}
+	if err := ws.Ready(); err != nil {
+		t.Fatalf("Ready() must be nil, got %v", err)
+	}
+}

--- a/services/substrate/runtime/call.go
+++ b/services/substrate/runtime/call.go
@@ -49,14 +49,32 @@ func (f *Function) Call(inst Instance, id uint32) (err error) {
 		return fmt.Errorf("getting module name for resource `%s` failed with: %w", f.serviceable.Id(), err)
 	}
 
-	module, err := inst.Module(moduleName)
-	if err != nil {
-		return fmt.Errorf("creating module instance failed with: %w", err)
-	}
+	var module vm.ModuleInstance
+	var fx vm.FunctionInstance
+	if ii, ok := inst.(*instance); ok {
+		// any error below (including a RawCall trap or timeout, which closes
+		// the runtime via CloseOnContextDone) leaves the instance in an
+		// unknown state; flag it so Free retires it instead of repooling.
+		defer func() {
+			if err != nil {
+				ii.failed = true
+			}
+		}()
 
-	fx, err := module.Function(f.config.Call)
-	if err != nil {
-		return fmt.Errorf("getting wasm function instance failed with: %w", err)
+		module, fx, err = ii.function(moduleName, f.config.Call)
+		if err != nil {
+			return fmt.Errorf("getting wasm function instance failed with: %w", err)
+		}
+	} else {
+		module, err = inst.Module(moduleName)
+		if err != nil {
+			return fmt.Errorf("creating module instance failed with: %w", err)
+		}
+
+		fx, err = module.Function(f.config.Call)
+		if err != nil {
+			return fmt.Errorf("getting wasm function instance failed with: %w", err)
+		}
 	}
 
 	ctx, ctxC := context.WithTimeout(f.ctx, time.Duration(time.Nanosecond*time.Duration(f.config.Timeout)))

--- a/services/substrate/runtime/free_test.go
+++ b/services/substrate/runtime/free_test.go
@@ -1,0 +1,135 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/taubyte/tau/core/vm"
+)
+
+func TestShouldRetire(t *testing.T) {
+	const capBytes = uint64(300000) // 2/3 of capBytes == 200000
+
+	for name, test := range map[string]struct {
+		useMem uint32
+		want   bool
+	}{
+		"under two thirds of cap": {
+			useMem: 150000,
+			want:   false,
+		},
+		// The threshold is a strict `>`: sitting exactly on two thirds is kept.
+		"exactly two thirds of cap": {
+			useMem: 200000,
+			want:   false,
+		},
+		"past two thirds of cap": {
+			useMem: 250000,
+			want:   true,
+		},
+		// A module whose footprint fills the cap has no growth headroom;
+		// pooling it would only defer a mid-call OOM trap, so it cold-starts
+		// every call by design.
+		"at cap": {
+			useMem: 300000,
+			want:   true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := shouldRetire(test.useMem, capBytes); got != test.want {
+				t.Errorf("shouldRetire(%d, %d) = %v, want %v", test.useMem, capBytes, got, test.want)
+			}
+		})
+	}
+}
+
+// fakeMemory/fakeModule/fakeRuntime are minimal vm fakes exposing only the
+// surface Free() touches: a single module whose reported size we control.
+type fakeMemory struct {
+	vm.Memory
+	size uint32
+}
+
+func (m fakeMemory) Size() uint32 { return m.size }
+
+type fakeModule struct {
+	vm.ModuleInstance
+	size uint32
+}
+
+func (m fakeModule) Memory() vm.Memory { return fakeMemory{size: m.size} }
+
+type fakeRuntime struct {
+	vm.Runtime
+	size   uint32
+	closed int
+}
+
+func (r *fakeRuntime) Modules() []string { return []string{"m"} }
+
+func (r *fakeRuntime) Module(name string) (vm.ModuleInstance, error) {
+	return fakeModule{size: r.size}, nil
+}
+
+func (r *fakeRuntime) Close() error {
+	r.closed++
+	return nil
+}
+
+// TestInstanceFree exercises the stateful Free() contract: healthy instances
+// are pooled, instances grown past two thirds of the enforced page cap are
+// retired (closed, not repooled — the old code leaked them), and instances
+// flagged failed are retired regardless of memory.
+func TestInstanceFree(t *testing.T) {
+	const pages = 4 // cap = 4 * 65536 = 262144 bytes, 2/3 == 174762
+
+	newInst := func(rt *fakeRuntime) (*instance, *Function) {
+		f := &Function{
+			vmConfig:           &vm.Config{MemoryLimitPages: pages},
+			availableInstances: make(chan Instance, InstanceMaxRequests),
+		}
+		return &instance{runtime: rt, parent: f}, f
+	}
+
+	pooled := func(f *Function) bool {
+		select {
+		case <-f.availableInstances:
+			return true
+		default:
+			return false
+		}
+	}
+
+	t.Run("healthy instance is pooled", func(t *testing.T) {
+		rt := &fakeRuntime{size: 2 * vm.MemoryPageSize}
+		i, f := newInst(rt)
+		if err := i.Free(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rt.closed != 0 || !pooled(f) {
+			t.Fatalf("instance should be pooled, closed=%d", rt.closed)
+		}
+	})
+
+	t.Run("instance past two thirds of cap is retired", func(t *testing.T) {
+		rt := &fakeRuntime{size: 3 * vm.MemoryPageSize}
+		i, f := newInst(rt)
+		if err := i.Free(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rt.closed != 1 || pooled(f) {
+			t.Fatalf("instance should be retired, closed=%d", rt.closed)
+		}
+	})
+
+	t.Run("failed instance is retired regardless of memory", func(t *testing.T) {
+		rt := &fakeRuntime{size: vm.MemoryPageSize}
+		i, f := newInst(rt)
+		i.failed = true
+		if err := i.Free(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rt.closed != 1 || pooled(f) {
+			t.Fatalf("failed instance should be retired, closed=%d", rt.closed)
+		}
+	})
+}

--- a/services/substrate/runtime/free_test.go
+++ b/services/substrate/runtime/free_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/taubyte/tau/core/vm"
+	structureSpec "github.com/taubyte/tau/pkg/specs/structure"
 )
 
 func TestShouldRetire(t *testing.T) {
@@ -84,6 +85,8 @@ func TestInstanceFree(t *testing.T) {
 
 	newInst := func(rt *fakeRuntime) (*instance, *Function) {
 		f := &Function{
+			config:             &structureSpec.Function{Name: "someFunc"},
+			serviceable:        newMockServiceable(),
 			vmConfig:           &vm.Config{MemoryLimitPages: pages},
 			availableInstances: make(chan Instance, InstanceMaxRequests),
 		}
@@ -118,6 +121,31 @@ func TestInstanceFree(t *testing.T) {
 		}
 		if rt.closed != 1 || pooled(f) {
 			t.Fatalf("instance should be retired, closed=%d", rt.closed)
+		}
+		// retired without ever pooling → the no-headroom config warning fires
+		if !f.noPoolWarned.Load() {
+			t.Fatal("expected never-pooled retirement to set noPoolWarned")
+		}
+	})
+
+	t.Run("growth retirement after pooling does not warn", func(t *testing.T) {
+		rt := &fakeRuntime{size: 2 * vm.MemoryPageSize}
+		i, f := newInst(rt)
+		if err := i.Free(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !pooled(f) {
+			t.Fatal("instance should be pooled")
+		}
+		rt.size = 3 * vm.MemoryPageSize
+		if err := i.Free(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rt.closed != 1 {
+			t.Fatalf("grown instance should be retired, closed=%d", rt.closed)
+		}
+		if f.noPoolWarned.Load() {
+			t.Fatal("growth retirement after pooling must not warn")
 		}
 	})
 

--- a/services/substrate/runtime/instantiate.go
+++ b/services/substrate/runtime/instantiate.go
@@ -13,18 +13,50 @@ import (
 	vmContext "github.com/taubyte/tau/pkg/vm/context"
 )
 
-func (i *instance) Free() error {
+func (i *instance) usedMemory() (uint32, error) {
 	var useMem uint32
 	for _, name := range i.runtime.Modules() {
 		mod, err := i.runtime.Module(name)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		useMem += mod.Memory().Size()
 	}
 
-	if useMem > uint32(i.parent.config.Memory*2/3) {
-		return fmt.Errorf("used memory limit exceeded") //TODO: cleanup instance
+	return useMem, nil
+}
+
+// shouldRetire decides whether a pooled instance should be discarded instead
+// of reused. wasm linear memory only ever grows, so once usage crosses the
+// last third of the enforced cap we retire the instance while it can still be
+// replaced cheaply, rather than letting its allocator hit the cap mid-call
+// later. The threshold is measured against the page-derived cap that is
+// actually enforced, not raw config.Memory: pages round up, so the byte value
+// understates the real cap and would retire instances that still have
+// headroom. Modules whose minimum footprint already sits past two thirds of
+// the cap never pool — with no room to grow, reuse only defers a mid-call OOM
+// trap, so cold-starting every call is the correct behavior for such
+// under-provisioned functions.
+func shouldRetire(useMem uint32, capBytes uint64) bool {
+	return uint64(useMem) > capBytes*2/3
+}
+
+func (i *instance) Free() error {
+	if i.failed {
+		i.Close()
+		return nil
+	}
+
+	useMem, err := i.usedMemory()
+	if err != nil {
+		i.Close()
+		return err
+	}
+
+	capBytes := uint64(i.parent.vmConfig.MemoryLimitPages) * uint64(vm.MemoryPageSize)
+	if shouldRetire(useMem, capBytes) {
+		i.Close()
+		return nil
 	}
 
 	i.parent.availableInstances <- i
@@ -33,6 +65,32 @@ func (i *instance) Free() error {
 
 func (i *instance) Module(name string) (vm.ModuleInstance, error) {
 	return i.runtime.Module(name)
+}
+
+// function returns cached module/function handles for moduleName/fxName,
+// resolving and caching them on first use. Instances are used by one request
+// at a time, so no locking is required.
+func (i *instance) function(moduleName, fxName string) (vm.ModuleInstance, vm.FunctionInstance, error) {
+	if i.fxModule != nil && i.fxModuleName == moduleName && i.fxName == fxName {
+		return i.fxModule, i.fx, nil
+	}
+
+	mod, err := i.runtime.Module(moduleName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	fx, err := mod.Function(fxName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	i.fxModuleName = moduleName
+	i.fxName = fxName
+	i.fxModule = mod
+	i.fx = fx
+
+	return mod, fx, nil
 }
 
 func (i *instance) SDK() plugins.Instance {

--- a/services/substrate/runtime/instantiate.go
+++ b/services/substrate/runtime/instantiate.go
@@ -55,10 +55,19 @@ func (i *instance) Free() error {
 
 	capBytes := uint64(i.parent.vmConfig.MemoryLimitPages) * uint64(vm.MemoryPageSize)
 	if shouldRetire(useMem, capBytes) {
+		// an instance retired before ever being pooled means the function's
+		// memory config leaves no headroom: every call will cold-start.
+		if !i.pooled && i.parent.noPoolWarned.CompareAndSwap(false, true) {
+			logger.Warnf(
+				"function `%s` (%s) uses %d bytes of its %d-byte memory cap; instances never pool and every call cold-starts — increase the function's memory",
+				i.parent.config.Name, i.parent.serviceable.Id(), useMem, capBytes,
+			)
+		}
 		i.Close()
 		return nil
 	}
 
+	i.pooled = true
 	i.parent.availableInstances <- i
 	return nil
 }

--- a/services/substrate/runtime/types.go
+++ b/services/substrate/runtime/types.go
@@ -45,6 +45,18 @@ type instance struct {
 	memUsages   []uint32
 	sdk         plugins.Instance
 	parent      *Function
+
+	// failed marks an instance whose call errored or timed out; its runtime
+	// is in an unknown (possibly closed) state, so Free retires it instead of
+	// repooling.
+	failed bool
+
+	// cached function handle, keyed by the module/function name it was
+	// resolved under, to avoid a fresh wazero ExportedFunction lookup per call.
+	fxModuleName string
+	fxName       string
+	fxModule     vm.ModuleInstance
+	fx           vm.FunctionInstance
 }
 
 type instanceRequest struct {

--- a/services/substrate/runtime/types.go
+++ b/services/substrate/runtime/types.go
@@ -37,6 +37,10 @@ type Function struct {
 	calls         *atomic.Uint64
 	totalCallTime *atomic.Int64
 	maxMemory     *atomic.Uint64
+
+	// noPoolWarned gates the once-per-function warning emitted when instances
+	// retire without ever pooling (memory config leaves no headroom).
+	noPoolWarned atomic.Bool
 }
 
 type instance struct {
@@ -50,6 +54,10 @@ type instance struct {
 	// is in an unknown (possibly closed) state, so Free retires it instead of
 	// repooling.
 	failed bool
+
+	// pooled marks an instance that made it into the pool at least once,
+	// distinguishing normal growth-retirement from a config that never pools.
+	pooled bool
 
 	// cached function handle, keyed by the module/function name it was
 	// resolved under, to avoid a fresh wazero ExportedFunction lookup per call.


### PR DESCRIPTION
Dream-based profiling of the serving paths, the fixes it motivated, and one revived feature. All measured via the new benchmark suite (`make bench-dreaming`).

## Instance pool fixes (`services/substrate/runtime`)

`Free()` retired instances against `config.Memory*2/3` in raw bytes, while the enforced cap is page-derived (rounded up) — any function whose wasm memory exceeded the byte threshold cold-started **every request** and the discarded instance was never closed. Measured impact at an affected config: **74× slower, 80× more memory** (5.7ms/2MB/7166 allocs vs 77µs/25KB/211 allocs per request).

- retire against the page-derived cap; always `Close()` retired instances
- retire instances whose call errored or timed out (a timed-out instance's runtime is closed by wazero's `CloseOnContextDone`; repooling it poisoned the pool)
- cache the module+function handles per pooled instance (wazero `ExportedFunction` allocates a ~11.5KB call engine per lookup — was 45% of warm-path allocations)
- warn once per function when its memory config leaves no pooling headroom (min wasm memory ≥ ⅔ cap ⇒ cold start per call by design; reuse would only defer a mid-call OOM trap — verified empirically, the AS allocator traps after ~100 reused calls)

## Cold-start cost (`pkg/vm`)

- dfs backend now LRU-caches decompressed wasm module bytes by CID (content-addressed → immutable; 256MiB cap, singleflight misses). Kills the per-instantiation DAG fetch + zip + LZW decompress (~22% of cold CPU).
- host-module reflection tables cached per type (factory `W_` discovery, handler signatures); the call trampoline no longer probes `Implements()` per host-function call
- `WithDebugInfoEnabled(false)`: DWARF parsing taxed every module compile; traces keep function names

## Benchmarks (`dream/benchmarks`, `make bench-dreaming`)

HTTP function (warm/cold/parallel), TNS fetch, universe boot, p2p function, websocket echo, database KV, storage add/get. Baselines:

| path | before | after |
|---|---|---|
| HTTP warm | 77µs / 25.5KB / 211 allocs | 73µs / 13.6KB / 207 allocs |
| HTTP cold start | 5.69ms / 2.04MB / 7166 allocs | ~2.5ms / 1.16MB / 4927 allocs |
| p2p function | — | 296µs / 626 allocs |
| websocket echo | broken (see below) | ~180µs / 51 allocs |
| database get / put | — | 208µs / 339 allocs; put is ms-scale, grows with store |
| storage add / get (256KB) | — | 256µs / 125µs |

## Websocket revival (`services/substrate/components/pubsub`)

The websocket serviceable was deleted in the shadow refactor (#386) with its lookup call site commented out — every websocket connection since has failed at lookup with `no pub-sub matches found`. Reimplemented against the current `Serviceable` interface (deterministic per-channel cache id; no-op `HandleMessage` — bridging stays in the handler/datastream layer), restored the messaging-map split, unskipped the socket test, and unskipped `BenchmarkWebsocketEcho` which now guards the path end to end.

## Notes

- `TestLoader` now runs with the CID cache disabled: it deletes the backing file and expects loads to fail, which the (immutable, content-addressed) cache correctly masks.
- Known follow-up, left out of scope: `p2p/streams/client.New` spawns a `discover()` goroutine per command dispatch that `Send` never closes.

Verified locally (org Actions still down): full unit sweep (258 pkgs), `-race` on touched packages, dreaming suites for substrate/pubsub/monkey-compile, full benchmark suite.