### PR TITLE
test(taucorder): poll discovery in auth discover tests

### DIFF
--- a/pkg/taucorder/service/auth_test.go
+++ b/pkg/taucorder/service/auth_test.go
@@ -82,27 +82,60 @@ func TestAuth_Dreaming(t *testing.T) {
 
 	t.Run("Discover service", func(t *testing.T) {
 		c := pbconnect.NewAuthServiceClient(http.DefaultClient, "http://"+listener.Addr().String())
-		pstream, err := c.Discover(ctx, connect.NewRequest(&pb.DiscoverServiceRequest{
-			Node: ni.Msg,
-		}))
-		assert.NilError(t, err)
-		count := 0
-		for pstream.Receive() {
-			count++
+
+		// The two auth copies advertise "/auth/v1" through the DHT
+		// (discoveryUtil.Advertise) asynchronously, and Discover is a
+		// best-effort, point-in-time snapshot of currently discoverable
+		// providers (libp2p FindPeers) — Count is a max, not a target.
+		// Propagation is eventually consistent, so a single shot races under
+		// load (count observed below 2). Poll until both providers converge.
+		// The deadline must clear the node's BackoffDiscovery window: once a
+		// namespace lookup returns nothing, re-queries are suppressed for
+		// minBackoff, so a shorter deadline could not recover a missed first
+		// lookup. Mirrors swarm_test.go's Discover.
+		var count int
+		deadline := time.Now().Add(90 * time.Second)
+		for {
+			count = 0
+			pstream, err := c.Discover(ctx, connect.NewRequest(&pb.DiscoverServiceRequest{
+				Node: ni.Msg,
+			}))
+			if err == nil {
+				for pstream.Receive() {
+					count++
+				}
+				pstream.Close()
+			}
+			if count == 2 || time.Now().After(deadline) {
+				break
+			}
+			time.Sleep(250 * time.Millisecond)
 		}
 		assert.Equal(t, count, 2)
 	})
 
 	t.Run("Discover service (count set)", func(t *testing.T) {
 		c := pbconnect.NewAuthServiceClient(http.DefaultClient, "http://"+listener.Addr().String())
-		pstream, err := c.Discover(ctx, connect.NewRequest(&pb.DiscoverServiceRequest{
-			Node:  ni.Msg,
-			Count: 1,
-		}))
-		assert.NilError(t, err)
-		count := 0
-		for pstream.Receive() {
-			count++
+
+		// Same eventual-consistency poll as above, capped at Count=1.
+		var count int
+		deadline := time.Now().Add(90 * time.Second)
+		for {
+			count = 0
+			pstream, err := c.Discover(ctx, connect.NewRequest(&pb.DiscoverServiceRequest{
+				Node:  ni.Msg,
+				Count: 1,
+			}))
+			if err == nil {
+				for pstream.Receive() {
+					count++
+				}
+				pstream.Close()
+			}
+			if count == 1 || time.Now().After(deadline) {
+				break
+			}
+			time.Sleep(250 * time.Millisecond)
 		}
 		assert.Equal(t, count, 1)
 	})


### PR DESCRIPTION
`TestAuth_Dreaming`'s "Discover service" and "Discover service (count set)" subtests asserted an exact provider count from a **single** `FindPeers` call. But taucorder service discovery is eventually consistent: the two auth copies advertise `/auth/v1` through the DHT (`discoveryUtil.Advertise`) asynchronously, and `Discover` is a best-effort point-in-time snapshot — `Count` is a max, not a target. Under load a single shot races the advertisement propagation and observes fewer than expected, which is exactly the failure seen in a full `-p 4` dreaming sweep (`Discover_service` count came back below 2).

The sibling `swarm_test.go`'s "Discover service" was already hardened for this exact eventual-consistency behavior with a poll-until-converged loop (90s deadline that clears the BackoffDiscovery window, 250ms interval). This applies the same, established pattern to the two auth subtests. The happy path still converges on the first iteration, so it stays fast; only the racing case retries.

No production code changes — the RPC's best-effort semantics are correct; the tests' single-shot exact-count assumption was the brittleness.

Verified: two real (uncached, `-count=1`) full dreaming sweeps green (38/38, taucorder included), plus TestAuth_Dreaming 8/8 in isolation. Verified locally (org Actions still down).