### PR TITLE
perf(yaseer): immutable Query with a memoized resolution cache, remove Fork()

### DIFF
--- a/pkg/schema/basic/get.go
+++ b/pkg/schema/basic/get.go
@@ -3,7 +3,7 @@ package basic
 func Get[T any](c ConfigIface, path ...string) (value T) {
 	config := c.Config()
 	for _, p := range path {
-		config.Get(p)
+		config = config.Get(p)
 	}
 
 	config.Value(&value)

--- a/pkg/schema/databases/custom.go
+++ b/pkg/schema/databases/custom.go
@@ -22,8 +22,8 @@ func (d getter) Secret() bool {
 func (g getter) Encryption() (key string, keyType string) {
 	enc := g.Config().Get("encryption")
 
-	enc.Fork().Get("key").Value(&key)
-	enc.Fork().Get("type").Value(&keyType)
+	enc.Get("key").Value(&key)
+	enc.Get("type").Value(&keyType)
 
 	return
 }
@@ -57,8 +57,8 @@ func Encryption(key string) basic.Op {
 		_type, key := getEncryptionTypeAndKey(key)
 		encryption := c.Config().Get("encryption")
 		return []*seer.Query{
-			encryption.Fork().Get("type").Set(_type),
-			encryption.Fork().Get("key").Set(key),
+			encryption.Get("type").Set(_type),
+			encryption.Get("key").Set(key),
 		}
 	}
 }

--- a/pkg/schema/libraries/custom.go
+++ b/pkg/schema/libraries/custom.go
@@ -26,8 +26,8 @@ func Github(id string, fullname string) basic.Op {
 	return func(c basic.ConfigIface) []*seer.Query {
 		base := c.Config().Get("source").Get("github")
 		return []*seer.Query{
-			base.Fork().Get("id").Set(id),
-			base.Fork().Get("fullname").Set(fullname),
+			base.Get("id").Set(id),
+			base.Get("fullname").Set(fullname),
 		}
 	}
 }

--- a/pkg/schema/messaging/custom.go
+++ b/pkg/schema/messaging/custom.go
@@ -13,8 +13,8 @@ func Channel(regex bool, match string) basic.Op {
 	return func(c basic.ConfigIface) []*seer.Query {
 		channel := c.Config().Get("channel")
 		return []*seer.Query{
-			channel.Fork().Get("regex").Set(regex),
-			channel.Fork().Get("match").Set(match),
+			channel.Get("regex").Set(regex),
+			channel.Get("match").Set(match),
 		}
 	}
 }
@@ -23,8 +23,8 @@ func Bridges(mqtt bool, websocket bool) basic.Op {
 	return func(c basic.ConfigIface) []*seer.Query {
 		bridges := c.Config().Get("bridges")
 		return []*seer.Query{
-			bridges.Fork().Get("mqtt").Get("enable").Set(mqtt),
-			bridges.Fork().Get("websocket").Get("enable").Set(websocket),
+			bridges.Get("mqtt").Get("enable").Set(mqtt),
+			bridges.Get("websocket").Get("enable").Set(websocket),
 		}
 	}
 }

--- a/pkg/schema/storages/custom.go
+++ b/pkg/schema/storages/custom.go
@@ -32,8 +32,8 @@ func Object(versioning bool, size string) basic.Op {
 	return func(c basic.ConfigIface) []*seer.Query {
 		object := c.Config().Get("object")
 		return []*seer.Query{
-			object.Fork().Get("versioning").Set(versioning),
-			object.Fork().Get("size").Set(size),
+			object.Get("versioning").Set(versioning),
+			object.Get("size").Set(size),
 		}
 	}
 }
@@ -42,8 +42,8 @@ func Streaming(ttl string, size string) basic.Op {
 	return func(c basic.ConfigIface) []*seer.Query {
 		streaming := c.Config().Get("streaming")
 		return []*seer.Query{
-			streaming.Fork().Get("ttl").Set(ttl),
-			streaming.Fork().Get("size").Set(size),
+			streaming.Get("ttl").Set(ttl),
+			streaming.Get("size").Set(size),
 		}
 	}
 }

--- a/pkg/schema/website/custom.go
+++ b/pkg/schema/website/custom.go
@@ -27,8 +27,8 @@ func Github(id string, fullname string) basic.Op {
 		provider := "github"
 		base := c.Config().Get("source").Get(provider)
 		return []*seer.Query{
-			base.Fork().Get("id").Set(id),
-			base.Fork().Get("fullname").Set(fullname),
+			base.Get("id").Set(id),
+			base.Get("fullname").Set(fullname),
 		}
 	}
 }

--- a/pkg/spore-drive/config/accounts.go
+++ b/pkg/spore-drive/config/accounts.go
@@ -31,30 +31,30 @@ type (
 )
 
 func (a *accounts) SessionTTL() (v string) {
-	a.Fork().Get("session-ttl").Value(&v)
+	a.Query.Get("session-ttl").Value(&v)
 	return
 }
 
 func (a *accounts) SetSessionTTL(v string) error {
-	return a.Fork().Get("session-ttl").Set(v).Commit()
+	return a.Query.Get("session-ttl").Set(v).Commit()
 }
 
 func (a *accounts) Email() EmailParser {
-	return &email{root: a.root, Query: a.Fork().Get("email")}
+	return &email{root: a.root, Query: a.Query.Get("email")}
 }
 
 func (e *email) SMTP() SMTPParser {
-	return &smtp{root: e.root, Query: e.Fork().Get("smtp")}
+	return &smtp{root: e.root, Query: e.Query.Get("smtp")}
 }
 
-func (s *smtp) Host() (v string) { s.Fork().Get("host").Value(&v); return }
-func (s *smtp) Port() (v uint64) { s.Fork().Get("port").Value(&v); return }
-func (s *smtp) User() (v string) { s.Fork().Get("user").Value(&v); return }
-func (s *smtp) Pass() (v string) { s.Fork().Get("pass").Value(&v); return }
-func (s *smtp) From() (v string) { s.Fork().Get("from").Value(&v); return }
+func (s *smtp) Host() (v string) { s.Query.Get("host").Value(&v); return }
+func (s *smtp) Port() (v uint64) { s.Query.Get("port").Value(&v); return }
+func (s *smtp) User() (v string) { s.Query.Get("user").Value(&v); return }
+func (s *smtp) Pass() (v string) { s.Query.Get("pass").Value(&v); return }
+func (s *smtp) From() (v string) { s.Query.Get("from").Value(&v); return }
 
-func (s *smtp) SetHost(v string) error { return s.Fork().Get("host").Set(v).Commit() }
-func (s *smtp) SetPort(v uint64) error { return s.Fork().Get("port").Set(v).Commit() }
-func (s *smtp) SetUser(v string) error { return s.Fork().Get("user").Set(v).Commit() }
-func (s *smtp) SetPass(v string) error { return s.Fork().Get("pass").Set(v).Commit() }
-func (s *smtp) SetFrom(v string) error { return s.Fork().Get("from").Set(v).Commit() }
+func (s *smtp) SetHost(v string) error { return s.Query.Get("host").Set(v).Commit() }
+func (s *smtp) SetPort(v uint64) error { return s.Query.Get("port").Set(v).Commit() }
+func (s *smtp) SetUser(v string) error { return s.Query.Get("user").Set(v).Commit() }
+func (s *smtp) SetPass(v string) error { return s.Query.Get("pass").Set(v).Commit() }
+func (s *smtp) SetFrom(v string) error { return s.Query.Get("from").Set(v).Commit() }

--- a/pkg/spore-drive/config/auth.go
+++ b/pkg/spore-drive/config/auth.go
@@ -32,34 +32,34 @@ type (
 )
 
 func (a *auth) List() (l []string) {
-	l, _ = a.Fork().List()
+	l, _ = a.Query.List()
 	return
 }
 
 func (a *auth) Get(name string) SignerParser {
-	return &signer{root: a.root, Query: a.Fork().Get(name)}
+	return &signer{root: a.root, Query: a.Query.Get(name)}
 }
 
 func (a *auth) Add(name string) SignerParser {
-	return &signer{root: a.root, Query: a.Fork().Get(name)}
+	return &signer{root: a.root, Query: a.Query.Get(name)}
 }
 
 func (a *auth) Delete(name string) error {
-	return a.Fork().Get(name).Delete().Commit()
+	return a.Query.Get(name).Delete().Commit()
 }
 
 func (s *signer) Username() (u string) {
-	s.Fork().Get("username").Value(&u)
+	s.Query.Get("username").Value(&u)
 	return
 }
 
 func (s *signer) Password() (p string) {
-	s.Fork().Get("password").Value(&p)
+	s.Query.Get("password").Value(&p)
 	return
 }
 
 func (s *signer) Key() (k string) {
-	s.Fork().Get("key").Value(&k)
+	s.Query.Get("key").Value(&k)
 	return
 }
 
@@ -89,15 +89,15 @@ func (s *signer) Create() (io.WriteCloser, error) {
 }
 
 func (s *signer) SetUsername(name string) error {
-	return s.Fork().Get("username").Set(name).Commit()
+	return s.Query.Get("username").Set(name).Commit()
 }
 
 func (s *signer) SetPassword(password string) error {
-	s.Fork().Get("key").Delete().Commit()
-	return s.Fork().Get("password").Set(password).Commit()
+	s.Query.Get("key").Delete().Commit()
+	return s.Query.Get("password").Set(password).Commit()
 }
 
 func (s *signer) SetKey(path string) error {
-	s.Fork().Get("password").Delete().Commit()
-	return s.Fork().Get("key").Set(path).Commit()
+	s.Query.Get("password").Delete().Commit()
+	return s.Query.Get("key").Set(path).Commit()
 }

