### PR TITLE
chore(httpsvc): drop dead ACME trust for bare <svc>.<fqdn>

### DIFF
--- a/services/common/httpsvc/httpsvc.go
+++ b/services/common/httpsvc/httpsvc.go
@@ -12,7 +12,6 @@ import (
 	basicHttp "github.com/taubyte/tau/pkg/http/basic"
 	basicHttpSecure "github.com/taubyte/tau/pkg/http/basic/secure"
 	"github.com/taubyte/tau/pkg/http/options"
-	commonSpecs "github.com/taubyte/tau/pkg/specs/common"
 )
 
 // New wires the standard tau HTTP listener: autocert HTTPS in production,
@@ -60,18 +59,12 @@ func AutoOptsFromConfig(cfg config.Config) []options.Option {
 	return ops
 }
 
-// autoTrustFromConfig folds the three "trust this host without TNS proof"
-// cfg predicates into one closure: an exact-match against `<svc>.<NetworkFqdn>`
-// for each known tau service, plus alias and services-domain regex matches.
+// autoTrustFromConfig trusts (issues a cert for, without TNS proof) exactly the
+// hosts a tau service answers on: alias domains, custom domains bound via
+// domains.hosts, and the <svc>.tau.<NetworkFqdn> services-domain pattern.
 func autoTrustFromConfig(cfg config.Config) func(string) bool {
 	return func(host string) bool {
 		host = strings.TrimSuffix(host, ".")
-		fqdn := cfg.NetworkFqdn()
-		for _, srv := range commonSpecs.Services {
-			if host == srv+"."+fqdn {
-				return true
-			}
-		}
 		if cfg.AliasDomainsMatch(host) {
 			return true
 		}

--- a/services/common/httpsvc/httpsvc_test.go
+++ b/services/common/httpsvc/httpsvc_test.go
@@ -91,6 +91,9 @@ func TestAutoTrustFromConfig(t *testing.T) {
 	assert.Assert(t, trust("svc.example.com"))
 	assert.Assert(t, trust("admin.example.com")) // custom domain bound via domains.hosts
 	assert.Assert(t, !trust("random.example.com"))
+	// A bare <svc>.<fqdn> (no ".tau.") is not a host DNS resolves or a route
+	// serves, so it is not trusted — even for a known service name.
+	assert.Assert(t, !trust("seer.net.example.com"))
 	assert.Assert(t, trust("alias.example.com.")) // trailing dot tolerated
 }
 


### PR DESCRIPTION
`autoTrustFromConfig` trusted `<svc>.<NetworkFqdn>` (no `.tau.`) for every known service, but nothing resolves or serves that form:

- **DNS** requires `<svc>.tau.<fqdn>` (`ServicesDomainRegExp` = `^[^.]+\.tau\.<fqdn>$`)
- **HTTP routes** bind the same set via `config.RouteHosts`

So a client never connects with that SNI, and the autocert `HostPolicy` entry was dead. This removes it (and the now-unused `commonSpecs` import). The live trust — alias domains, `domains.hosts` bindings, and the `<svc>.tau.<fqdn>` services-domain pattern — is unchanged.

A regression assertion (`!trust("seer.net.example.com")`) locks it: that would have passed before (via the removed loop, `seer` being a known service) and now correctly returns false.

Verified: full matrix green (community unit/dreaming/web3/raft, ee unit/dreaming, JS/Py clients).