### PR TITLE
perf(monkey): vendor compile-fixture build scaffold, drop tb_templates pull

### DIFF
--- a/services/monkey/fixtures/compile/assets/templates/code/functions/Assembly_Script/common/.taubyte/build.sh
+++ b/services/monkey/fixtures/compile/assets/templates/code/functions/Assembly_Script/common/.taubyte/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+. /utils/wasm.sh
+
+build "${FILENAME}"
+ret=$?
+echo -n $ret > /out/ret-code
+exit $ret

--- a/services/monkey/fixtures/compile/assets/templates/code/functions/Assembly_Script/common/.taubyte/config.yaml
+++ b/services/monkey/fixtures/compile/assets/templates/code/functions/Assembly_Script/common/.taubyte/config.yaml
@@ -1,0 +1,6 @@
+version: 1.00
+environment:
+  image: taubyte/assembly-script-wasi:latest
+  variables:
+workflow:
+  - build

--- a/services/monkey/fixtures/compile/assets/templates/code/functions/Go/common/.taubyte/build.sh
+++ b/services/monkey/fixtures/compile/assets/templates/code/functions/Go/common/.taubyte/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+. /utils/wasm.sh
+
+build "${FILENAME}"
+ret=$?
+echo -n $ret > /out/ret-code
+exit $ret

--- a/services/monkey/fixtures/compile/assets/templates/code/functions/Go/common/.taubyte/config.yaml
+++ b/services/monkey/fixtures/compile/assets/templates/code/functions/Go/common/.taubyte/config.yaml
@@ -1,0 +1,6 @@
+version: 1.00
+environment:
+  image: taubyte/go-wasi:latest
+  variables:
+workflow:
+  - build

--- a/services/monkey/fixtures/compile/assets/templates/code/functions/Go/common/go.mod.tmpl
+++ b/services/monkey/fixtures/compile/assets/templates/code/functions/Go/common/go.mod.tmpl
@@ -1,0 +1,3 @@
+module function 
+
+go 1.19

--- a/services/monkey/fixtures/compile/assets/templates/code/functions/Rust/common/.taubyte/build.sh
+++ b/services/monkey/fixtures/compile/assets/templates/code/functions/Rust/common/.taubyte/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+. /utils/wasm.sh
+
+build "${FILENAME}"
+ret=$?
+echo -n $ret > /out/ret-code
+exit $ret

--- a/services/monkey/fixtures/compile/assets/templates/code/functions/Rust/common/.taubyte/config.yaml
+++ b/services/monkey/fixtures/compile/assets/templates/code/functions/Rust/common/.taubyte/config.yaml
@@ -1,0 +1,6 @@
+version: 1.00
+environment:
+  image: taubyte/rust-wasi:latest
+  variables:
+workflow:
+  - build

--- a/services/monkey/fixtures/compile/fixture_compile_for.go
+++ b/services/monkey/fixtures/compile/fixture_compile_for.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/taubyte/tau/dream"
-	tauTemplates "github.com/taubyte/tau/pkg/cli/singletons/templates"
 	spec "github.com/taubyte/tau/pkg/specs/common"
 	structureSpec "github.com/taubyte/tau/pkg/specs/structure"
 )
@@ -142,7 +141,6 @@ func CompileFor(u *dream.Universe, params ...interface{}) error {
 		paths:         b.Paths,
 		call:          b.Call,
 		forceBuild:    b.ForceBuild,
-		templateRepo:  tauTemplates.Repository(),
 		hoarderClient: hoarder,
 	}
 

--- a/services/monkey/fixtures/compile/function.go
+++ b/services/monkey/fixtures/compile/function.go
@@ -108,7 +108,7 @@ func (f functionContext) codeFile(language wasmSpec.SupportedLanguage) error {
 			}
 		}
 
-		if err = language.CopyFunctionTemplateConfig(f.ctx.templateRepo, "", copyPath); err != nil {
+		if err = copyTemplateConfig(language, copyPath); err != nil {
 			return nil, fmt.Errorf("copying `%s` config template failed with: %s", language, err)
 		}
 

--- a/services/monkey/fixtures/compile/library.go
+++ b/services/monkey/fixtures/compile/library.go
@@ -93,7 +93,9 @@ func (l libraryContext) directory() error {
 			return nil, errors.New("library includes unsupported code files")
 		}
 
-		language.CopyFunctionTemplateConfig(l.ctx.templateRepo, "", root)
+		if err := copyTemplateConfig(*language, root); err != nil {
+			return nil, err
+		}
 
 		pterm.Info.Println("building library in root:", root)
 		c.ForceGitDir(root)

--- a/services/monkey/fixtures/compile/smartops.go
+++ b/services/monkey/fixtures/compile/smartops.go
@@ -105,7 +105,7 @@ func (f smartopsContext) codeFile(language wasmSpec.SupportedLanguage) error {
 			}
 		}
 