--- a/pkg/spore-drive/config/cloud.go
+++ b/pkg/spore-drive/config/cloud.go
@@ -77,22 +77,22 @@ type (
 )
 
 func (c *cloud) Domain() DomainParser {
-	return &domain{root: c.root, Query: c.Fork().Get("domain")}
+	return &domain{root: c.root, Query: c.Query.Get("domain")}
 
 }
 
 func (d *domain) Root() (r string) {
-	d.Fork().Get("root").Value(&r)
+	d.Query.Get("root").Value(&r)
 	return
 }
 
 func (d *domain) Generated() (g string) {
-	d.Fork().Get("generated").Value(&g)
+	d.Query.Get("generated").Value(&g)
 	return
 }
 
 func (d *domain) Validation() ValidationParser {
-	return &validation{root: d.root, Query: d.Fork().Get("validation").Get("key")}
+	return &validation{root: d.root, Query: d.Query.Get("validation").Get("key")}
 }
 
 func (v *validation) Generate() error {
@@ -125,17 +125,17 @@ func (v *validation) Generate() error {
 }
 
 func (v *validation) Keys() (privkey string, pubkey string) {
-	v.Fork().Get("private").Value(&privkey)
-	v.Fork().Get("public").Value(&pubkey)
+	v.Query.Get("private").Value(&privkey)
+	v.Query.Get("public").Value(&pubkey)
 	return
 }
 
 func (v *validation) SetPrivateKey(path string) error {
-	return v.Fork().Get("private").Set(path).Commit()
+	return v.Query.Get("private").Set(path).Commit()
 }
 
 func (v *validation) SetPublicKey(path string) error {
-	return v.Fork().Get("public").Set(path).Commit()
+	return v.Query.Get("public").Set(path).Commit()
 }
 
 func (v *validation) OpenPrivateKey() (io.ReadCloser, error) {
@@ -190,57 +190,57 @@ func (v *validation) CreatePublicKey() (io.WriteCloser, error) {
 // which yaseer would treat as path separators if used as keys).
 func (d *domain) Hosts() map[string]string {
 	m := make(map[string]string)
-	d.Fork().Get("hosts").Value(&m)
+	d.Query.Get("hosts").Value(&m)
 	return m
 }
 
 func (d *domain) SetHost(host, service string) error {
 	m := d.Hosts()
 	m[host] = service
-	return d.Fork().Get("hosts").Set(m).Commit()
+	return d.Query.Get("hosts").Set(m).Commit()
 }
 
 func (d *domain) DeleteHost(host string) error {
 	m := d.Hosts()
 	delete(m, host)
-	return d.Fork().Get("hosts").Set(m).Commit()
+	return d.Query.Get("hosts").Set(m).Commit()
 }
 
 func (d *domain) SetRoot(r string) error {
-	return d.Fork().Get("root").Set(r).Commit()
+	return d.Query.Get("root").Set(r).Commit()
 }
 
 func (d *domain) SetGenerated(g string) error {
-	return d.Fork().Get("generated").Set(g).Commit()
+	return d.Query.Get("generated").Set(g).Commit()
 }
 
 func (c *cloud) P2P() P2PParser {
-	return &p2p{root: c.root, Query: c.Fork().Get("p2p")}
+	return &p2p{root: c.root, Query: c.Query.Get("p2p")}
 }
 
 func (p *p2p) Bootstrap() BootstrapParser {
-	return &bootstrap{root: p.root, Query: p.Fork().Get("bootstrap")}
+	return &bootstrap{root: p.root, Query: p.Query.Get("bootstrap")}
 }
 
 func (b *bootstrap) Shape(shape string) ListParser[string] {
-	return &list[string]{root: b.root, Query: b.Fork().Get(shape)}
+	return &list[string]{root: b.root, Query: b.Query.Get(shape)}
 }
 
 func (b *bootstrap) Delete(shape string) error {
-	return b.Fork().Get(shape).Delete().Commit()
+	return b.Query.Get(shape).Delete().Commit()
 }
 
 func (b *bootstrap) List() (l []string) {
-	l, _ = b.Fork().List()
+	l, _ = b.Query.List()
 	return
 }
 
 func (p *p2p) Swarm() SwarmKeyParser {
-	return &swarm{root: p.root, Query: p.Fork().Get("swarm").Get("key")}
+	return &swarm{root: p.root, Query: p.Query.Get("swarm").Get("key")}
 }
 
 func (s *swarm) Get() (k string) {
-	s.Fork().Value(&k)
+	s.Query.Value(&k)
 	return
 }
 
@@ -269,7 +269,7 @@ func (s *swarm) Create() (io.WriteCloser, error) {
 }
 
 func (s *swarm) Set(path string) error {
-	return s.Fork().Set(path).Commit()
+	return s.Query.Set(path).Commit()
 }
 
 func (s *swarm) Generate() error {

--- a/pkg/spore-drive/config/hosts.go
+++ b/pkg/spore-drive/config/hosts.go
@@ -59,62 +59,62 @@ type location struct {
 }
 
 func (h *hosts) List() []string {
-	l, _ := h.Fork().List()
+	l, _ := h.Query.List()
 	return l
 }
 
 func (h *hosts) Host(name string) HostParser {
-	return &host{root: h.root, Query: h.Fork().Get(name)}
+	return &host{root: h.root, Query: h.Query.Get(name)}
 }
 
 func (h *hosts) Delete(name string) error {
-	return h.Fork().Get(name).Delete().Commit()
+	return h.Query.Get(name).Delete().Commit()
 }
 
 func (h *host) Addresses() ListParser[string] {
-	return &list[string]{root: h.root, Query: h.Fork().Get("addr")}
+	return &list[string]{root: h.root, Query: h.Query.Get("addr")}
 }
 
 func (h *host) SSH() SSHParser {
-	return &ssh{root: h.root, Query: h.Fork().Get("ssh")}
+	return &ssh{root: h.root, Query: h.Query.Get("ssh")}
 }
 
 func (h *host) Location() (float32, float32) {
 	var l location
-	h.Fork().Get("location").Value(&l)
+	h.Query.Get("location").Value(&l)
 	return l.Latitude, l.Longitude
 }
 
 func (h *host) SetLocation(lat float32, long float32) error {
-	return h.Fork().Get("location").Set(location{
+	return h.Query.Get("location").Set(location{
 		Latitude:  lat,
 		Longitude: long,
 	}).Commit()
 }
 
 func (h *host) Shapes() HostShapesParser {
-	return &hostShapes{root: h.root, Query: h.Fork().Get("shapes")}
+	return &hostShapes{root: h.root, Query: h.Query.Get("shapes")}
 }
 
 func (s *ssh) Address() (a string) {
-	s.Fork().Get("addr").Value(&a)
+	s.Query.Get("addr").Value(&a)
 	return
 }
 
 func (s *ssh) Port() uint16 {
 	var p int
-	if err := s.Fork().Get("port").Value(&p); err != nil {
+	if err := s.Query.Get("port").Value(&p); err != nil {
 		p = 22
 	}
 	return uint16(p)
 }
 
 func (s *ssh) SetAddress(addr string) error {
-	return s.Fork().Get("addr").Set(addr).Commit()
+	return s.Query.Get("addr").Set(addr).Commit()
 }
 
 func (s *ssh) SetPort(prt uint16) error {
-	return s.Fork().Get("port").Set(int(prt)).Commit()
+	return s.Query.Get("port").Set(int(prt)).Commit()
 }
 
 func (s *ssh) SetFullAddress(faddr string) error {
@@ -142,41 +142,41 @@ func (s *ssh) SetFullAddress(faddr string) error {
 }
 
 func (s *ssh) Auth() ListParser[string] {
-	return &list[string]{root: s.root, Query: s.Fork().Get("auth")}
+	return &list[string]{root: s.root, Query: s.Query.Get("auth")}
 }
 
 func (hs *hostShapes) List() (l []string) {
-	l, _ = hs.Fork().List()
+	l, _ = hs.Query.List()
 	return
 }
 
 func (hs *hostShapes) Instance(s string) InstanceParser {
-	return &instShape{root: hs.root, Query: hs.Fork().Get(s)}
+	return &instShape{root: hs.root, Query: hs.Query.Get(s)}
 }
 
 func (hs *hostShapes) Delete(s string) error {
-	return hs.Fork().Get(s).Delete().Commit()
+	return hs.Query.Get(s).Delete().Commit()
 }
 
 func (hs *instShape) Key() (k string) {
-	hs.Fork().Get("key").Value(&k)
+	hs.Query.Get("key").Value(&k)
 	return
 }
 
 func (hs *instShape) Id() (i string) {
 	var err error
 
-	if err = hs.Fork().Get("id").Value(&i); err == nil {
+	if err = hs.Query.Get("id").Value(&i); err == nil {
 		return
 	}
 
 	var k string
-	if err := hs.Fork().Get("key").Value(&k); err != nil {
+	if err := hs.Query.Get("key").Value(&k); err != nil {
 		return
 	}
 
 	if i, _, err = generateNodeKeyAndID(k); err == nil {
-		hs.Fork().Get("id").Set(i).Commit()
+		hs.Query.Get("id").Set(i).Commit()
 	}
 
 	return
@@ -189,8 +189,8 @@ func (hs *instShape) SetKey(key string) error {
 		return err
 	}
 
-	err = hs.Fork().Get("key").Set(key).Commit()
-	hs.Fork().Get("id").Set(i).Commit()
+	err = hs.Query.Get("key").Set(key).Commit()
+	hs.Query.Get("id").Set(i).Commit()
 
 	return err
 }
@@ -202,8 +202,8 @@ func (hs *instShape) GenerateKey() error {
 		return err
 	}
 
-	err = hs.Fork().Get("key").Set(key).Commit()
-	hs.Fork().Get("id").Set(i).Commit()
+	err = hs.Query.Get("key").Set(key).Commit()
+	hs.Query.Get("id").Set(i).Commit()
 
 	return err
 }

--- a/pkg/spore-drive/config/list.go
+++ b/pkg/spore-drive/config/list.go
@@ -12,24 +12,24 @@ type ListParser[T comparable] interface {
 type list[T comparable] leaf
 
 func (a *list[T]) List() (l []T) {
-	a.Fork().Value(&l)
+	a.Query.Value(&l)
 	return
 }
 
 func (a *list[T]) Add(v T) error {
-	return a.Fork().Set(appendNew(a.List(), v)).Commit()
+	return a.Query.Set(appendNew(a.List(), v)).Commit()
 }
 
 func (a *list[T]) Append(v ...T) error {
-	return a.Fork().Set(appendNew(a.List(), v...)).Commit()
+	return a.Query.Set(appendNew(a.List(), v...)).Commit()
 }
 
 func (a *list[T]) Set(v ...T) error {
-	return a.Fork().Set(v).Commit()
+	return a.Query.Set(v).Commit()
 }
 
 func (a *list[T]) Clear() error {
-	return a.Fork().Set([]T{}).Commit()
+	return a.Query.Set([]T{}).Commit()
 }
 
 func (a *list[T]) Delete(v T) error {
@@ -40,5 +40,5 @@ func (a *list[T]) Delete(v T) error {
 			l = append(l, i)
 		}
 	}
-	return a.Fork().Set(l).Commit()
+	return a.Query.Set(l).Commit()
 }

--- a/pkg/spore-drive/config/shapes.go
+++ b/pkg/spore-drive/config/shapes.go
@@ -26,45 +26,45 @@ type (
 )
 
 func (s *shapes) List() (l []string) {
-	l, _ = s.Fork().List()
+	l, _ = s.Query.List()
 	return
 }
 
 func (s *shapes) Shape(name string) ShapeParser {
-	return &shape{root: s.root, Query: s.Fork().Get(name)}
+	return &shape{root: s.root, Query: s.Query.Get(name)}
 }
 
 func (s *shapes) Delete(name string) error {
-	return s.Fork().Get(name).Delete().Commit()
+	return s.Query.Get(name).Delete().Commit()
 }
 
 func (s *shape) Services() ListParser[string] {
-	return &list[string]{root: s.root, Query: s.Fork().Get("services")}
+	return &list[string]{root: s.root, Query: s.Query.Get("services")}
 }
 
 func (s *shape) Ports() PortsParser {
-	return &ports{root: s.root, Query: s.Fork().Get("ports")}
+	return &ports{root: s.root, Query: s.Query.Get("ports")}
 }
 
 func (s *shape) Plugins() ListParser[string] {
-	return &list[string]{root: s.root, Query: s.Fork().Get("plugins")}
+	return &list[string]{root: s.root, Query: s.Query.Get("plugins")}
 }
 
 func (p *ports) List() (l []string) {
-	l, _ = p.Fork().List()
+	l, _ = p.Query.List()
 	return
 }
 
 func (p *ports) Get(name string) uint16 {
 	var prt int
-	p.Fork().Get(name).Value(&prt)
+	p.Query.Get(name).Value(&prt)
 	return uint16(prt)
 }
 
 func (p *ports) Set(name string, prt uint16) error {
-	return p.Fork().Get(name).Set(int(prt)).Commit()
+	return p.Query.Get(name).Set(int(prt)).Commit()
 }
 
 func (p *ports) Delete(name string) error {
-	return p.Fork().Get(name).Delete().Commit()
+	return p.Query.Get(name).Delete().Commit()
 }

--- a/pkg/tcc/engine/dump.go
+++ b/pkg/tcc/engine/dump.go
@@ -22,7 +22,7 @@ func (s *instance) Dump(obj object.Object[object.Refrence]) error {
 	// Group node - handle config file and children
 	if n.Match == nil {
 		// Root node - write root attributes to config.yaml
-		configQuery := query.Fork().Get(NodeDefaultSeerLeaf).Document()
+		configQuery := query.Get(NodeDefaultSeerLeaf).Document()
 		if err := s.dumpAttributes(n, obj, configQuery); err != nil {
 			return err
 		}
@@ -80,7 +80,7 @@ func (s *instance) dumpChild(child *Node, obj object.Object[object.Refrence], qu
 		// DefineIterGroup has StringMatchAll and Group=true
 		if _, isIterGroup := iterNode.Match.(StringMatchAll); isIterGroup && iterNode.Group {
 			// This is a group like "applications" with nested IterGroup
-			return s.dumpApplications(iterNode, groupObj, query.Fork().Get(groupName))
+			return s.dumpApplications(iterNode, groupObj, query.Get(groupName))
 		}
 
 		// Regular DefineIter - write each resource as {groupName}/{name}.yaml
@@ -91,7 +91,7 @@ func (s *instance) dumpChild(child *Node, obj object.Object[object.Refrence], qu
 			}
 
 			// Create document: {groupName}/{name}.yaml
-			docQuery := query.Fork().Get(groupName).Get(name).Document()
+			docQuery := query.Get(groupName).Get(name).Document()
 			if err := s.dumpAttributes(iterNode, resObj, docQuery); err != nil {
 				return fmt.Errorf("dumping attributes for %s/%s failed: %w", groupName, name, err)
 			}
@@ -120,7 +120,7 @@ func (s *instance) dumpApplications(iterGroupNode *Node, appsObj object.Object[o
 		}
 
 		// Write application config.yaml: {appName}/config.yaml
-		appConfigQuery := query.Fork().Get(appName).Get(NodeDefaultSeerLeaf).Document()
+		appConfigQuery := query.Get(appName).Get(NodeDefaultSeerLeaf).Document()
 		if err := s.dumpAttributes(iterGroupNode, appObj, appConfigQuery); err != nil {
 			return fmt.Errorf("dumping application %s config failed: %w", appName, err)
 		}
@@ -130,7 +130,7 @@ func (s *instance) dumpApplications(iterGroupNode *Node, appsObj object.Object[o
 
 		// Write application resources
 		for _, resourceNode := range resourceNodes {
-			if err := s.dumpChild(resourceNode, appObj, query.Fork().Get(appName)); err != nil {
+			if err := s.dumpChild(resourceNode, appObj, query.Get(appName)); err != nil {
 				return fmt.Errorf("dumping application %s resources failed: %w", appName, err)
 			}
 		}
@@ -179,7 +179,7 @@ func (s *instance) dumpAttributes(n *Node, obj object.Object[object.Refrence], q
 }
 
 func writeValueToPath(query *yaseer.Query, path []StringMatch, attr *Attribute, val interface{}, obj object.Object[object.Refrence]) error {
-	q := query.Fork()
+	q := query
 
 	for _, p := range path {
 		switch pt := p.(type) {

--- a/pkg/tcc/engine/node.go
+++ b/pkg/tcc/engine/node.go
@@ -170,7 +170,7 @@ func inferPathQuery(path []StringMatch, query *yaseer.Query) (*yaseer.Query, str
 	for _, itm := range path {
 		switch pitm := itm.(type) {
 		case string:
-			query.Get(pitm)
+			query = query.Get(pitm)
 			last_match = pitm
 			// Invalidate cache since query state changed
 			cacheValid = false
@@ -194,7 +194,7 @@ func inferPathQuery(path []StringMatch, query *yaseer.Query) (*yaseer.Query, str
 			for _, l := range list {
 				if pitm.Match(l) {
 					found = true
-					query.Get(l)
+					query = query.Get(l)
 					last_match = l
 					// Invalidate cache since query state changed
 					cacheValid = false

--- a/pkg/tcc/engine/node.go
+++ b/pkg/tcc/engine/node.go
@@ -162,7 +162,6 @@ func (n *Node) childrenToSlice() []any {
 }
 
 func inferPathQuery(path []StringMatch, query *yaseer.Query) (*yaseer.Query, string, error) {
-	query = query.Fork()
 	var last_match string
 	var cachedList []string
 	var cacheValid bool
@@ -181,7 +180,7 @@ func inferPathQuery(path []StringMatch, query *yaseer.Query) (*yaseer.Query, str
 			if cacheValid && cachedList != nil {
 				list = cachedList
 			} else {
-				list, err = query.Fork().List()
+				list, err = query.List()
 				if err != nil {
 					return nil, "", wrapErrorWithLocation(query, err, "list path matches failed")
 				}
@@ -362,18 +361,18 @@ func load[T ObjectDataType](n *Node, query *yaseer.Query) (object.Object[T], err
 	}
 
 	// file might or might not have config, so we ignore error
-	err := setAttributes(n, obj, query.Fork().Get(NodeDefaultSeerLeaf))
+	err := setAttributes(n, obj, query.Get(NodeDefaultSeerLeaf))
 	if err != nil && n.hasRequiredAttributes() {
 		return nil, err
 	}
 
-	list, _ := query.Fork().List()
+	list, _ := query.List()
 
 	// Also enumerate keys nested inside the level's config.yaml so
 	// `DefineGroup("clouds", DefineIter(...))` matches a `clouds:` map
 	// authored as nested YAML, not just as a `clouds/<key>.yaml` directory.
 	// Filesystem entries take precedence.
-	configList, _ := query.Fork().Get(NodeDefaultSeerLeaf).List()
+	configList, _ := query.Get(NodeDefaultSeerLeaf).List()
 	inFS := make(map[string]bool, len(list))
 	for _, l := range list {
 		inFS[l] = true
@@ -410,7 +409,7 @@ func load[T ObjectDataType](n *Node, query *yaseer.Query) (object.Object[T], err
 			if l == NodeDefaultSeerLeaf {
 				continue
 			}
-			if err := processChild(itm, l, query.Fork().Get(l)); err != nil {
+			if err := processChild(itm, l, query.Get(l)); err != nil {
 				return nil, err
 			}
 		}
@@ -418,7 +417,7 @@ func load[T ObjectDataType](n *Node, query *yaseer.Query) (object.Object[T], err
 			if inFS[l] || l == NodeDefaultSeerLeaf {
 				continue
 			}
-			if err := processChild(itm, l, query.Fork().Get(NodeDefaultSeerLeaf).Get(l)); err != nil {
+			if err := processChild(itm, l, query.Get(NodeDefaultSeerLeaf).Get(l)); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/tcc/engine/node_internal_test.go
+++ b/pkg/tcc/engine/node_internal_test.go
@@ -41,7 +41,7 @@ func TestInferPathQuery_StringPath(t *testing.T) {
 	assert.NilError(t, err)
 
 	query := sr.Query()
-	query.Get("path1")
+	query = query.Get("path1")
 
 	path := []StringMatch{"path2"}
 	resultQuery, lastMatch, err := inferPathQuery(path, query)

--- a/pkg/tcc/internal/parity/schema/basic/get.go
+++ b/pkg/tcc/internal/parity/schema/basic/get.go
@@ -3,7 +3,7 @@ package basic
 func Get[T any](c ConfigIface, path ...string) (value T) {
 	config := c.Config()
 	for _, p := range path {
-		config.Get(p)
+		config = config.Get(p)
 	}
 
 	config.Value(&value)

--- a/pkg/tcc/internal/parity/schema/databases/getter.go
+++ b/pkg/tcc/internal/parity/schema/databases/getter.go
@@ -54,8 +54,8 @@ func (d getter) Secret() bool {
 func (g getter) Encryption() (key string, keyType string) {
 	enc := g.Config().Get("encryption")
 
-	enc.Fork().Get("key").Value(&key)
-	enc.Fork().Get("type").Value(&keyType)
+	enc.Get("key").Value(&key)
+	enc.Get("type").Value(&keyType)
 
 	return
 }

--- a/pkg/tcc/internal/parity/schema/databases/set.go
+++ b/pkg/tcc/internal/parity/schema/databases/set.go
@@ -55,8 +55,8 @@ func Encryption(key string) basic.Op {
 		_type, key := getEncryptionTypeAndKey(key)
 		encryption := c.Config().Get("encryption")
 		return []*seer.Query{
-			encryption.Fork().Get("type").Set(_type),
-			encryption.Fork().Get("key").Set(key),
+			encryption.Get("type").Set(_type),
+			encryption.Get("key").Set(key),
 		}
 	}
 }

--- a/pkg/tcc/internal/parity/schema/libraries/set.go
+++ b/pkg/tcc/internal/parity/schema/libraries/set.go
@@ -29,8 +29,8 @@ func Github(id string, fullname string) basic.Op {
 	return func(c basic.ConfigIface) []*seer.Query {
 		base := c.Config().Get("source").Get("github")
 		return []*seer.Query{
-			base.Fork().Get("id").Set(id),
-			base.Fork().Get("fullname").Set(fullname),
+			base.Get("id").Set(id),
+			base.Get("fullname").Set(fullname),
 		}
 	}
 }

--- a/pkg/tcc/internal/parity/schema/messaging/set.go
+++ b/pkg/tcc/internal/parity/schema/messaging/set.go
@@ -13,8 +13,8 @@ func Channel(regex bool, match string) basic.Op {
 	return func(c basic.ConfigIface) []*seer.Query {
 		channel := c.Config().Get("channel")
 		return []*seer.Query{
-			channel.Fork().Get("regex").Set(regex),
-			channel.Fork().Get("match").Set(match),
+			channel.Get("regex").Set(regex),
+			channel.Get("match").Set(match),
 		}
 	}
 }
@@ -23,8 +23,8 @@ func Bridges(mqtt bool, websocket bool) basic.Op {
 	return func(c basic.ConfigIface) []*seer.Query {
 		bridges := c.Config().Get("bridges")
 		return []*seer.Query{
-			bridges.Fork().Get("mqtt").Get("enable").Set(mqtt),
-			bridges.Fork().Get("websocket").Get("enable").Set(websocket),
+			bridges.Get("mqtt").Get("enable").Set(mqtt),
+			bridges.Get("websocket").Get("enable").Set(websocket),
 		}
 	}
 }

--- a/pkg/tcc/internal/parity/schema/storages/set.go
+++ b/pkg/tcc/internal/parity/schema/storages/set.go
@@ -30,8 +30,8 @@ func Object(versioning bool, size string) basic.Op {
 	return func(c basic.ConfigIface) []*seer.Query {
 		object := c.Config().Get("object")
 		return []*seer.Query{
-			object.Fork().Get("versioning").Set(versioning),
-			object.Fork().Get("size").Set(size),
+			object.Get("versioning").Set(versioning),
+			object.Get("size").Set(size),
 		}
 	}
 }
@@ -40,8 +40,8 @@ func Streaming(ttl string, size string) basic.Op {
 	return func(c basic.ConfigIface) []*seer.Query {
 		streaming := c.Config().Get("streaming")
 		return []*seer.Query{
-			streaming.Fork().Get("ttl").Set(ttl),
-			streaming.Fork().Get("size").Set(size),
+			streaming.Get("ttl").Set(ttl),
+			streaming.Get("size").Set(size),
 		}
 	}
 }

--- a/pkg/tcc/internal/parity/schema/website/set.go
+++ b/pkg/tcc/internal/parity/schema/website/set.go
@@ -34,8 +34,8 @@ func Github(id string, fullname string) basic.Op {
 		provider := "github"
 		base := c.Config().Get("source").Get(provider)
 		return []*seer.Query{
-			base.Fork().Get("id").Set(id),
-			base.Fork().Get("fullname").Set(fullname),
+			base.Get("id").Set(id),
+			base.Get("fullname").Set(fullname),
 		}
 	}
 }

--- a/pkg/tcc/taubyte/v1/bench_test.go
+++ b/pkg/tcc/taubyte/v1/bench_test.go
@@ -1,0 +1,23 @@
+package compiler
+
+import (
+	"context"
+	"testing"
+)
+
+// BenchmarkCompile runs a full compile of the fixture project — read the config
+// tree via yaseer + all four transform passes — the work a patrick build does.
+func BenchmarkCompile(b *testing.B) {
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c, err := New(WithLocal("fixtures/config"), WithBranch("master"))
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, _, err := c.Compile(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/yaseer/batch_test.go
+++ b/pkg/yaseer/batch_test.go
@@ -12,9 +12,9 @@ func TestBatch_Commit(t *testing.T) {
 		query2 := seer.Get("batch2").Get("doc2").Document()
 		query3 := seer.Get("batch3").Get("doc3").Document()
 
-		query1.Set("value1")
-		query2.Set("value2")
-		query3.Set("value3")
+		query1 = query1.Set("value1")
+		query2 = query2.Set("value2")
+		query3 = query3.Set("value3")
 
 		batch := seer.Batch(query1, query2, query3)
 		err := batch.Commit()
@@ -44,7 +44,7 @@ func TestBatch_Commit(t *testing.T) {
 		query2 := seer.Get("bad").Document() // This will fail because Document() needs a Get first
 
 		// Force an error in query2
-		query2.Get("nested").Document().Set("value")
+		query2 = query2.Get("nested").Document().Set("value")
 
 		batch := seer.Batch(query1, query2)
 		// The batch should either succeed or fail depending on the error handling

--- a/pkg/yaseer/coverage_test.go
+++ b/pkg/yaseer/coverage_test.go
@@ -113,8 +113,10 @@ func TestWithWALEmptyPathRejected(t *testing.T) {
 func TestOpToWireUnknownHandler(t *testing.T) {
 	// Synthesise an op with a handler we never registered.
 	o := op{
-		opType:  opTypeGet,
-		handler: func(this op, q *Query, p []string, v *yamlNode) ([]string, *yamlNode, error) { return p, v, nil },
+		opType: opTypeGet,
+		handler: func(this op, q *Query, w bool, p []string, v *yamlNode) ([]string, *yamlNode, error) {
+			return p, v, nil
+		},
 	}
 	if _, err := opToWire(o); err == nil {
 		t.Error("expected error for unknown handler")
@@ -215,7 +217,7 @@ func TestDecodeOpsFrameTruncatedAtEveryStep(t *testing.T) {
 	// Build a valid frame body, then progressively truncate from the
 	// tail to hit each "truncated" error branch.
 	q := (&Query{seer: &Seer{}}).Get("x").Set("y")
-	body, err := encodeOpsFrame(q.ops)
+	body, err := encodeOpsFrame(q.opChain())
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
@@ -229,7 +231,7 @@ func TestDecodeOpsFrameTruncatedAtEveryStep(t *testing.T) {
 
 func TestDecodeOpsFrameTrailingBytes(t *testing.T) {
 	q := (&Query{seer: &Seer{}}).Get("x")
-	body, _ := encodeOpsFrame(q.ops)
+	body, _ := encodeOpsFrame(q.opChain())
 	body = append(body, 0x99) // trailing garbage byte
 	if _, err := decodeOpsFrame(body); err == nil {
 		t.Error("expected error for trailing bytes")
@@ -280,7 +282,7 @@ func TestLoadCommitFramesBadCRC(t *testing.T) {
 	// recovery at that point.
 	s := &Seer{fs: memfs, walPath: ".wal"}
 	q := s.Query().Get("x").Set("y")
-	body, _ := encodeOpsFrame(q.ops)
+	body, _ := encodeOpsFrame(q.opChain())
 	var buf bytes.Buffer
 	buf.WriteString(frameMagic)
 	binary.Write(&buf, binary.BigEndian, uint32(len(body)))
@@ -560,7 +562,7 @@ func TestAppendCommitWALDisabledIsNoop(t *testing.T) {
 	memfs := afero.NewMemMapFs()
 	s := &Seer{fs: memfs, walPath: ""}
 	q := s.Query().Get("x").Set("y")
-	if err := s.appendCommitWAL(q.ops); err != nil {
+	if err := s.appendCommitWAL(q.opChain()); err != nil {
 		t.Errorf("disabled appendCommitWAL should be noop, got %v", err)
 	}
 }
@@ -571,7 +573,7 @@ func TestAppendCommitWALReadOnlyFS(t *testing.T) {
 	roFS := afero.NewReadOnlyFs(afero.NewMemMapFs())
 	s := &Seer{fs: roFS, walPath: ".wal"}
 	q := s.Query().Get("x").Set("y")
-	if err := s.appendCommitWAL(q.ops); err == nil {
+	if err := s.appendCommitWAL(q.opChain()); err == nil {
 		t.Error("expected error appending to read-only FS")
 	}
 }

--- a/pkg/yaseer/error_test.go
+++ b/pkg/yaseer/error_test.go
@@ -88,9 +88,9 @@ func TestYAMLError_Parsing(t *testing.T) {
 func TestFork_Query(t *testing.T) {
 	seer := newTestSeer(t)
 
-	t.Run("Fork creates independent copy of query", func(t *testing.T) {
+	t.Run("branches from a shared base are independent", func(t *testing.T) {
 		original := seer.Get("fork").Get("test").Document()
-		forked := Fork(original)
+		forked := original // immutable: reusing the base branches implicitly
 
 		// Modify original
 		original = original.Set("original_value")
@@ -119,12 +119,8 @@ func TestFork_Query(t *testing.T) {
 	t.Run("branching is independent (immutable queries)", func(t *testing.T) {
 		base := seer.Get("fork2").Get("test2")
 
-		// Fork is now a no-op identity; independence comes from Get returning a
-		// new query rather than mutating the receiver.
-		if base.Fork() != base {
-			t.Error("Fork should return the same instance for an immutable query")
-		}
-
+		// Immutable: independence comes from Get returning a new query rather
+		// than mutating the receiver, so no explicit Fork is needed.
 		a := base.Get("nested1")
 		b := base.Get("nested2")
 		if a == b {

--- a/pkg/yaseer/error_test.go
+++ b/pkg/yaseer/error_test.go
@@ -93,10 +93,10 @@ func TestFork_Query(t *testing.T) {
 		forked := Fork(original)
 
 		// Modify original
-		original.Set("original_value")
+		original = original.Set("original_value")
 
 		// Forked should be independent
-		forked.Set("forked_value")
+		forked = forked.Set("forked_value")
 
 		// Commit both
 		if err := original.Commit(); err != nil {
@@ -126,8 +126,8 @@ func TestFork_Query(t *testing.T) {
 		}
 
 		// Operations on one shouldn't affect the other
-		query.Get("nested1")
-		forked.Get("nested2")
+		query = query.Get("nested1")
+		forked = forked.Get("nested2")
 
 		if len(query.requestedPath) != len(forked.requestedPath) {
 			t.Error("Forked query should have same initial path")
@@ -140,7 +140,7 @@ func TestClear_Query(t *testing.T) {
 
 	t.Run("Clear resets query state", func(t *testing.T) {
 		query := seer.Get("clear").Get("test").Document()
-		query.Set("value")
+		query = query.Set("value")
 
 		cleared := query.Clear()
 
@@ -174,7 +174,7 @@ func TestErrors_Query(t *testing.T) {
 	t.Run("Errors returns copy of error slice", func(t *testing.T) {
 		query := seer.Query()
 		// Force an error
-		query.Document() // This should add an error
+		query = query.Document() // This should add an error
 
 		errors := query.Errors()
 		if len(errors) == 0 {
@@ -220,7 +220,7 @@ func TestDocument_ErrorHandling(t *testing.T) {
 
 	t.Run("Document on empty query adds error", func(t *testing.T) {
 		query := seer.Query()
-		query.Document() // Should add error
+		query = query.Document() // Should add error
 
 		errors := query.Errors()
 		if len(errors) == 0 {
@@ -234,7 +234,7 @@ func TestValue_ErrorHandling(t *testing.T) {
 
 	t.Run("Value returns error when query has errors", func(t *testing.T) {
 		query := seer.Query()
-		query.Document() // Add error
+		query = query.Document() // Add error
 
 		var val string
 		err := query.Value(&val)
@@ -408,7 +408,7 @@ func TestCommit_ErrorHandling(t *testing.T) {
 
 	t.Run("Commit with errors returns error", func(t *testing.T) {
 		query := seer.Query()
-		query.Document() // This adds an error
+		query = query.Document() // This adds an error
 
 		err := query.Commit()
 		if err == nil {
@@ -419,7 +419,7 @@ func TestCommit_ErrorHandling(t *testing.T) {
 	t.Run("Commit handles operation handler errors", func(t *testing.T) {
 		// Create a query that will fail during commit
 		query := seer.Get("commit").Get("test").Document()
-		query.Set("value")
+		query = query.Set("value")
 
 		// Normal commit should work
 		// If error occurs, that's the path we're testing

--- a/pkg/yaseer/error_test.go
+++ b/pkg/yaseer/error_test.go
@@ -116,54 +116,22 @@ func TestFork_Query(t *testing.T) {
 		_ = forkVal
 	})
 
-	t.Run("Fork method creates independent copy", func(t *testing.T) {
-		query := seer.Get("fork2").Get("test2")
-		forked := query.Fork()
+	t.Run("branching is independent (immutable queries)", func(t *testing.T) {
+		base := seer.Get("fork2").Get("test2")
 
-		// Both should be independent
-		if query == forked {
-			t.Error("Fork should create a new instance")
+		// Fork is now a no-op identity; independence comes from Get returning a
+		// new query rather than mutating the receiver.
+		if base.Fork() != base {
+			t.Error("Fork should return the same instance for an immutable query")
 		}
 
-		// Operations on one shouldn't affect the other
-		query = query.Get("nested1")
-		forked = forked.Get("nested2")
-
-		if len(query.requestedPath) != len(forked.requestedPath) {
-			t.Error("Forked query should have same initial path")
+		a := base.Get("nested1")
+		b := base.Get("nested2")
+		if a == b {
+			t.Error("distinct Get() calls must yield distinct queries")
 		}
-	})
-}
-
-func TestClear_Query(t *testing.T) {
-	seer := newTestSeer(t)
-
-	t.Run("Clear resets query state", func(t *testing.T) {
-		query := seer.Get("clear").Get("test").Document()
-		query = query.Set("value")
-
-		cleared := query.Clear()
-
-		if len(cleared.ops) != 0 {
-			t.Error("Clear should remove all operations")
-		}
-		if len(cleared.errors) != 0 {
-			t.Error("Clear should remove all errors")
-		}
-		if cleared.write {
-			t.Error("Clear should reset write flag")
-		}
-	})
-
-	t.Run("Clear returns query for chaining", func(t *testing.T) {
-		query := seer.Get("clear2")
-		cleared := query.Clear()
-
-		if cleared == nil {
-			t.Error("Clear should return the query")
-		}
-		if cleared != query {
-			t.Error("Clear should return the same query instance")
+		if len(a.logicalPath()) != len(b.logicalPath()) {
+			t.Error("sibling branches should have equal-length paths")
 		}
 	})
 }

--- a/pkg/yaseer/list_test.go
+++ b/pkg/yaseer/list_test.go
@@ -22,10 +22,10 @@ func TestListEmpty(t *testing.T) {
 		seer.Get("parent").Get("p").Document(),
 		seer.Get("a").Get("b").Get("C").Document().Get("a").Get("orange"),
 	} {
-		err = query.Fork().Commit()
+		err = query.Commit()
 		assert.NilError(t, err)
 
-		items, err = query.Fork().List()
+		items, err = query.List()
 		assert.NilError(t, err)
 		assert.Assert(t, len(items) == 0)
 	}
@@ -87,12 +87,12 @@ func TestListDeepCommitDelete(t *testing.T) {
 	query := seer.Get("parent").Get("sad").Get("fruits")
 
 	for _, i := range items {
-		err = query.Fork().Get(i).Commit()
+		err = query.Get(i).Commit()
 		assert.NilError(t, err)
 	}
 
 	for _, i := range toDelete {
-		err = query.Fork().Get(i).Delete().Commit()
+		err = query.Get(i).Delete().Commit()
 		assert.NilError(t, err)
 	}
 

--- a/pkg/yaseer/node.go
+++ b/pkg/yaseer/node.go
@@ -8,129 +8,134 @@ import (
 	"github.com/spf13/afero"
 )
 
-// Helper
-func Fork(n *Query) *Query {
-	return n.Fork()
+// Fork is retained for API compatibility. A Query is immutable, so branching is
+// implicit (each Get/Set/... returns a new Query) and forking is a no-op.
+func Fork(n *Query) *Query { return n.Fork() }
+
+// Fork returns the query itself: immutability makes an explicit copy unnecessary.
+func (n *Query) Fork() *Query { return n }
+
+// child returns a new Query deriving from n via op o, without mutating n.
+func (n *Query) child(o op) *Query {
+	return &Query{seer: n.seer, parent: n, op: o, errors: n.errors}
 }
 
-// Copy a query ... the conly way to reuse a query.
-func (n *Query) Fork() *Query {
-	nq := &Query{
-		seer:          n.seer,
-		write:         n.write,
-		requestedPath: make([]string, len(n.requestedPath)),
-		ops:           make([]op, len(n.ops)),
-		errors:        make([]error, 0),
+// queryFromOps rebuilds a linked Query chain from a flat op slice (WAL replay).
+func queryFromOps(s *Seer, ops []op) *Query {
+	q := &Query{seer: s}
+	for _, o := range ops {
+		q = q.child(o)
 	}
-
-	copy(nq.requestedPath, n.requestedPath)
-	copy(nq.ops, n.ops)
-
-	return nq
+	return q
 }
 
 func (n *Query) Set(value interface{}) *Query {
-	n.ops = append(n.ops,
-		op{
-			opType:  opTypeSet,
-			value:   value,
-			handler: opSetInYaml,
-		},
-	)
-	return n
+	return n.child(op{opType: opTypeSet, value: value, handler: opSetInYaml})
 }
 
 func (n *Query) Delete() *Query {
-	n.ops = append(n.ops,
-		op{
-			opType:  opTypeSet,
-			handler: opDelete,
-		},
-	)
-	return n
+	return n.child(op{opType: opTypeSet, handler: opDelete})
 }
 
 func (n *Query) Get(name string) *Query {
-	n.requestedPath = append(n.requestedPath, name)
-	n.ops = append(n.ops,
-		op{
-			opType:  opTypeGetOrCreate,
-			name:    name,
-			handler: opGetOrCreate,
-		},
-	)
-	return n
+	return n.child(op{opType: opTypeGetOrCreate, name: name, handler: opGetOrCreate})
 }
 
+// Document reinterprets the last Get as a document boundary: it replaces that op
+// with a CreateDocument for the same name, parented to whatever preceded the Get.
 func (n *Query) Document() *Query {
-	if len(n.ops) == 0 {
-		// should never happen actually, as you need to call get or set before
-		n.errors = append(n.errors, errors.New("can't convert root to a document"))
-		return n
+	if n.parent == nil {
+		// no prior Get to convert
+		errs := append(append([]error(nil), n.errors...), errors.New("can't convert root to a document"))
+		return &Query{seer: n.seer, parent: n, errors: errs}
 	}
-
-	n.write = true
-
-	// grab path from previous
-	// and delete last op
-	last_op_index := len(n.ops) - 1
-	name := n.ops[last_op_index].name
-	n.ops = n.ops[:last_op_index]
-
-	n.ops = append(n.ops,
-		op{
-			opType:  opTypeCreateDocument,
-			name:    name,
-			handler: opCreateDocument,
-		},
-	)
-	return n
+	return &Query{
+		seer:   n.seer,
+		parent: n.parent,
+		op:     op{opType: opTypeCreateDocument, name: n.op.name, handler: opCreateDocument},
+		errors: n.errors,
+	}
 }
 
-// return a copy of the Stack Error
+// return a copy of the accumulated errors
 func (n *Query) Errors() []error {
 	ret := make([]error, len(n.errors))
 	copy(ret, n.errors)
 	return ret
 }
 
-func (n *Query) Clear() *Query {
-	n.write = false
-	n.ops = n.ops[:0]
-	n.errors = n.errors[:0]
-	return n
+// logicalPath is the sequence of Get/Document names from root to n — the raw
+// requested path, without the ".yaml" suffix the resolver appends to documents.
+func (n *Query) logicalPath() []string {
+	if n.parent == nil {
+		return nil
+	}
+	p := n.parent.logicalPath()
+	switch n.op.opType {
+	case opTypeGetOrCreate, opTypeCreateDocument:
+		return append(p, n.op.name)
+	default: // Set/Delete contribute no path segment
+		return p
+	}
+}
+
+// opChain linearizes the ops from root to n, in execution order.
+func (n *Query) opChain() []op {
+	if n.parent == nil {
+		return nil
+	}
+	return append(n.parent.opChain(), n.op)
+}
+
+// resolve walks the chain root->n, applying each op to the previous result. Read
+// resolutions (write == false) are memoized per node and invalidated by the Seer
+// generation counter. Caller must hold seer.lock.
+func (n *Query) resolve(write bool) (path []string, node *yamlNode, err error) {
+	if n.parent == nil {
+		return nil, nil, nil
+	}
+	if !write && n.memoValid && n.memoGen == n.seer.gen {
+		return n.memoPath, n.memoNode, nil
+	}
+	ppath, pnode, err := n.parent.resolve(write)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Handlers append to the path slice; clone the parent's so sibling branches
+	// resolving off the same (memoized) parent path don't corrupt each other.
+	ppath = append([]string(nil), ppath...)
+	path, node, err = n.op.handler(n.op, n, write, ppath, pnode)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !write {
+		n.memoNode, n.memoPath, n.memoGen, n.memoValid = node, path, n.seer.gen, true
+	}
+	return path, node, nil
 }
 
 func (n *Query) Commit() error {
 	n.seer.lock.Lock()
 	defer n.seer.lock.Unlock()
-	n.write = true
 	if len(n.errors) > 0 {
 		return fmt.Errorf("%d errors preventing commit", len(n.errors))
 	}
-
-	var (
-		path []string  = make([]string, 0)
-		doc  *yamlNode // nil when created here
-		err  error
-	)
-	for _, op := range n.ops {
-		path, doc, err = op.handler(op, n, path, doc)
-		if err != nil {
-			return fmt.Errorf("committing failed with %s", err.Error())
-		}
+	// A write mutates yaml.Node trees / the documents map in place; bump the
+	// generation before any of that so every read memo taken earlier invalidates,
+	// even if a later op in this commit fails partway through.
+	n.seer.gen++
+	if _, _, err := n.resolve(true); err != nil {
+		return fmt.Errorf("committing failed with %s", err.Error())
 	}
 
-	// A commit resolves into exactly one document; filePath is its
-	// map key. Mark it dirty so Sync rewrites just this document.
+	// A commit resolves into exactly one document; filePath is its map key.
 	if n.filePath != "" {
 		n.seer.dirty[n.filePath] = struct{}{}
 	}
 
-	// Op-based WAL: persist a description of this commit's ops so a
-	// kill between now and the next Sync() doesn't drop the change.
-	// No-op when WAL is disabled (n.seer.walPath == "").
-	if err := n.seer.appendCommitWAL(n.ops); err != nil {
+	// Op-based WAL: persist this commit's ops so a kill before the next Sync()
+	// doesn't drop the change. No-op when WAL is disabled (walPath == "").
+	if err := n.seer.appendCommitWAL(n.opChain()); err != nil {
 		return fmt.Errorf("wal append failed: %w", err)
 	}
 
@@ -140,21 +145,13 @@ func (n *Query) Commit() error {
 func (n *Query) Value(dst interface{}) error {
 	n.seer.lock.Lock()
 	defer n.seer.lock.Unlock()
-	n.write = false
 	if len(n.errors) > 0 {
 		return fmt.Errorf("%d errors preventing getting value", len(n.errors))
 	}
 
-	var (
-		path []string  = make([]string, 0)
-		doc  *yamlNode // nil when created here
-		err  error
-	)
-	for _, op := range n.ops {
-		path, doc, err = op.handler(op, n, path, doc)
-		if err != nil {
-			return fmt.Errorf("Value failed with %s", err.Error())
-		}
+	path, doc, err := n.resolve(false)
+	if err != nil {
+		return fmt.Errorf("Value failed with %s", err.Error())
 	}
 
 	if doc == nil {
@@ -216,7 +213,7 @@ func (n *Query) List() ([]string, error) {
 	var val interface{}
 	err := n.Value(&val)
 	if err != nil {
-		path := "/" + joinPath(n.requestedPath)
+		path := "/" + joinPath(n.logicalPath())
 		st, statErr := n.seer.fs.Stat(path)
 		if statErr == nil && st.IsDir() {
 			dirFiles, err := afero.ReadDir(n.seer.fs, path)
@@ -254,18 +251,33 @@ func (n *Query) List() ([]string, error) {
 	}
 }
 
+// Location reports where the resolved value lives. On a failed resolve the
+// terminal node has no location, so walk up to the deepest resolved ancestor —
+// matching the old replay model where the last successful op's location stuck.
+func (n *Query) location() (string, int, int) {
+	for q := n; q != nil; q = q.parent {
+		if q.filePath != "" || q.line != 0 || q.column != 0 {
+			return q.filePath, q.line, q.column
+		}
+	}
+	return "", 0, 0
+}
+
 func (n *Query) FilePath() string {
-	return n.filePath
+	fp, _, _ := n.location()
+	return fp
 }
 
 func (n *Query) Line() int {
-	return n.line
+	_, line, _ := n.location()
+	return line
 }
 
 func (n *Query) Column() int {
-	return n.column
+	_, _, col := n.location()
+	return col
 }
 
 func (n *Query) Location() (filePath string, line int, column int) {
-	return n.filePath, n.line, n.column
+	return n.location()
 }

--- a/pkg/yaseer/node.go
+++ b/pkg/yaseer/node.go
@@ -8,13 +8,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-// Fork is retained for API compatibility. A Query is immutable, so branching is
-// implicit (each Get/Set/... returns a new Query) and forking is a no-op.
-func Fork(n *Query) *Query { return n.Fork() }
-
-// Fork returns the query itself: immutability makes an explicit copy unnecessary.
-func (n *Query) Fork() *Query { return n }
-
 // child returns a new Query deriving from n via op o, without mutating n.
 func (n *Query) child(o op) *Query {
 	return &Query{seer: n.seer, parent: n, op: o, errors: n.errors}

--- a/pkg/yaseer/ops.go
+++ b/pkg/yaseer/ops.go
@@ -17,22 +17,22 @@ func getNodeLocation(node *yaml.Node) (line, column int) {
 	return node.Line, node.Column
 }
 
-func opDelete(this op, query *Query, path []string, value *yamlNode) ([]string, *yamlNode, error) {
-	if !query.write {
+func opDelete(this op, query *Query, write bool, path []string, value *yamlNode) ([]string, *yamlNode, error) {
+	if !write {
 		return path, nil, errors.New("failed to call Delete() during a read query")
 	}
 
 	if value == nil || value.parent == nil {
-		return _opDeleteInFileSystem(this, query, path, nil)
+		return _opDeleteInFileSystem(this, query, write, path, nil)
 	} else {
 		// else we're dealing with inside
-		return _opDeleteInYaml(this, query, path, value)
+		return _opDeleteInYaml(this, query, write, path, value)
 	}
 }
 
-func _opDeleteInYaml(this op, query *Query, path []string, value *yamlNode) ([]string, *yamlNode, error) {
+func _opDeleteInYaml(this op, query *Query, write bool, path []string, value *yamlNode) ([]string, *yamlNode, error) {
 
-	if !query.write {
+	if !write {
 		return path, nil, errors.New("failed to call Delete() during a read query")
 	}
 
@@ -53,7 +53,7 @@ func _opDeleteInYaml(this op, query *Query, path []string, value *yamlNode) ([]s
 	return path, &yamlNode{parent: value.parent, prev: nil, this: nil, filePath: value.filePath}, nil
 }
 
-func _opDeleteInFileSystem(this op, query *Query, _path []string, value *yamlNode) ([]string, *yamlNode, error) {
+func _opDeleteInFileSystem(this op, query *Query, write bool, _path []string, value *yamlNode) ([]string, *yamlNode, error) {
 	_path = append(_path, this.name)
 	path := "/" + joinPath(_path)
 
@@ -86,9 +86,9 @@ func _opDeleteInFileSystem(this op, query *Query, _path []string, value *yamlNod
 
 }
 
-func opSetInYaml(this op, query *Query, path []string, value *yamlNode) ([]string, *yamlNode, error) {
+func opSetInYaml(this op, query *Query, write bool, path []string, value *yamlNode) ([]string, *yamlNode, error) {
 
-	if !query.write {
+	if !write {
 		return path, nil, errors.New("failed to call Set() during a read query")
 	}
 
@@ -116,20 +116,20 @@ func opSetInYaml(this op, query *Query, path []string, value *yamlNode) ([]strin
 	return path, &yamlNode{parent: parentNode, prev: value.prev, this: curNode, filePath: value.filePath}, err
 }
 
-func opGetOrCreate(this op, query *Query, path []string, value *yamlNode) ([]string, *yamlNode, error) {
+func opGetOrCreate(this op, query *Query, write bool, path []string, value *yamlNode) ([]string, *yamlNode, error) {
 	if value == nil {
-		if query.write {
-			return _opGetOrCreateInFileSystem(this, query, path, nil)
+		if write {
+			return _opGetOrCreateInFileSystem(this, query, write, path, nil)
 		} else {
-			return _opGetInFileSystem(this, query, path, nil)
+			return _opGetInFileSystem(this, query, write, path, nil)
 		}
 	} else {
 		// else we're dealing with inside
-		return _opGetInYaml(this, query, path, value)
+		return _opGetInYaml(this, query, write, path, value)
 	}
 }
 
-func _opGetInYaml(this op, query *Query, path []string, value *yamlNode) ([]string, *yamlNode, error) {
+func _opGetInYaml(this op, query *Query, write bool, path []string, value *yamlNode) ([]string, *yamlNode, error) {
 
 	if value == nil || value.this == nil {
 		return path, nil, fmt.Errorf("can not find %s in the empty document %s", this.name, joinPath(path))
@@ -159,7 +159,7 @@ func _opGetInYaml(this op, query *Query, path []string, value *yamlNode) ([]stri
 			}
 		}
 
-		if query.write {
+		if write {
 			parentNode = curNode
 			curNode = &yaml.Node{}
 			curNode.Encode(map[string]interface{}{this.name: nil})
@@ -181,7 +181,7 @@ func _opGetInYaml(this op, query *Query, path []string, value *yamlNode) ([]stri
 		}
 		_index := int(_idx)
 		if _index >= len(curNode.Content) {
-			if query.write {
+			if write {
 				parentNode = curNode
 				curNode = &yaml.Node{}
 				curNode.Encode(nil)
@@ -203,7 +203,7 @@ func _opGetInYaml(this op, query *Query, path []string, value *yamlNode) ([]stri
 		return path, &yamlNode{parent: parentNode, prev: nil, this: curNode.Content[_index], filePath: filePath}, nil
 	}
 
-	if query.write {
+	if write {
 
 		curNode.Encode(map[string]interface{}{this.name: nil})
 		line, column := getNodeLocation(curNode.Content[1])
@@ -217,7 +217,7 @@ func _opGetInYaml(this op, query *Query, path []string, value *yamlNode) ([]stri
 	return path, nil, fmt.Errorf("can not find %s", joinPath(path))
 }
 
-func _opGetOrCreateInFileSystem(this op, query *Query, _path []string, value *yamlNode) ([]string, *yamlNode, error) {
+func _opGetOrCreateInFileSystem(this op, query *Query, write bool, _path []string, value *yamlNode) ([]string, *yamlNode, error) {
 	_path = append(_path, this.name)
 	path := "/" + joinPath(_path)
 	doc, exists := query.seer.documents[path+".yaml"]
@@ -267,7 +267,7 @@ func _opGetOrCreateInFileSystem(this op, query *Query, _path []string, value *ya
 	return _path, nil, fmt.Errorf("unsupported file `%s`", path)
 }
 
-func _opGetInFileSystem(this op, query *Query, _path []string, value *yamlNode) ([]string, *yamlNode, error) {
+func _opGetInFileSystem(this op, query *Query, write bool, _path []string, value *yamlNode) ([]string, *yamlNode, error) {
 	_path = append(_path, this.name)
 	path := "/" + joinPath(_path)
 	doc, exists := query.seer.documents[path+".yaml"]
@@ -313,7 +313,7 @@ func _opGetInFileSystem(this op, query *Query, _path []string, value *yamlNode) 
 	return _path, nil, fmt.Errorf("unsupported file `%s`", path)
 }
 
-func opCreateDocument(this op, query *Query, _path []string, value *yamlNode) ([]string, *yamlNode, error) {
+func opCreateDocument(this op, query *Query, write bool, _path []string, value *yamlNode) ([]string, *yamlNode, error) {
 	_path = append(_path, this.name+".yaml")
 	path := "/" + joinPath(_path)
 	// Check for it first
@@ -333,7 +333,7 @@ func opCreateDocument(this op, query *Query, _path []string, value *yamlNode) ([
 			return _path, nil, fmt.Errorf("can't create document: `%s` is a directory", path)
 		}
 	} else { // we need to create
-		if query.write {
+		if write {
 			f, err := query.seer.fs.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0640)
 			if err != nil {
 				return _path, nil, fmt.Errorf("creating yaml file %s failed with %w", path, err)

--- a/pkg/yaseer/root.go
+++ b/pkg/yaseer/root.go
@@ -108,13 +108,7 @@ func (s *Seer) List() ([]string, error) {
 }
 
 func (s *Seer) Query() *Query {
-	return &Query{
-		seer: s,
-		// Presized to typical path depth so chained Get()s don't realloc.
-		requestedPath: make([]string, 0, 4),
-		ops:           make([]op, 0, 4),
-		errors:        make([]error, 0),
-	}
+	return &Query{seer: s}
 }
 
 type YAMLError struct {
@@ -190,5 +184,8 @@ func (s *Seer) loadYamlDocument(path string) (*yaml.Node, error) {
 	}
 
 	s.documents[path] = root_node
+	// A read that loads a previously-absent document changes what later
+	// resolutions see, so invalidate read memos taken before this load.
+	s.gen++
 	return root_node, nil
 }

--- a/pkg/yaseer/types.go
+++ b/pkg/yaseer/types.go
@@ -18,6 +18,9 @@ type Seer struct {
 	// documents untouched (both a perf win and so Sync never reformats a
 	// file the caller only read).
 	dirty map[string]struct{}
+	// gen is bumped on every write (and on loading a new document) to invalidate
+	// stale read-resolution memos held by Query nodes.
+	gen uint64
 	// walPath is the file (relative to the configured FS root) where
 	// Sync() stages a write-ahead log entry before touching data
 	// files. Empty disables WAL entirely — the default.
@@ -46,17 +49,31 @@ type yamlNode struct {
 	filePath string     // path to the YAML file this node came from
 }
 
-type opHandler func(this op, node *Query, path []string /*returned by previous op*/, value *yamlNode /* value passed by parent*/) ( /*path*/ []string /*value*/, *yamlNode, error)
+// write is threaded explicitly (not read off the Query) because a Query is now
+// immutable and shared across branches — the terminal Value/Commit decides it.
+type opHandler func(this op, node *Query, write bool, path []string /*returned by previous op*/, value *yamlNode /* value passed by parent*/) ( /*path*/ []string /*value*/, *yamlNode, error)
 
+// Query is an immutable node in a resolution chain: it holds the op that derives
+// it from its parent, never mutating either. Get/Set/Delete/Document return a new
+// Query; Value/Commit resolve the chain root->leaf. Sharing a Query across
+// branches is safe, which is why Fork() is a no-op.
 type Query struct {
-	seer          *Seer
-	write         bool     // set to true by Commit() --- set to false by Value()
-	requestedPath []string // is built by the Gets
-	ops           []op
-	errors        []error
-	filePath      string
-	line          int
-	column        int
+	seer   *Seer
+	parent *Query // nil for the root query
+	op     op     // op linking parent -> this (zero value when parent == nil)
+	errors []error
+
+	// memoized READ resolution, invalidated when memoGen != seer.gen.
+	// Writes never read or set this. Guarded by seer.lock (via resolve).
+	memoNode  *yamlNode
+	memoPath  []string
+	memoGen   uint64
+	memoValid bool
+
+	// location of the value this node resolved to (set during resolve)
+	filePath string
+	line     int
+	column   int
 }
 
 type Batch struct {

--- a/pkg/yaseer/wal.go
+++ b/pkg/yaseer/wal.go
@@ -315,7 +315,7 @@ func (s *Seer) replayWAL() error {
 		return nil
 	}
 	for i, ops := range frames {
-		q := &Query{seer: s, ops: ops}
+		q := queryFromOps(s, ops)
 		if err := q.Commit(); err != nil {
 			slog.Warn("yaseer: WAL replay frame failed", "index", i, "error", err)
 			continue

--- a/pkg/yaseer/wal_test.go
+++ b/pkg/yaseer/wal_test.go
@@ -127,7 +127,7 @@ func TestWAL_RoundTripFrame(t *testing.T) {
 	// Build an ops list by exercising the public Query API so the
 	// handlers match the ones live commits use.
 	q := s.Get("foo").Get("bar").Document().Get("baz").Set("value")
-	body, err := encodeOpsFrame(q.ops)
+	body, err := encodeOpsFrame(q.opChain())
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
@@ -135,15 +135,15 @@ func TestWAL_RoundTripFrame(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if len(rebuilt) != len(q.ops) {
-		t.Fatalf("opCount mismatch: got %d, want %d", len(rebuilt), len(q.ops))
+	if len(rebuilt) != len(q.opChain()) {
+		t.Fatalf("opCount mismatch: got %d, want %d", len(rebuilt), len(q.opChain()))
 	}
-	for i := range q.ops {
-		if rebuilt[i].opType != q.ops[i].opType {
-			t.Errorf("op[%d] opType = %d, want %d", i, rebuilt[i].opType, q.ops[i].opType)
+	for i := range q.opChain() {
+		if rebuilt[i].opType != q.opChain()[i].opType {
+			t.Errorf("op[%d] opType = %d, want %d", i, rebuilt[i].opType, q.opChain()[i].opType)
 		}
-		if rebuilt[i].name != q.ops[i].name {
-			t.Errorf("op[%d] name = %q, want %q", i, rebuilt[i].name, q.ops[i].name)
+		if rebuilt[i].name != q.opChain()[i].name {
+			t.Errorf("op[%d] name = %q, want %q", i, rebuilt[i].name, q.opChain()[i].name)
 		}
 	}
 }

--- a/tools/tau/config/config.go
+++ b/tools/tau/config/config.go
@@ -27,5 +27,5 @@ func getOrCreateConfig() *tauConfig {
 
 func (*tauConfig) Document() *seer.Query {
 	configBaseName := strings.TrimSuffix(filepath.Base(constants.TauConfigFileName), ".yaml")
-	return _config.root.Get(configBaseName).Document().Fork()
+	return _config.root.Get(configBaseName).Document()
 }

--- a/tools/tau/config/profiles.go
+++ b/tools/tau/config/profiles.go
@@ -13,7 +13,7 @@ func Profiles() *profileHandler {
 }
 
 func (p *profileHandler) Root() *seer.Query {
-	return _config.Document().Get(singletonsI18n.ProfilesKey).Fork()
+	return _config.Document().Get(singletonsI18n.ProfilesKey)
 }
 
 func (p *profileHandler) Get(name string) (profile Profile, err error) {

--- a/tools/tau/config/projects.go
+++ b/tools/tau/config/projects.go
@@ -12,7 +12,7 @@ func Projects() *projectHandler {
 }
 
 func (p *projectHandler) Root() *seer.Query {
-	return _config.Document().Get(singletonsI18n.ProjectsKey).Fork()
+	return _config.Document().Get(singletonsI18n.ProjectsKey)
 }
 
 func (p *projectHandler) Get(name string) (project Project, err error) {

--- a/tools/tau/session/session.go
+++ b/tools/tau/session/session.go
@@ -26,7 +26,7 @@ func (s *tauSession) Document() *seer.Query {
 	if docName == "" {
 		docName = sessionFileName
 	}
-	return _session.root.Get(docName).Document().Fork()
+	return _session.root.Get(docName).Document()
 }
 
 func (s *tauSession) keys() (values []string, err error) {


### PR DESCRIPTION
Makes `seer.Query` immutable and adds a memoized resolution cache, so the tcc engine stops re-resolving the same document once per attribute. **Compile: −42% allocs, −38% B/op, −46% time** (benchstat n=6), byte-exact parity oracle green.

Three commits, each verified independently against the parity oracle:

### 1. `rewrite discarded-return Query calls to assignment form` (no-op prep)
Today `Get/Set/Delete/Document` mutate the receiver and return it, so some call sites invoke them as statements and rely on the mutation (`config.Get(p)` in a loop, `query.Get(pitm)` in `inferPathQuery`). Once Query returns a new value, those become silent no-ops — and Go gives no unused-result warning. A type-aware AST census over the whole module found all 19 (3 production, the frozen parity copy, yaseer's own tests); rewritten to `x = x.Get(...)`. Provable no-op today, required to make the flip safe.

### 2. `immutable Query with memoized resolution cache` (the win)
`Get/Set/Delete/Document` return a new node linked to its parent instead of mutating. `resolve()` walks root→leaf and memoizes each read resolution on the node, so a shared prefix (the base document) resolves once and every branch reuses it — the cache composes hierarchically along the parent chain. A Seer generation counter invalidates memos: bumped at `Commit` entry (unconditionally, since a write mutates `yaml.Node` trees / the `documents` map in place and a later op may still fail) and when `loadYamlDocument` caches a newly-read document. Writes never touch the read memo.

Mechanics for the immutable model:
- op handlers take `write` explicitly instead of reading a Query field.
- `requestedPath` derives from the op-name chain, kept separate from the resolver's `.yaml`-suffixed path.
- `Location()` walks to the deepest resolved ancestor, matching the old replay model where the last successful op's location stuck after a failure.
- WAL append/replay linearize via the parent chain.

### 3. `remove Fork() now that queries are immutable`
`Fork()` only existed to copy a mutable query before branching; immutable queries branch implicitly. Deleted the method and all ~143 call sites. spore-drive/config wrappers embed `*seer.Query` and used `.Fork()` to drop into the embedded query (escaping their own shadowing methods) — those became `.Query`, not deletion.

## Design vetted before implementation
The combined "make immutable + remove Fork in one pass" plan was reviewed by two independent models (Fable + codex xhigh). Both caught that the naive flip breaks silently (statement-form `Get` callers) and required the split above. All flagged gaps (explicit `write` param, unconditional gen bump, `Location` ancestor walk, logical `requestedPath`, WAL linearization) are handled.

## Verification
- Byte-exact parity oracle (`TestCompile`) green at every commit.
- `tcc-gen --check`: 45/45, 0 drift — no generated file touched (only handmade `custom.go` / `basic/get.go`).
- All four suites green: `make test`, `make test-dreaming`, `make test-raft`, plus `go build ./...`.