### PR TITLE
fix(substrate): share the p2p command client instead of leaking one per send

### DIFF
--- a/services/substrate/components/p2p/command_leak_test.go
+++ b/services/substrate/components/p2p/command_leak_test.go
@@ -1,0 +1,125 @@
+package p2p
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	peercore "github.com/libp2p/go-libp2p/core/peer"
+	iface "github.com/taubyte/tau/core/services/substrate/components/p2p"
+	keypair "github.com/taubyte/tau/p2p/keypair"
+	"github.com/taubyte/tau/p2p/peer"
+	"github.com/taubyte/tau/p2p/streams"
+	"github.com/taubyte/tau/p2p/streams/client"
+	"github.com/taubyte/tau/p2p/streams/command"
+	cr "github.com/taubyte/tau/p2p/streams/command/response"
+	peerService "github.com/taubyte/tau/p2p/streams/service"
+	structureSpec "github.com/taubyte/tau/pkg/specs/structure"
+	"github.com/taubyte/tau/services/substrate/components/p2p/stream"
+)
+
+// TestCommandSendNoGoroutineLeak reproduces the p2p Command.Send/SendTo
+// goroutine leak: beforeSend used to construct a brand new p2p/streams/client
+// (and its background discover goroutine) on every call instead of reusing
+// one client for the Stream's lifetime. Sending many commands through a
+// single Stream/Command must not grow the goroutine count roughly linearly
+// with the number of sends.
+func TestCommandSendNoGoroutineLeak(t *testing.T) {
+	const protocol = "/leaktest/p2p/1.0"
+	const cmdName = "echo"
+
+	ctx := t.Context()
+
+	receiver, err := peer.New(ctx, nil, keypair.NewRaw(), nil, []string{"/ip4/127.0.0.1/tcp/0"}, nil, true, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer receiver.Close()
+
+	svr, err := peerService.New(receiver, "leak-test", protocol)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer svr.Stop()
+
+	err = svr.Define(cmdName, func(context.Context, streams.Connection, command.Body) (cr.Response, error) {
+		return cr.Response{"ok": true}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	svr.Start()
+
+	sender, err := peer.New(ctx, nil, keypair.NewRaw(), nil, []string{"/ip4/127.0.0.1/tcp/0"}, nil, true, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sender.Close()
+
+	if err := sender.Peer().Connect(ctx, peercore.AddrInfo{ID: receiver.ID(), Addrs: receiver.Peer().Addrs()}); err != nil {
+		t.Fatal(err)
+	}
+
+	// One shared client, exactly as (*p2p.Service).p2pClient hands to every
+	// Stream it creates.
+	p2pClient, err := client.New(sender, protocol)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p2pClient.Close()
+
+	srv := NewTestService(sender)
+	matcher := &iface.MatchDefinition{Project: "leak-test-project", Protocol: protocol}
+
+	st, err := stream.New(srv, ctx, &structureSpec.Service{Id: "leak-test-service"}, "", matcher, p2pClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	cmd, err := st.Command(cmdName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	send := func() error {
+		_, err := cmd.Send(ctx, map[string]any{"data": []byte("ping")})
+		return err
+	}
+
+	if err := send(); err != nil {
+		t.Fatalf("warm-up send failed: %s", err)
+	}
+
+	for range 3 {
+		runtime.GC()
+		time.Sleep(50 * time.Millisecond)
+	}
+	before := runtime.NumGoroutine()
+
+	const iterations = 50
+	for i := range iterations {
+		if err := send(); err != nil {
+			t.Fatalf("send %d failed: %s", i, err)
+		}
+	}
+
+	const maxGrowth = 15
+	var after int
+	settled := false
+	for range 30 {
+		runtime.GC()
+		time.Sleep(50 * time.Millisecond)
+		after = runtime.NumGoroutine()
+		if after-before < maxGrowth {
+			settled = true
+			break
+		}
+	}
+
+	if !settled {
+		t.Fatalf("goroutine growth after %d sends through one Command: before=%d after=%d (grew by %d, want < %d)",
+			iterations, before, after, after-before, maxGrowth)
+	}
+}

--- a/services/substrate/components/p2p/service.go
+++ b/services/substrate/components/p2p/service.go
@@ -66,5 +66,10 @@ func (srv *Service) Stream(ctx context.Context, projectID, applicationID, protoc
 		return nil, err
 	}
 
-	return stream.New(srv, ctx, foundService, serviceApplication, matcher)
+	p2pClient, err := srv.p2pClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting p2p client failed with: %w", err)
+	}
+
+	return stream.New(srv, ctx, foundService, serviceApplication, matcher, p2pClient)
 }

--- a/services/substrate/components/p2p/stream/command.go
+++ b/services/substrate/components/p2p/stream/command.go
@@ -11,13 +11,12 @@ import (
 	"github.com/taubyte/tau/p2p/streams/client"
 	"github.com/taubyte/tau/p2p/streams/command"
 	"github.com/taubyte/tau/p2p/streams/command/response"
-	protocolCommon "github.com/taubyte/tau/services/common"
 	"github.com/taubyte/tau/services/substrate/components/p2p/common"
 )
 
 type Command struct {
-	srv     iface.Service
 	matcher *iface.MatchDefinition
+	client  *client.Client
 }
 
 func (st *Stream) Command(command string) (iface.Command, error) {
@@ -27,30 +26,25 @@ func (st *Stream) Command(command string) (iface.Command, error) {
 
 	st.matcher.Command = command
 	return &Command{
-		srv:     st.srv,
 		matcher: st.matcher,
+		client:  st.client,
 	}, nil
 }
 
-func (c *Command) beforeSend(ctx context.Context, body command.Body) (*client.Client, command.Body, error) {
-	p2pClient, err := client.New(c.srv.Node(), protocolCommon.SubstrateP2PProtocol)
-	if err != nil {
-		return nil, nil, fmt.Errorf("New p2p client failed with: %s", err)
-	}
-
+func (c *Command) beforeSend(body command.Body) (*client.Client, command.Body, error) {
 	data, ok := body["data"]
 	if !ok {
 		return nil, nil, fmt.Errorf("no data found in body")
 	}
 
-	return p2pClient, command.Body{
+	return c.client, command.Body{
 		"matcher": c.matcher,
 		"data":    data,
 	}, nil
 }
 
 func (c *Command) Send(ctx context.Context, body map[string]interface{}) (response.Response, error) {
-	p2pClient, body, err := c.beforeSend(ctx, body)
+	p2pClient, body, err := c.beforeSend(body)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +58,7 @@ func (c *Command) Send(ctx context.Context, body map[string]interface{}) (respon
 }
 
 func (c *Command) SendTo(ctx context.Context, cid cid.Cid, body map[string]interface{}) (response.Response, error) {
-	p2pClient, body, err := c.beforeSend(ctx, body)
+	p2pClient, body, err := c.beforeSend(body)
 	if err != nil {
 		return nil, err
 	}

--- a/services/substrate/components/p2p/stream/new.go
+++ b/services/substrate/components/p2p/stream/new.go
@@ -6,15 +6,17 @@ import (
 
 	sdkSmartOpsCommon "github.com/taubyte/go-sdk-smartops/common"
 	iface "github.com/taubyte/tau/core/services/substrate/components/p2p"
+	"github.com/taubyte/tau/p2p/streams/client"
 	structureSpec "github.com/taubyte/tau/pkg/specs/structure"
 	"github.com/taubyte/tau/services/substrate/components/p2p/service"
 )
 
-func New(srv iface.Service, ctx context.Context, config *structureSpec.Service, serviceApplication string, matcher *iface.MatchDefinition) (iface.Stream, error) {
+func New(srv iface.Service, ctx context.Context, config *structureSpec.Service, serviceApplication string, matcher *iface.MatchDefinition, p2pClient *client.Client) (iface.Stream, error) {
 	s := &Stream{
 		srv:     srv,
 		config:  config,
 		matcher: matcher,
+		client:  p2pClient,
 	}
 	s.instanceCtx, s.instanceCtxC = context.WithCancel(ctx)
 

--- a/services/substrate/components/p2p/stream/types.go
+++ b/services/substrate/components/p2p/stream/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	iface "github.com/taubyte/tau/core/services/substrate/components/p2p"
+	"github.com/taubyte/tau/p2p/streams/client"
 	structureSpec "github.com/taubyte/tau/pkg/specs/structure"
 )
 
@@ -13,6 +14,7 @@ type Stream struct {
 	srv     iface.Service
 	config  *structureSpec.Service
 	matcher *iface.MatchDefinition
+	client  *client.Client
 
 	instanceCtx  context.Context
 	instanceCtxC context.CancelFunc

--- a/services/substrate/components/p2p/types.go
+++ b/services/substrate/components/p2p/types.go
@@ -2,9 +2,13 @@ package p2p
 
 import (
 	"context"
+	"errors"
+	"sync"
 
 	nodeIface "github.com/taubyte/tau/core/services/substrate"
 	p2pIface "github.com/taubyte/tau/core/services/substrate/components/p2p"
+	"github.com/taubyte/tau/p2p/streams/client"
+	"github.com/taubyte/tau/services/common"
 	"github.com/taubyte/tau/services/substrate/runtime/cache"
 )
 
@@ -14,11 +18,55 @@ type Service struct {
 	nodeIface.Service
 	stream p2pIface.CommandService
 	cache  *cache.Cache
+
+	// client is the Service's single shared outgoing-command client, reused by
+	// every Stream instead of one-per-Send (each client spawns a background
+	// discover goroutine, so per-Send clients leaked goroutines). clientMu
+	// guards lazy creation against a concurrent Close: Close() teardown races
+	// in-flight Stream() calls because the substrate tears down components
+	// before the WASM vm that drives them (see substrate.Service.Close).
+	clientMu     sync.Mutex
+	client       *client.Client
+	clientClosed bool
+}
+
+// p2pClient returns the Service's shared outgoing-command client, creating it
+// lazily on first use so it comes up on demand rather than racing the node's
+// discovery/DHT convergence at boot (eager creation at New() poisons the
+// discovery backoff cache before the DHT converges). It errors once the Service
+// is closed so a late Stream() doesn't spawn a discover goroutine that would
+// outlive teardown.
+func (s *Service) p2pClient() (*client.Client, error) {
+	s.clientMu.Lock()
+	defer s.clientMu.Unlock()
+
+	if s.clientClosed {
+		return nil, errors.New("p2p service is closed")
+	}
+
+	if s.client == nil {
+		c, err := client.New(s.Node(), common.SubstrateP2PProtocol)
+		if err != nil {
+			return nil, err
+		}
+		s.client = c
+	}
+
+	return s.client, nil
 }
 
 func (s *Service) Close() error {
 	s.cache.Close()
 	s.stream.Close()
+
+	s.clientMu.Lock()
+	c := s.client
+	s.clientClosed = true
+	s.clientMu.Unlock()
+
+	if c != nil {
+		c.Close()
+	}
 	return nil
 }
 


### PR DESCRIPTION
Found by the profiling work in #470: every p2p command dispatch (`Command.Send`/`SendTo` in `services/substrate/components/p2p/stream`) constructed a `p2p/streams/client.Client` and never closed it. Each client spawns a background `discover()` goroutine under a cancelable context, so every dispatch leaked a goroutine + context for the life of the node. Every other consumer in the tree (`clients/p2p/*`, acme store) holds one client per node+protocol; this call site was the anomaly.

## Change

- The p2p component now owns a single shared client, threaded through `Stream` → `Command`; `Service.Close()` closes it.
- Creation is **lazy** (first `Stream()` call): eager creation at `New()` fires `FindPeers` before the DHT converges and poisons the discovery backoff cache (`DiscoveryBackoffMin` = 60s), deterministically breaking `TestService_Discover_Dreaming` — the WHY is documented in the accessor.
- Creation/teardown is **mutex-guarded**: `Close()` races in-flight `Stream()` calls because substrate tears down components before the wasm vm that drives them; a `sync.Once` version tripped the race detector under a 300-iteration stress. A late `Stream()` after `Close()` gets a clean error instead of spawning a discover goroutine that outlives teardown.

## Verification

- New regression test `TestCommandSendNoGoroutineLeak`: 50 sends through one `Command` over two real loopback libp2p nodes, bounds goroutine growth (<15). With the old code, growth is exactly 50 — one leaked `discover()` per send.
- `BenchmarkP2PFunction` (from #470's suite): **626 → 494 allocs/op, 37KB → 26.8KB/op**.
- `-race` on the package, dreaming p2p suites, and the full unit sweep (259 pkgs) all green. Verified locally (org Actions still down).