-		if err = language.CopyFunctionTemplateConfig(f.ctx.templateRepo, "", copyPath); err != nil {
+		if err = copyTemplateConfig(language, copyPath); err != nil {
 			return nil, fmt.Errorf("copying `%s` config template failed with: %s", language, err)
 		}
 

--- a/services/monkey/fixtures/compile/templates.go
+++ b/services/monkey/fixtures/compile/templates.go
@@ -1,0 +1,34 @@
+package compile
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/otiai10/copy"
+	wasmSpec "github.com/taubyte/tau/pkg/specs/builders/wasm"
+)
+
+// copyTemplateConfig copies the vendored <lang> "common" build scaffold
+// (.taubyte/{build.sh,config.yaml} + go.mod) into destination — the
+// fixture-local, network-free replacement for wasmSpec.CopyFunctionTemplateConfig,
+// which copied it out of a freshly-pulled tb_templates clone. The scaffold lives
+// next to this source (assets/templates/), located via runtime.Caller so it
+// resolves regardless of the calling test's working directory.
+//
+// The Go module file is vendored as go.mod.tmpl so it isn't seen as a nested
+// module in the tau tree; it's renamed back to go.mod in the build dir.
+func copyTemplateConfig(lang wasmSpec.SupportedLanguage, destination string) error {
+	_, self, _, _ := runtime.Caller(0)
+	src := filepath.Join(filepath.Dir(self), "assets", "templates", "code", "functions", string(lang), "common")
+
+	if err := copy.Copy(src, destination); err != nil {
+		return err
+	}
+
+	tmpl := filepath.Join(destination, "go.mod.tmpl")
+	if _, err := os.Stat(tmpl); err == nil {
+		return os.Rename(tmpl, filepath.Join(destination, "go.mod"))
+	}
+	return nil
+}

--- a/services/monkey/fixtures/compile/types.go
+++ b/services/monkey/fixtures/compile/types.go
@@ -6,7 +6,6 @@ import (
 	"github.com/taubyte/tau/core/services/hoarder"
 	"github.com/taubyte/tau/core/services/monkey"
 	"github.com/taubyte/tau/dream"
-	"github.com/taubyte/tau/pkg/git"
 )
 
 type resourceContext struct {
@@ -19,7 +18,6 @@ type resourceContext struct {
 	paths         []string
 	call          string
 	forceBuild    bool
-	templateRepo  *git.Repository
 	hoarderClient hoarder.Client
 }
 


### PR DESCRIPTION
## What

The compile fixture (`compileFor`) no longer pulls `taubyte-test/tb_templates`
from github. The tiny per-language build scaffold it needs
(`.taubyte/{build.sh,config.yaml}` + `go.mod`) is vendored into the fixture and
copied locally. The fixture is now fully offline.

Follows #474 (build-asset caching).

## Why

`CompileFor` called `tauTemplates.Repository()` **unconditionally** — before
deciding build vs cache-hit vs direct-`.zwasm`. That pull ran on *every*
`compileFor`, including tests that never build (cache hits, prebuilt `.zwasm`).
So a github blip failed unrelated tests: e.g. gateway's `TestBasicPing`, which
serves a **prebuilt** `ping.zwasm`, still died pulling `tb_templates`.

The scaffold is test-only — production functions carry their own `.taubyte/`
from `tau new`; the fixture pulled it only to wrap a bare source file
(`echo.go`) into something buildable.

## How

- Vendored `code/functions/{Go,Assembly_Script,Rust}/common` into
  `assets/templates/` (7 small files).
- `copyTemplateConfig` copies the `<lang>/common` scaffold into the build dir
  (via `runtime.Caller`, so it resolves from any test's cwd), replacing
  `wasmSpec.CopyFunctionTemplateConfig`'s copy-out-of-a-clone.
- Dropped `tauTemplates.Repository()` and the `templateRepo` field entirely.
- `go.mod` is vendored as `go.mod.tmpl` (a literal `go.mod` would read as a
  nested module — and `go:embed` even silently excludes such dirs); renamed back
  to `go.mod` in the build dir.

Drift from `tb_templates` is accepted — real builds still run against the live
container image (`taubyte/go-wasi:latest` etc.).

## Verified

- Forced a Go cache-miss → builds correctly from the vendored scaffold (14s), no
  template pull.
- Affected dreaming packages green (gateway, monkey/fixtures/compile,
  monkey/tests, pubsub, counter, substrate/tests). gateway no longer touches
  github. `go.mod.tmpl` does not create a nested module (`go list ./...` clean).
