### PR TITLE
fix(p2p): retry starved peer lookups; mesh dream universes without crossed dials

### DIFF
--- a/dream/universeMethods.go
+++ b/dream/universeMethods.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	peercore "github.com/libp2p/go-libp2p/core/peer"
 	commonIface "github.com/taubyte/tau/core/common"
@@ -51,27 +52,45 @@ func (u *Universe) Mesh(newNodes ...peer.Node) {
 
 	u.lock.RLock()
 	var wg sync.WaitGroup
-	for _, n0 := range append(u.all, newNodes...) {
-		for _, n1 := range u.all {
-			if n0 != n1 {
-				wg.Add(1)
-				go func(n0, n1 peer.Node) {
-					defer wg.Done()
-					err := n0.Peer().Connect(
-						ctx,
-						peercore.AddrInfo{
-							ID:    n1.ID(),
-							Addrs: n1.Peer().Addrs(),
-						},
-					)
-					if err != nil {
-						n0.Peering().AddPeer(peercore.AddrInfo{
-							ID:    n1.ID(),
-							Addrs: n1.Peer().Addrs(),
-						})
-					}
-				}(n0, n1)
+	nodes := append(u.all, newNodes...)
+	for i, a := range nodes {
+		for _, b := range nodes[i+1:] {
+			// dial each unordered pair exactly once, from a canonical
+			// side: concurrent crossed dials make both TLS handshakes
+			// act as the client ("received unexpected handshake message
+			// of type *tls.clientHelloMsg") and park BOTH sides in the
+			// swarm's dial backoff, wedging the pair for tens of seconds.
+			n0, n1 := a, b
+			if n0.ID() > n1.ID() {
+				n0, n1 = n1, n0
 			}
+			wg.Add(1)
+			go func(n0, n1 peer.Node) {
+				defer wg.Done()
+				// retry with freshly resolved addresses (nodes meshed
+				// while booting may not expose listen addresses yet)
+				// instead of surrendering to the peering service,
+				// whose reconnect backoff (5s, doubling) can leave
+				// the universe half-meshed for over a minute.
+				for range 3 {
+					info := peercore.AddrInfo{
+						ID:    n1.ID(),
+						Addrs: n1.Peer().Addrs(),
+					}
+					if len(info.Addrs) > 0 {
+						if err := n0.Peer().Connect(ctx, info); err == nil {
+							return
+						}
+					}
+					select {
+					case <-ctx.Done():
+						n0.Peering().AddPeer(peercore.AddrInfo{ID: n1.ID(), Addrs: n1.Peer().Addrs()})
+						return
+					case <-time.After(time.Second):
+					}
+				}
+				n0.Peering().AddPeer(peercore.AddrInfo{ID: n1.ID(), Addrs: n1.Peer().Addrs()})
+			}(n0, n1)
 		}
 	}
 	wg.Wait()

--- a/dream/vars.go
+++ b/dream/vars.go
@@ -36,7 +36,7 @@ var (
 	// Valid sub-binds for services
 	ValidSubBinds = []string{"http", "p2p", "dns", "https", "verbose", "copies"}
 
-	MeshTimeout = 5 * time.Second
+	MeshTimeout = 30 * time.Second
 
 	// Disk usage cache configuration
 	DiskUsageCacheTimeout = 5 * time.Second

--- a/p2p/streams/client/client.go
+++ b/p2p/streams/client/client.go
@@ -133,7 +133,11 @@ var (
 	DefaultMaxParallel int = 64
 	MaxStreamsPerSend  int = 16
 
-	RefreshPeersInterval time.Duration = 30 * time.Second
+	// PeerRetryInterval bounds how long a pending send can be stuck behind a
+	// discovery gap (e.g. identify hasn't updated the peerstore yet, or a
+	// backoff-cached lookup came back empty): recovery latency must beat
+	// SendToPeerTimeout.
+	PeerRetryInterval time.Duration = time.Second
 
 	SendToPeerTimeout time.Duration = 10 * time.Second
 	ConnectTimeout    time.Duration = 500 * time.Millisecond
@@ -266,6 +270,9 @@ func (c *Client) discover() {
 	discoverDone := false
 	dpeersWait := make(chan peerCore.AddrInfo)
 
+	retry := time.NewTicker(PeerRetryInterval)
+	defer retry.Stop()
+
 	for {
 		select {
 		case <-c.ctx.Done():
@@ -305,6 +312,40 @@ func (c *Client) discover() {
 					dpeers = c.discPeers()
 					discoverDone = false
 				}
+			}
+
+		case <-retry.C:
+			// event-driven discovery only refreshes when a peerRequest
+			// arrives; without this, a request parked here because identify
+			// hadn't updated the peerstore yet (or FindPeers was served from
+			// a poisoned backoff cache) would never be looked at again.
+			if len(c.peerFeeds) == 0 {
+				continue
+			}
+
+			kept := make([]*peerRequest, 0, len(c.peerFeeds))
+			for _, pr := range c.peerFeeds {
+				select {
+				case <-pr.ctx.Done():
+					close(pr.ch)
+				default:
+					kept = append(kept, pr)
+				}
+			}
+			c.peerFeeds = kept
+
+			c.refreshFromPeerStore()
+
+			needMore := false
+			for _, pr := range c.peerFeeds {
+				if pr.need > len(c.activePeers) {
+					needMore = true
+					break
+				}
+			}
+			if needMore && discoverDone {
+				dpeers = c.discPeers()
+				discoverDone = false
 			}
 		}
 	}

--- a/p2p/streams/client/client_test.go
+++ b/p2p/streams/client/client_test.go
@@ -2986,3 +2986,86 @@ func TestGoroutineCountPerSend(t *testing.T) {
 		})
 	}
 }
+
+// TestSendRecoversFromEarlyDiscovery covers the peer-discovery starvation bug:
+// a Send started before the target peer registers its stream handler used to
+// starve forever even after identify caught up, because discover() only
+// refreshed candidate peers when a new peerRequest arrived. With the
+// PeerRetryInterval ticker in place, the parked request gets picked up on the
+// next tick once refreshFromPeerStore() finds B in the peerstore.
+func TestSendRecoversFromEarlyDiscovery(t *testing.T) {
+	logging.SetLogLevel("*", "error")
+
+	ctx := t.Context()
+
+	a, err := peer.New(
+		ctx,
+		nil,
+		keypair.NewRaw(),
+		nil,
+		[]string{"/ip4/127.0.0.1/tcp/0"},
+		nil,
+		true,
+		false,
+	)
+	require.NoError(t, err, "node A creation failed")
+	defer a.Close()
+
+	b, err := peer.New(
+		ctx,
+		nil,
+		keypair.NewRaw(),
+		nil,
+		[]string{"/ip4/127.0.0.1/tcp/0"},
+		nil,
+		true,
+		false,
+	)
+	require.NoError(t, err, "node B creation failed")
+	defer b.Close()
+
+	// Connect before B's handler exists, so identify has nothing to report
+	// for this protocol yet when A's client is created below.
+	err = a.Peer().Connect(ctx, peercore.AddrInfo{ID: b.ID(), Addrs: b.Peer().Addrs()})
+	require.NoError(t, err, "connect A->B failed")
+
+	svr, err := peerService.New(b, "late", "/late/1.0")
+	require.NoError(t, err, "service creation failed")
+	defer svr.Stop()
+
+	err = svr.Define("ping", func(_ context.Context, _ streams.Connection, _ command.Body) (cr.Response, error) {
+		return cr.Response{"pong": true}, nil
+	})
+	require.NoError(t, err)
+
+	client, err := New(a, "/late/1.0")
+	require.NoError(t, err, "client creation failed")
+	defer client.Close()
+
+	type sendResult struct {
+		resp cr.Response
+		err  error
+	}
+	done := make(chan sendResult, 1)
+	start := time.Now()
+	go func() {
+		resp, err := client.Send("ping", command.Body{})
+		done <- sendResult{resp, err}
+	}()
+
+	// Let the send goroutine park on the client's peer discovery before B
+	// starts handling the protocol (and identify pushes the update to A).
+	time.Sleep(1500 * time.Millisecond)
+	svr.Start()
+
+	select {
+	case res := <-done:
+		elapsed := time.Since(start)
+		require.NoError(t, res.err, "send should recover once identify catches up")
+		pong, _ := res.resp.Get("pong")
+		assert.Equal(t, true, pong)
+		assert.Less(t, elapsed, 8*time.Second, "send should recover well before SendToPeerTimeout")
+	case <-time.After(9 * time.Second):
+		t.Fatal("send never recovered after the handler appeared; discover() isn't retrying peer lookup")
+	}
+}

--- a/services/seer/tests/hearbeat_test.go
+++ b/services/seer/tests/hearbeat_test.go
@@ -3,6 +3,7 @@
 package tests
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -10,10 +11,10 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/network"
+	peercore "github.com/libp2p/go-libp2p/core/peer"
 	commonIface "github.com/taubyte/tau/core/common"
 	iface "github.com/taubyte/tau/core/services/seer"
 	"github.com/taubyte/tau/dream"
-	streamsClient "github.com/taubyte/tau/p2p/streams/client"
 	"gotest.tools/v3/assert"
 
 	_ "github.com/taubyte/tau/clients/p2p/seer/dream"
@@ -24,14 +25,6 @@ import (
 var client_count = 16
 
 func TestHeartbeat_Dreaming(t *testing.T) {
-	// 16 clients heartbeat concurrently while sibling packages load the
-	// machine during the -p 4 dreaming sweep; the default 10s p2p send
-	// timeout can starve and fail the send with an i/o timeout before the
-	// swarm recovers from discovery backoff.
-	oldTimeout := streamsClient.SendToPeerTimeout
-	streamsClient.SendToPeerTimeout = 90 * time.Second
-	defer func() { streamsClient.SendToPeerTimeout = oldTimeout }()
-
 	m, err := dream.New(t.Context())
 	assert.NilError(t, err)
 	defer m.Close()
@@ -70,21 +63,35 @@ func TestHeartbeat_Dreaming(t *testing.T) {
 		}
 	}
 
-	// give time for all clients to discover the seer node before driving
-	// the concurrent load below.
+	// every client must hold a real (non-limited) connection to the seer
+	// before the concurrent load below: a heartbeat has only the 10s send
+	// timeout for discovery plus the command roundtrip. The boot mesh is
+	// best-effort — under load a pair's initial dial can fail and end up
+	// with a relay-limited connection that streams can't open over, and
+	// nothing upgrades it — so actively dial stragglers with the seer's
+	// direct addresses instead of waiting.
 	seerNode := u.Seer().Node()
-	for deadline := time.Now().Add(20 * time.Second); ; {
-		allConnected := true
-		for _, s := range simples {
-			if s.PeerNode().Peer().Network().Connectedness(seerNode.ID()) != network.Connected {
-				allConnected = false
-				break
+	seerInfo := peercore.AddrInfo{ID: seerNode.ID(), Addrs: seerNode.Peer().Addrs()}
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		var unconnected []string
+		for i, s := range simples {
+			if state := s.PeerNode().Peer().Network().Connectedness(seerNode.ID()); state != network.Connected {
+				unconnected = append(unconnected, fmt.Sprintf("client%d=%s", i, state))
+				dialCtx, dialC := context.WithTimeout(u.Context(), 5*time.Second)
+				if err := s.PeerNode().Peer().Connect(dialCtx, seerInfo); err != nil {
+					t.Logf("client%d dial to seer: %v", i, err)
+				}
+				dialC()
 			}
 		}
-		if allConnected || time.Now().After(deadline) {
+		if len(unconnected) == 0 {
 			break
 		}
-		time.Sleep(100 * time.Millisecond)
+		if time.Now().After(deadline) {
+			t.Fatalf("clients not connected to the seer within 60s: %v", unconnected)
+		}
+		time.Sleep(500 * time.Millisecond)
 	}
 
 	hostname, err := os.Hostname()


### PR DESCRIPTION
Root-causes the chronic dreaming-test flakiness (seer heartbeat failing roughly half of loaded sweeps, patrick client timeouts). Diagnosed via mid-wedge goroutine dumps and probe dials; two bugs compounded:

## 1. Peer-lookup starvation in the streams client (production)

`discover()` was purely event-driven: candidate peers were only refreshed when a new request arrived. A send that arrived before identify completed — or while the discovery backoff cache held a poisoned empty result (`DiscoveryBackoffMin` is 60s) — parked in `peerFeeds` forever, even though the target peer sat connected in the peerstore seconds later. Goroutine dumps showed all sends waiting on peers, all `discover()` loops idle, zero server-side command frames.

The never-wired `RefreshPeersInterval` constant is replaced by a `PeerRetryInterval` (1s) ticker that, only while requests are starving, prunes dead feeds, re-scans the peerstore, and re-arms discovery (BackoffDiscovery rate-limits internally). One extra select wakeup per second per client when idle; no new goroutines.

`TestSendRecoversFromEarlyDiscovery` parks a send behind a late-registered stream handler: without the ticker it starves to the send deadline (verified), with it recovery is sub-second.

## 2. Crossed dials in dream's mesh (test harness)

`Mesh` dialed every pair in both directions concurrently. When dials crossed, both TLS handshakes acted as the client (`received unexpected handshake message of type *tls.clientHelloMsg`) and **both** sides landed in the swarm's dial backoff — wedging the pair for tens of seconds and surrendering it to the peering service's 5s-doubling reconnect backoff. Mesh now dials each unordered pair exactly once from a canonical side, retries with freshly resolved addresses (nodes meshed mid-boot may not expose listen addresses yet), and gets a 30s budget instead of 5s.

## 3. Heartbeat test hardening

Drops the 90s send-timeout workaround (the 10s default is restored as the canary for this exact regression) and actively connects stragglers with the seer's direct addresses instead of proceeding on a half-meshed universe — under load a pair can end up with a relay-limited connection that streams can't open over, and nothing upgrades it.

## Verification

- Heartbeat under sustained heavy load: **8/8** (previously ~50%); patrick client fresh-process 6/6 (+3/3, +4/4 under load); seer client 3/3 under load.
- Full dreaming sweep on the committed tree: **38/38 packages, zero failures**; full unit sweep 259 packages green; `p2p/streams` under `-race` incl. the new regression test.
- Bisected against main at every step (main controls 6/6) to keep attribution honest.

Verified locally (org Actions still down).