### PR TITLE
feat(tcc): compile-free partial validation + field completion for live editing

### DIFF
--- a/pkg/tcc/clients/js/src/gen/schema.ts
+++ b/pkg/tcc/clients/js/src/gen/schema.ts
@@ -109,6 +109,9 @@ export class DatabaseConfig {
   validateField(field: string[], value: unknown): Promise<void> {
     return this.s.binding.validateField(this.s.handle, this.res, field, value);
   }
+  complete(field: string[], partial?: string): Promise<string[]> {
+    return this.s.binding.complete(this.s.handle, this.res, field, partial);
+  }
 
   async id(): Promise<string | undefined> {
     return (await this.s.binding.get(this.s.handle, this.res, ["id"])) as string | undefined;
@@ -218,6 +221,9 @@ export class DomainConfig {
   validateField(field: string[], value: unknown): Promise<void> {
     return this.s.binding.validateField(this.s.handle, this.res, field, value);
   }
+  complete(field: string[], partial?: string): Promise<string[]> {
+    return this.s.binding.complete(this.s.handle, this.res, field, partial);
+  }
 
   async id(): Promise<string | undefined> {
     return (await this.s.binding.get(this.s.handle, this.res, ["id"])) as string | undefined;
@@ -315,6 +321,9 @@ export class FunctionConfig {
   }
   validateField(field: string[], value: unknown): Promise<void> {
     return this.s.binding.validateField(this.s.handle, this.res, field, value);
+  }
+  complete(field: string[], partial?: string): Promise<string[]> {
+    return this.s.binding.complete(this.s.handle, this.res, field, partial);
   }
 
   async id(): Promise<string | undefined> {
@@ -496,6 +505,9 @@ export class LibraryConfig {
   validateField(field: string[], value: unknown): Promise<void> {
     return this.s.binding.validateField(this.s.handle, this.res, field, value);
   }
+  complete(field: string[], partial?: string): Promise<string[]> {
+    return this.s.binding.complete(this.s.handle, this.res, field, partial);
+  }
 
   async id(): Promise<string | undefined> {
     return (await this.s.binding.get(this.s.handle, this.res, ["id"])) as string | undefined;
@@ -593,6 +605,9 @@ export class MessagingConfig {
   }
   validateField(field: string[], value: unknown): Promise<void> {
     return this.s.binding.validateField(this.s.handle, this.res, field, value);
+  }
+  complete(field: string[], partial?: string): Promise<string[]> {
+    return this.s.binding.complete(this.s.handle, this.res, field, partial);
   }
 
   async id(): Promise<string | undefined> {
@@ -702,6 +717,9 @@ export class ServiceConfig {
   validateField(field: string[], value: unknown): Promise<void> {
     return this.s.binding.validateField(this.s.handle, this.res, field, value);
   }
+  complete(field: string[], partial?: string): Promise<string[]> {
+    return this.s.binding.complete(this.s.handle, this.res, field, partial);
+  }
 
   async id(): Promise<string | undefined> {
     return (await this.s.binding.get(this.s.handle, this.res, ["id"])) as string | undefined;
@@ -769,6 +787,9 @@ export class SmartOpConfig {
   }
   validateField(field: string[], value: unknown): Promise<void> {
     return this.s.binding.validateField(this.s.handle, this.res, field, value);
+  }
+  complete(field: string[], partial?: string): Promise<string[]> {
+    return this.s.binding.complete(this.s.handle, this.res, field, partial);
   }
 
   async id(): Promise<string | undefined> {
@@ -867,6 +888,9 @@ export class StorageConfig {
   }
   validateField(field: string[], value: unknown): Promise<void> {
     return this.s.binding.validateField(this.s.handle, this.res, field, value);
+  }
+  complete(field: string[], partial?: string): Promise<string[]> {
+    return this.s.binding.complete(this.s.handle, this.res, field, partial);
   }
 
   async id(): Promise<string | undefined> {
@@ -976,6 +1000,9 @@ export class WebsiteConfig {
   }
   validateField(field: string[], value: unknown): Promise<void> {
     return this.s.binding.validateField(this.s.handle, this.res, field, value);
+  }
+  complete(field: string[], partial?: string): Promise<string[]> {
+    return this.s.binding.complete(this.s.handle, this.res, field, partial);
   }
 
   async id(): Promise<string | undefined> {

--- a/pkg/tcc/clients/js/src/gen/schema.ts
+++ b/pkg/tcc/clients/js/src/gen/schema.ts
@@ -103,6 +103,12 @@ export class DatabaseConfig {
   delete(): Promise<void> {
     return this.s.binding.delete(this.s.handle, this.res);
   }
+  validate(): Promise<string[]> {
+    return this.s.binding.validateResource(this.s.handle, this.res);
+  }
+  validateField(field: string[], value: unknown): Promise<void> {
+    return this.s.binding.validateField(this.s.handle, this.res, field, value);
+  }
 
   async id(): Promise<string | undefined> {
     return (await this.s.binding.get(this.s.handle, this.res, ["id"])) as string | undefined;
@@ -206,6 +212,12 @@ export class DomainConfig {
   delete(): Promise<void> {
     return this.s.binding.delete(this.s.handle, this.res);
   }
+  validate(): Promise<string[]> {
+    return this.s.binding.validateResource(this.s.handle, this.res);
+  }
+  validateField(field: string[], value: unknown): Promise<void> {
+    return this.s.binding.validateField(this.s.handle, this.res, field, value);
+  }
 
   async id(): Promise<string | undefined> {
     return (await this.s.binding.get(this.s.handle, this.res, ["id"])) as string | undefined;
@@ -297,6 +309,12 @@ export class FunctionConfig {
 
   delete(): Promise<void> {
     return this.s.binding.delete(this.s.handle, this.res);
+  }
+  validate(): Promise<string[]> {
+    return this.s.binding.validateResource(this.s.handle, this.res);
+  }
+  validateField(field: string[], value: unknown): Promise<void> {
+    return this.s.binding.validateField(this.s.handle, this.res, field, value);
   }
 
   async id(): Promise<string | undefined> {
@@ -472,6 +490,12 @@ export class LibraryConfig {
   delete(): Promise<void> {
     return this.s.binding.delete(this.s.handle, this.res);
   }
+  validate(): Promise<string[]> {
+    return this.s.binding.validateResource(this.s.handle, this.res);
+  }
+  validateField(field: string[], value: unknown): Promise<void> {
+    return this.s.binding.validateField(this.s.handle, this.res, field, value);
+  }
 
   async id(): Promise<string | undefined> {
     return (await this.s.binding.get(this.s.handle, this.res, ["id"])) as string | undefined;
@@ -563,6 +587,12 @@ export class MessagingConfig {
 
   delete(): Promise<void> {
     return this.s.binding.delete(this.s.handle, this.res);
+  }
+  validate(): Promise<string[]> {
+    return this.s.binding.validateResource(this.s.handle, this.res);
+  }
+  validateField(field: string[], value: unknown): Promise<void> {
+    return this.s.binding.validateField(this.s.handle, this.res, field, value);
   }
 
   async id(): Promise<string | undefined> {
@@ -666,6 +696,12 @@ export class ServiceConfig {
   delete(): Promise<void> {
     return this.s.binding.delete(this.s.handle, this.res);
   }
+  validate(): Promise<string[]> {
+    return this.s.binding.validateResource(this.s.handle, this.res);
+  }
+  validateField(field: string[], value: unknown): Promise<void> {
+    return this.s.binding.validateField(this.s.handle, this.res, field, value);
+  }
 
   async id(): Promise<string | undefined> {
     return (await this.s.binding.get(this.s.handle, this.res, ["id"])) as string | undefined;
@@ -727,6 +763,12 @@ export class SmartOpConfig {
 
   delete(): Promise<void> {
     return this.s.binding.delete(this.s.handle, this.res);
+  }
+  validate(): Promise<string[]> {
+    return this.s.binding.validateResource(this.s.handle, this.res);
+  }
+  validateField(field: string[], value: unknown): Promise<void> {
+    return this.s.binding.validateField(this.s.handle, this.res, field, value);
   }
 
   async id(): Promise<string | undefined> {
@@ -819,6 +861,12 @@ export class StorageConfig {
 
   delete(): Promise<void> {
     return this.s.binding.delete(this.s.handle, this.res);
+  }
+  validate(): Promise<string[]> {
+    return this.s.binding.validateResource(this.s.handle, this.res);
+  }
+  validateField(field: string[], value: unknown): Promise<void> {
+    return this.s.binding.validateField(this.s.handle, this.res, field, value);
   }
 
   async id(): Promise<string | undefined> {
@@ -922,6 +970,12 @@ export class WebsiteConfig {
 
   delete(): Promise<void> {
     return this.s.binding.delete(this.s.handle, this.res);
+  }
+  validate(): Promise<string[]> {
+    return this.s.binding.validateResource(this.s.handle, this.res);
+  }
+  validateField(field: string[], value: unknown): Promise<void> {
+    return this.s.binding.validateField(this.s.handle, this.res, field, value);
   }
 
   async id(): Promise<string | undefined> {

--- a/pkg/tcc/clients/js/src/loader.ts
+++ b/pkg/tcc/clients/js/src/loader.ts
@@ -37,6 +37,8 @@ export interface TccGlobal {
   sessionSet(handle: number, resource: string[], field: string[], value: unknown): null | { error: string };
   sessionCompile(handle: number, opts?: CompileOptions): CompileResult | { error: string };
   sessionValidate(handle: number, opts?: CompileOptions): { validations: Validation[] } | { error: string };
+  sessionValidateField(handle: number, resource: string[], field: string[], value: unknown): null | { error: string };
+  sessionValidateResource(handle: number, resource: string[]): { errors: string[] } | { error: string };
   sessionSave(handle: number, fs: SyncFs): null | { error: string };
   // field omitted -> delete the whole resource; field given -> unset that one field.
   sessionDelete(handle: number, resource: string[], field?: string[]): null | { error: string };
@@ -58,6 +60,8 @@ export interface SessionBinding {
   list(handle: number, path: string[]): Promise<string[]>;
   compile(handle: number, opts?: CompileOptions): Promise<CompileResult>;
   validate(handle: number, opts?: CompileOptions): Promise<Validation[]>;
+  validateField(handle: number, resource: string[], field: string[], value: unknown): Promise<void>;
+  validateResource(handle: number, resource: string[]): Promise<string[]>;
   save(handle: number, fs: AsyncFs, dir: string): Promise<void>;
   fork(handle: number): Promise<number>;
   merge(handle: number): Promise<void>;
@@ -89,6 +93,12 @@ export function makeBinding(tcc: TccGlobal): SessionBinding {
     },
     async validate(handle, opts) {
       return orThrow(tcc.sessionValidate(handle, opts)).validations;
+    },
+    async validateField(handle, resource, field, value) {
+      orThrow(tcc.sessionValidateField(handle, resource, field, value));
+    },
+    async validateResource(handle, resource) {
+      return orThrow(tcc.sessionValidateResource(handle, resource)).errors;
     },
     async save(handle, fs, dir) {
       const sync = makeSyncFs();

--- a/pkg/tcc/clients/js/src/loader.ts
+++ b/pkg/tcc/clients/js/src/loader.ts
@@ -39,6 +39,7 @@ export interface TccGlobal {
   sessionValidate(handle: number, opts?: CompileOptions): { validations: Validation[] } | { error: string };
   sessionValidateField(handle: number, resource: string[], field: string[], value: unknown): null | { error: string };
   sessionValidateResource(handle: number, resource: string[]): { errors: string[] } | { error: string };
+  sessionComplete(handle: number, resource: string[], field: string[], partial?: string): string[] | { error: string };
   sessionSave(handle: number, fs: SyncFs): null | { error: string };
   // field omitted -> delete the whole resource; field given -> unset that one field.
   sessionDelete(handle: number, resource: string[], field?: string[]): null | { error: string };
@@ -62,6 +63,7 @@ export interface SessionBinding {
   validate(handle: number, opts?: CompileOptions): Promise<Validation[]>;
   validateField(handle: number, resource: string[], field: string[], value: unknown): Promise<void>;
   validateResource(handle: number, resource: string[]): Promise<string[]>;
+  complete(handle: number, resource: string[], field: string[], partial?: string): Promise<string[]>;
   save(handle: number, fs: AsyncFs, dir: string): Promise<void>;
   fork(handle: number): Promise<number>;
   merge(handle: number): Promise<void>;
@@ -99,6 +101,9 @@ export function makeBinding(tcc: TccGlobal): SessionBinding {
     },
     async validateResource(handle, resource) {
       return orThrow(tcc.sessionValidateResource(handle, resource)).errors;
+    },
+    async complete(handle, resource, field, partial) {
+      return orThrow(tcc.sessionComplete(handle, resource, field, partial));
     },
     async save(handle, fs, dir) {
       const sync = makeSyncFs();

--- a/pkg/tcc/engine/annotate.go
+++ b/pkg/tcc/engine/annotate.go
@@ -18,11 +18,17 @@ func Annotate(key string, val any) Option {
 // the driver (Parse/Format) and tcc-gen (GoType) read, so each scalar's meaning
 // lives in one place instead of a switch in every consumer.
 func Duration(name string, opts ...Option) *Attribute {
-	return String(name, append(opts, Annotate("scalar", ScalarSpec{ID: "duration", GoType: "uint64", Parse: parseDuration, Format: formatDuration}))...)
+	return String(name, append(opts,
+		Annotate("scalar", ScalarSpec{ID: "duration", GoType: "uint64", Parse: parseDuration, Format: formatDuration}),
+		durationValidator(),
+	)...)
 }
 
 func Bytes(name string, opts ...Option) *Attribute {
-	return String(name, append(opts, Annotate("scalar", ScalarSpec{ID: "bytes", GoType: "uint64", Parse: parseBytes, Format: formatBytes}))...)
+	return String(name, append(opts,
+		Annotate("scalar", ScalarSpec{ID: "bytes", GoType: "uint64", Parse: parseBytes, Format: formatBytes}),
+		bytesValidator(),
+	)...)
 }
 
 // Doc attaches a human-readable description to an attribute for schema export

--- a/pkg/tcc/engine/completion.go
+++ b/pkg/tcc/engine/completion.go
@@ -37,10 +37,25 @@ func Completion(root []*Node, group string, field []string) (fc FieldCompletion,
 	return fc, true
 }
 
-// findAttr locates the attribute of a resource group whose authored path — its
-// canonical Path or a legacy Compat alias, the same paths the accessors accept —
-// matches field; nil if not found.
+// findAttr locates the attribute of a resource group addressed by field. It
+// matches an attribute's canonical Path or a legacy Compat alias (the paths the
+// accessors accept), and also a single element of a list field addressed by a
+// trailing numeric index — e.g. ["trigger","domains","0"] resolves to the
+// "trigger/domains" StringSlice, so per-element validation/completion of a list
+// works the same as the whole field. Returns nil for an unknown path.
 func findAttr(root []*Node, group string, field []string) *Attribute {
+	if a := matchAttr(root, group, field); a != nil {
+		return a
+	}
+	if n := len(field); n > 0 && isIndex(field[n-1]) {
+		if a := matchAttr(root, group, field[:n-1]); a != nil && a.Type == TypeStringSlice {
+			return a
+		}
+	}
+	return nil
+}
+
+func matchAttr(root []*Node, group string, field []string) *Attribute {
 	for _, g := range root {
 		name, _ := g.Match.(string)
 		if name != group || len(g.Children) == 0 {
@@ -53,4 +68,16 @@ func findAttr(root []*Node, group string, field []string) *Attribute {
 		}
 	}
 	return nil
+}
+
+func isIndex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/tcc/engine/completion.go
+++ b/pkg/tcc/engine/completion.go
@@ -36,8 +36,9 @@ func Completion(root []*Node, group string, field []string) FieldCompletion {
 	return fc
 }
 
-// findAttr locates the attribute of a resource group whose authored path matches
-// field; nil if not found.
+// findAttr locates the attribute of a resource group whose authored path — its
+// canonical Path or a legacy Compat alias, the same paths the accessors accept —
+// matches field; nil if not found.
 func findAttr(root []*Node, group string, field []string) *Attribute {
 	for _, g := range root {
 		name, _ := g.Match.(string)
@@ -45,7 +46,7 @@ func findAttr(root []*Node, group string, field []string) *Attribute {
 			continue
 		}
 		for _, a := range g.Children[0].Attributes {
-			if fieldPathEq(fieldPath(a), field) {
+			if fieldPathEq(fieldPath(a), field) || fieldPathEq(compatPath(a), field) {
 				return a
 			}
 		}

--- a/pkg/tcc/engine/completion.go
+++ b/pkg/tcc/engine/completion.go
@@ -1,0 +1,54 @@
+package engine
+
+// Field completion: the DSL-derived candidates for a field's value. Static
+// candidates (enum members, string-shape literals) come straight from the
+// constraint specs; a reference field additionally names a resource group whose
+// in-scope instances are candidates (the caller lists those from the live config,
+// since the DSL can't know them). Same introspection as validation, read the
+// other way: "what may go here" instead of "is this allowed".
+
+// FieldCompletion describes how a field's value can be completed.
+type FieldCompletion struct {
+	Values    []string // fixed candidates: enum members + shape literals (e.g. ".")
+	RefGroup  string   // if non-empty, instances of this resource group are candidates
+	RefPrefix string   // prefix to prepend to each referenced name (e.g. "libraries/")
+}
+
+// Completion returns the completion sources for one field of a resource group.
+// Empty (zero value) when the field has no enumerable candidates (free-form:
+// cid/fqdn/pattern/plain strings).
+func Completion(root []*Node, group string, field []string) FieldCompletion {
+	a := findAttr(root, group, field)
+	if a == nil {
+		return FieldCompletion{}
+	}
+	var fc FieldCompletion
+	if enum, ok := a.Meta["enum"].([]string); ok {
+		fc.Values = append(fc.Values, enum...)
+	}
+	if sh, ok := a.Meta["shape"].(ShapeSpec); ok {
+		fc.Values = append(fc.Values, sh.Literals...)
+	}
+	if ref, ok := a.Meta["ref"].(RefSpec); ok {
+		fc.RefGroup = ref.Group
+		fc.RefPrefix = ref.Prefix
+	}
+	return fc
+}
+
+// findAttr locates the attribute of a resource group whose authored path matches
+// field; nil if not found.
+func findAttr(root []*Node, group string, field []string) *Attribute {
+	for _, g := range root {
+		name, _ := g.Match.(string)
+		if name != group || len(g.Children) == 0 {
+			continue
+		}
+		for _, a := range g.Children[0].Attributes {
+			if fieldPathEq(fieldPath(a), field) {
+				return a
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/tcc/engine/completion.go
+++ b/pkg/tcc/engine/completion.go
@@ -14,15 +14,16 @@ type FieldCompletion struct {
 	RefPrefix string   // prefix to prepend to each referenced name (e.g. "libraries/")
 }
 
-// Completion returns the completion sources for one field of a resource group.
-// Empty (zero value) when the field has no enumerable candidates (free-form:
-// cid/fqdn/pattern/plain strings).
-func Completion(root []*Node, group string, field []string) FieldCompletion {
+// Completion returns the completion sources for one field of a resource group and
+// whether the field is known (an attribute at that path, canonical or compat).
+// found is false for an unknown path so a caller can distinguish "no candidates"
+// (a known free-form field: cid/fqdn/pattern/plain string) from "unknown field".
+func Completion(root []*Node, group string, field []string) (fc FieldCompletion, found bool) {
 	a := findAttr(root, group, field)
 	if a == nil {
-		return FieldCompletion{}
+		return FieldCompletion{}, false
 	}
-	var fc FieldCompletion
+	found = true
 	if enum, ok := a.Meta["enum"].([]string); ok {
 		fc.Values = append(fc.Values, enum...)
 	}
@@ -33,7 +34,7 @@ func Completion(root []*Node, group string, field []string) FieldCompletion {
 		fc.RefGroup = ref.Group
 		fc.RefPrefix = ref.Prefix
 	}
-	return fc
+	return fc, true
 }
 
 // findAttr locates the attribute of a resource group whose authored path — its

--- a/pkg/tcc/engine/partial.go
+++ b/pkg/tcc/engine/partial.go
@@ -1,0 +1,81 @@
+package engine
+
+// Partial validation: run a resource's declared single-value validators (enum,
+// string shape, cid, fqdn, variable-name, minimum, ...) against one field or one
+// resource, WITHOUT a compile. This is the cheap path for live editing (UI, IDE,
+// tau-cli) — O(fields), no whole-config assembly.
+//
+// It deliberately covers only single-value constraints. Cross-element constraints
+// (Ref existence, cross-app scope) need the assembled name->id index and stay a
+// whole-config concern (Compiler.Validate). A caller that wants full coverage runs
+// the field/resource check for instant feedback and a whole-config Validate on save.
+
+// ValidatedField pairs a resource field's authored path with the single-value
+// validator the DSL declared for it.
+type ValidatedField struct {
+	Path     []string
+	Validate AttributeValidator
+}
+
+// ValidatedFields returns every field of resource group `group` in root that
+// carries a single-value validator. Fields at a dynamic (Either/Key) path are
+// skipped — they have no plain authored path a caller can address.
+func ValidatedFields(root []*Node, group string) []ValidatedField {
+	var out []ValidatedField
+	for _, g := range root {
+		name, _ := g.Match.(string)
+		if name != group || len(g.Children) == 0 {
+			continue
+		}
+		for _, a := range g.Children[0].Attributes {
+			if a.Validator == nil {
+				continue
+			}
+			if p := fieldPath(a); p != nil {
+				out = append(out, ValidatedField{Path: p, Validate: a.Validator})
+			}
+		}
+	}
+	return out
+}
+
+// ValidateField runs the single-value validator for one field (by authored path)
+// of a resource group against value. Returns nil when the field has no validator
+// or isn't found (unknown/dynamic paths are permissive).
+func ValidateField(root []*Node, group string, field []string, value any) error {
+	for _, vf := range ValidatedFields(root, group) {
+		if fieldPathEq(vf.Path, field) {
+			return vf.Validate(value)
+		}
+	}
+	return nil
+}
+
+// fieldPath is an attribute's plain authored path (its Path, or its bare name);
+// nil if any segment is dynamic (Either/All).
+func fieldPath(a *Attribute) []string {
+	if len(a.Path) == 0 {
+		return []string{a.Name}
+	}
+	out := make([]string, 0, len(a.Path))
+	for _, p := range a.Path {
+		s, ok := p.(string)
+		if !ok {
+			return nil
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func fieldPathEq(a, b []string) bool {
+	if a == nil || len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/tcc/engine/partial.go
+++ b/pkg/tcc/engine/partial.go
@@ -1,5 +1,10 @@
 package engine
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Partial validation: run a resource's declared single-value validators (enum,
 // string shape, cid, fqdn, variable-name, minimum, ...) against one field or one
 // resource, WITHOUT a compile. This is the cheap path for live editing (UI, IDE,
@@ -65,15 +70,24 @@ func CheckFields(root []*Node, group string) [][]string {
 }
 
 // ValidateField runs the single-value validator for one field (by authored path)
-// of a resource group against value. Returns nil when the field has no validator
-// or isn't found (unknown/dynamic paths are permissive).
+// of a resource group against value. It distinguishes three outcomes so a caller
+// can tell "valid" from "not recognized":
+//   - the field is unknown (no attribute at that plain path) -> an "unknown field"
+//     error, so a typo'd path isn't silently reported as OK;
+//   - the field is known but carries no single-value validator -> nil (valid,
+//     unconstrained);
+//   - the field has a validator -> its result.
+//
+// Fields at a dynamic (Either/Key) path have no plain path and read as unknown.
 func ValidateField(root []*Node, group string, field []string, value any) error {
-	for _, vf := range ValidatedFields(root, group) {
-		if fieldPathEq(vf.Path, field) {
-			return vf.Validate(value)
-		}
+	a := findAttr(root, group, field)
+	if a == nil {
+		return fmt.Errorf("unknown field %q on %q", strings.Join(field, "/"), group)
 	}
-	return nil
+	if a.Validator == nil {
+		return nil
+	}
+	return a.Validator(value)
 }
 
 // fieldPath is an attribute's plain authored path (its Path, or its bare name);

--- a/pkg/tcc/engine/partial.go
+++ b/pkg/tcc/engine/partial.go
@@ -39,6 +39,31 @@ func ValidatedFields(root []*Node, group string) []ValidatedField {
 	return out
 }
 
+// CheckFields returns the authored paths of every field of a resource group that
+// carries a partial-checkable constraint — a single-value validator OR a reference
+// (dynamic Either/Key paths are skipped). It is what a per-resource partial
+// validation iterates: the single-value ones are validated directly, the reference
+// ones are checked for existence against the config's in-scope resources.
+func CheckFields(root []*Node, group string) [][]string {
+	var out [][]string
+	for _, g := range root {
+		name, _ := g.Match.(string)
+		if name != group || len(g.Children) == 0 {
+			continue
+		}
+		for _, a := range g.Children[0].Attributes {
+			_, hasRef := a.Meta["ref"].(RefSpec)
+			if a.Validator == nil && !hasRef {
+				continue
+			}
+			if p := fieldPath(a); p != nil {
+				out = append(out, p)
+			}
+		}
+	}
+	return out
+}
+
 // ValidateField runs the single-value validator for one field (by authored path)
 // of a resource group against value. Returns nil when the field has no validator
 // or isn't found (unknown/dynamic paths are permissive).

--- a/pkg/tcc/engine/partial.go
+++ b/pkg/tcc/engine/partial.go
@@ -96,8 +96,21 @@ func fieldPath(a *Attribute) []string {
 	if len(a.Path) == 0 {
 		return []string{a.Name}
 	}
-	out := make([]string, 0, len(a.Path))
-	for _, p := range a.Path {
+	return plainStrings(a.Path)
+}
+
+// compatPath is an attribute's plain legacy-alias path (Compat), which the
+// accessors accept as a read fallback; nil if none or dynamic.
+func compatPath(a *Attribute) []string {
+	if len(a.Compat) == 0 {
+		return nil
+	}
+	return plainStrings(a.Compat)
+}
+
+func plainStrings(path []StringMatch) []string {
+	out := make([]string, 0, len(path))
+	for _, p := range path {
 		s, ok := p.(string)
 		if !ok {
 			return nil

--- a/pkg/tcc/engine/partial_test.go
+++ b/pkg/tcc/engine/partial_test.go
@@ -22,15 +22,16 @@ func TestValidateField(t *testing.T) {
 	if err := ValidateField(root, "widgets", []string{"spec", "kind"}, "z"); err == nil {
 		t.Error("invalid enum value should fail")
 	}
-	// no validator on note, and unknown fields, are permissive
+	// a known field with no validator is valid (unconstrained), not an error
 	if err := ValidateField(root, "widgets", []string{"note"}, "anything"); err != nil {
-		t.Errorf("unvalidated field should pass: %v", err)
+		t.Errorf("unvalidated known field should pass: %v", err)
 	}
-	if err := ValidateField(root, "widgets", []string{"nope"}, "x"); err != nil {
-		t.Errorf("unknown field should be permissive: %v", err)
+	// but an unknown field path / group is reported as unknown, not silently OK
+	if err := ValidateField(root, "widgets", []string{"nope"}, "x"); err == nil {
+		t.Error("unknown field should error")
 	}
-	if err := ValidateField(root, "ghost", []string{"kind"}, "z"); err != nil {
-		t.Errorf("unknown group should be permissive: %v", err)
+	if err := ValidateField(root, "ghost", []string{"kind"}, "z"); err == nil {
+		t.Error("unknown group should error")
 	}
 }
 

--- a/pkg/tcc/engine/partial_test.go
+++ b/pkg/tcc/engine/partial_test.go
@@ -1,0 +1,48 @@
+package engine
+
+import "testing"
+
+// A tiny DSL: one resource "widgets" with an enum field kind and a plain field
+// note (no validator).
+func partialRoot() []*Node {
+	return []*Node{
+		DefineGroup("widgets", DefineIter([]*Attribute{
+			String("kind", Path("spec", "kind"), InSet("a", "b", "c")),
+			String("note"),
+		})),
+	}
+}
+
+func TestValidateField(t *testing.T) {
+	root := partialRoot()
+
+	if err := ValidateField(root, "widgets", []string{"spec", "kind"}, "b"); err != nil {
+		t.Errorf("valid enum value should pass: %v", err)
+	}
+	if err := ValidateField(root, "widgets", []string{"spec", "kind"}, "z"); err == nil {
+		t.Error("invalid enum value should fail")
+	}
+	// no validator on note, and unknown fields, are permissive
+	if err := ValidateField(root, "widgets", []string{"note"}, "anything"); err != nil {
+		t.Errorf("unvalidated field should pass: %v", err)
+	}
+	if err := ValidateField(root, "widgets", []string{"nope"}, "x"); err != nil {
+		t.Errorf("unknown field should be permissive: %v", err)
+	}
+	if err := ValidateField(root, "ghost", []string{"kind"}, "z"); err != nil {
+		t.Errorf("unknown group should be permissive: %v", err)
+	}
+}
+
+func TestValidatedFields(t *testing.T) {
+	got := ValidatedFields(partialRoot(), "widgets")
+	if len(got) != 1 {
+		t.Fatalf("want 1 validated field (kind), got %d", len(got))
+	}
+	if len(got[0].Path) != 2 || got[0].Path[0] != "spec" || got[0].Path[1] != "kind" {
+		t.Errorf("unexpected path %v", got[0].Path)
+	}
+	if got[0].Validate("z") == nil {
+		t.Error("returned validator should reject an out-of-set value")
+	}
+}

--- a/pkg/tcc/engine/scalar.go
+++ b/pkg/tcc/engine/scalar.go
@@ -25,6 +25,28 @@ type ScalarSpec struct {
 // parseDuration parses a duration string from field and sets it as nanoseconds.
 // A missing or nil field is a no-op (nil error); a non-string or unparsable value
 // is a wrapped error.
+// durationValidator / bytesValidator are load-time validators for the authored
+// scalar strings, so partial (per-field) validation can flag a malformed "20x" /
+// "banana" as the user types — not only at compile. The wire conversion still
+// happens in Parse; these just reject an unparseable string early, with file:line.
+func durationValidator() Option {
+	return Validator(func(s string) error {
+		if _, err := time.ParseDuration(s); err != nil {
+			return fmt.Errorf("invalid duration %q: %w", s, err)
+		}
+		return nil
+	})
+}
+
+func bytesValidator() Option {
+	return Validator(func(s string) error {
+		if _, err := units.ParseStrictBytes(s); err != nil {
+			return fmt.Errorf("invalid size %q: %w", s, err)
+		}
+		return nil
+	})
+}
+
 func parseDuration(sel object.Selector[object.Refrence], field string) error {
 	timeout, err := sel.Get(field)
 	if err != nil {

--- a/pkg/tcc/session/session.go
+++ b/pkg/tcc/session/session.go
@@ -25,6 +25,23 @@ import (
 // imports schema, keeping the dependency one-way.
 type CompilerFor func(fs afero.Fs, branch, cloud string) (*interp.Compiler, error)
 
+// FieldValidator runs a DSL's declared single-value field validators (enum, string
+// shape, cid, fqdn, ...) for partial validation — no compile. Injected by the
+// binding, since the session core is DSL-agnostic.
+type FieldValidator interface {
+	// ValidateField runs one field's validator; nil if the field has none.
+	ValidateField(group string, field []string, value any) error
+	// Fields returns the authored paths of a resource group's validated fields.
+	Fields(group string) [][]string
+}
+
+// Bindings wires a Session to a specific DSL: how to compile it (required) and how
+// to partial-validate its fields (optional).
+type Bindings struct {
+	CompilerFor    CompilerFor
+	FieldValidator FieldValidator
+}
+
 // CompileOptions are the per-compile parameters (empty Branch uses the compiler's
 // default).
 type CompileOptions struct {
@@ -35,32 +52,32 @@ type CompileOptions struct {
 // Session is an editable configuration, resident on a private in-memory
 // filesystem. Not safe for concurrent use.
 type Session struct {
-	fs          afero.Fs
-	seer        *yaseer.Seer
-	compilerFor CompilerFor
-	parent      *Session // non-nil for a fork (see Fork/Merge)
+	fs     afero.Fs
+	seer   *yaseer.Seer
+	bind   Bindings
+	parent *Session // non-nil for a fork (see Fork/Merge)
 }
 
 // New stages the config under dir in src into a private in-memory copy and opens
-// an editable session over it. compilerFor binds compilation (see the schema
-// package's NewSession).
-func New(src afero.Fs, dir string, compilerFor CompilerFor) (*Session, error) {
+// an editable session over it. bind wires the DSL (see the schema package's
+// NewSession).
+func New(src afero.Fs, dir string, bind Bindings) (*Session, error) {
 	mem := afero.NewMemMapFs()
 	if err := copyTree(src, dir, mem, "/"); err != nil {
 		return nil, err
 	}
-	return Adopt(mem, compilerFor)
+	return Adopt(mem, bind)
 }
 
 // Adopt opens a session directly over fs (no copy) — for callers that already own
 // a private filesystem (e.g. a freshly decompiled config). The session then owns
 // fs; don't mutate it behind the session's back.
-func Adopt(fs afero.Fs, compilerFor CompilerFor) (*Session, error) {
+func Adopt(fs afero.Fs, bind Bindings) (*Session, error) {
 	sr, err := yaseer.New(yaseer.VirtualFS(fs, "/"))
 	if err != nil {
 		return nil, err
 	}
-	return &Session{fs: fs, seer: sr, compilerFor: compilerFor}, nil
+	return &Session{fs: fs, seer: sr, bind: bind}, nil
 }
 
 // FS exposes the session's working filesystem (read-only intent; for compilers /
@@ -139,7 +156,50 @@ func (s *Session) compiler(opts CompileOptions) (*interp.Compiler, error) {
 	if err := s.seer.Sync(); err != nil {
 		return nil, err
 	}
-	return s.compilerFor(s.fs, opts.Branch, opts.Cloud)
+	return s.bind.CompilerFor(s.fs, opts.Branch, opts.Cloud)
+}
+
+// ValidateField runs the DSL's single-value validator for one field of a resource
+// against value (enum, string shape, cid, fqdn, ...) WITHOUT compiling — the cheap
+// live-edit path. It does not check cross-element constraints (refs, cross-app
+// scope); those need a whole-config Validate. Returns nil when partial validation
+// isn't wired or the field has no validator.
+func (s *Session) ValidateField(res, field []string, value any) error {
+	if s.bind.FieldValidator == nil {
+		return nil
+	}
+	return s.bind.FieldValidator.ValidateField(resGroup(res), field, value)
+}
+
+// ValidateResource runs every single-value validator of one resource against its
+// current values, returning all failures (empty slice = locally valid). Scoped to
+// the one file and compile-free; cross-element refs still need a whole-config
+// Validate.
+func (s *Session) ValidateResource(res []string) []error {
+	if s.bind.FieldValidator == nil {
+		return nil
+	}
+	group := resGroup(res)
+	var errs []error
+	for _, f := range s.bind.FieldValidator.Fields(group) {
+		v, err := s.Get(res, f)
+		if err != nil {
+			continue // field absent -> nothing to validate
+		}
+		if e := s.bind.FieldValidator.ValidateField(group, f, v); e != nil {
+			errs = append(errs, e)
+		}
+	}
+	return errs
+}
+
+// resGroup is the resource-kind name in a resource path: res[len-2] — the folder
+// above the instance name, whether or not the path is application-scoped.
+func resGroup(res []string) string {
+	if len(res) < 2 {
+		return ""
+	}
+	return res[len(res)-2]
 }
 
 // Save flushes the session and writes its config out under dir in dst.
@@ -165,7 +225,7 @@ func (s *Session) Fork() (*Session, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Session{fs: cow, seer: sr, compilerFor: s.compilerFor, parent: s}, nil
+	return &Session{fs: cow, seer: sr, bind: s.bind, parent: s}, nil
 }
 
 // Merge replays the fork's in-memory op-log onto the parent seer — no file

--- a/pkg/tcc/session/session.go
+++ b/pkg/tcc/session/session.go
@@ -11,6 +11,7 @@ package session
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -169,34 +170,89 @@ func (s *Session) compiler(opts CompileOptions) (*interp.Compiler, error) {
 	return s.bind.CompilerFor(s.fs, opts.Branch, opts.Cloud)
 }
 
-// ValidateField runs the DSL's single-value validator for one field of a resource
-// against value (enum, string shape, cid, fqdn, ...) WITHOUT compiling — the cheap
-// live-edit path. It does not check cross-element constraints (refs, cross-app
-// scope); those need a whole-config Validate. Returns nil when partial validation
-// isn't wired or the field has no validator.
+// ValidateField checks one field of a resource against value WITHOUT compiling —
+// the cheap live-edit path. It runs the DSL's single-value validator (enum, string
+// shape, cid, fqdn, ...) AND, for a reference field, that the value names a
+// resource that actually exists IN SCOPE (the resource's own app + root/global —
+// the same scope the compiler resolves against, so siblings don't count). Returns
+// nil when partial validation isn't wired or the field carries no constraint.
 func (s *Session) ValidateField(res, field []string, value any) error {
-	if s.bind.FieldValidator == nil {
-		return nil
+	group := resGroup(res)
+	if s.bind.FieldValidator != nil {
+		if err := s.bind.FieldValidator.ValidateField(group, field, value); err != nil {
+			return err
+		}
 	}
-	return s.bind.FieldValidator.ValidateField(resGroup(res), field, value)
+	if s.bind.Completer != nil {
+		if _, refGroup, refPrefix := s.bind.Completer.Field(group, field); refGroup != "" {
+			if err := s.checkRef(res, refGroup, refPrefix, value); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
-// ValidateResource runs every single-value validator of one resource against its
-// current values, returning all failures (empty slice = locally valid). Scoped to
-// the one file and compile-free; cross-element refs still need a whole-config
-// Validate.
+// checkRef verifies that every referenced name in value names a refGroup resource
+// visible from res (its app + root). Values that don't carry the ref prefix are
+// literals (e.g. a source of ".") and are left to the shape validator.
+func (s *Session) checkRef(res []string, refGroup, refPrefix string, value any) error {
+	inScope := map[string]bool{}
+	for _, n := range s.scopedNames(res, refGroup) {
+		inScope[n] = true
+	}
+	for _, v := range asStrings(value) {
+		name := v
+		if refPrefix != "" {
+			if !strings.HasPrefix(v, refPrefix) {
+				continue // a literal, not a reference
+			}
+			name = strings.TrimPrefix(v, refPrefix)
+		}
+		if name == "" {
+			continue
+		}
+		if !inScope[name] {
+			return fmt.Errorf("no %s named %q in scope", refGroup, name)
+		}
+	}
+	return nil
+}
+
+func asStrings(v any) []string {
+	switch t := v.(type) {
+	case string:
+		return []string{t}
+	case []string:
+		return t
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			if s, ok := e.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// ValidateResource checks every constrained field of one resource against its
+// current values — single-value validators and reference existence — returning all
+// failures (empty slice = valid). Scoped to the one file and compile-free. It does
+// not run whole-config concerns beyond references (e.g. deferred external checks);
+// those stay in Validate.
 func (s *Session) ValidateResource(res []string) []error {
 	if s.bind.FieldValidator == nil {
 		return nil
 	}
-	group := resGroup(res)
 	var errs []error
-	for _, f := range s.bind.FieldValidator.Fields(group) {
+	for _, f := range s.bind.FieldValidator.Fields(resGroup(res)) {
 		v, err := s.Get(res, f)
 		if err != nil {
 			continue // field absent -> nothing to validate
 		}
-		if e := s.bind.FieldValidator.ValidateField(group, f, v); e != nil {
+		if e := s.ValidateField(res, f, v); e != nil {
 			errs = append(errs, e)
 		}
 	}

--- a/pkg/tcc/session/session.go
+++ b/pkg/tcc/session/session.go
@@ -35,11 +35,21 @@ type FieldValidator interface {
 	Fields(group string) [][]string
 }
 
-// Bindings wires a Session to a specific DSL: how to compile it (required) and how
-// to partial-validate its fields (optional).
+// Completer supplies a DSL's field completion sources: the fixed candidates (enum
+// members, shape literals) and, for a reference field, the resource group whose
+// in-scope instances are candidates. Injected by the binding.
+type Completer interface {
+	// Field returns a field's fixed candidates and, if it references a resource
+	// group, that group + the prefix to prepend to each referenced name.
+	Field(group string, field []string) (values []string, refGroup, refPrefix string)
+}
+
+// Bindings wires a Session to a specific DSL: how to compile it (required), how to
+// partial-validate its fields, and how to complete field values (both optional).
 type Bindings struct {
 	CompilerFor    CompilerFor
 	FieldValidator FieldValidator
+	Completer      Completer
 }
 
 // CompileOptions are the per-compile parameters (empty Branch uses the compiler's
@@ -200,6 +210,63 @@ func resGroup(res []string) string {
 		return ""
 	}
 	return res[len(res)-2]
+}
+
+// Complete returns completion candidates for a field's value, filtered by the
+// partial string the user has typed (case-insensitive prefix; "" = all). Fixed
+// candidates come from the DSL (enum members, shape literals); reference fields
+// also offer the target group's instances IN SCOPE (the resource's own app plus
+// root/global), each prefixed. Returns nil if completion isn't wired.
+func (s *Session) Complete(res, field []string, partial string) []string {
+	if s.bind.Completer == nil {
+		return nil
+	}
+	values, refGroup, refPrefix := s.bind.Completer.Field(resGroup(res), field)
+	cands := append([]string(nil), values...)
+	if refGroup != "" {
+		for _, name := range s.scopedNames(res, refGroup) {
+			cands = append(cands, refPrefix+name)
+		}
+	}
+	return filterPrefix(cands, partial)
+}
+
+// scopedNames lists the instances of refGroup visible from res: its own
+// application scope (if application-scoped) then root/global, deduped.
+func (s *Session) scopedNames(res []string, refGroup string) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(path []string) {
+		names, err := s.List(path)
+		if err != nil {
+			return
+		}
+		for _, n := range names {
+			if !seen[n] {
+				seen[n] = true
+				out = append(out, n)
+			}
+		}
+	}
+	if len(res) >= 4 { // [container, app, group, name] -> the app's own scope
+		add([]string{res[0], res[1], refGroup})
+	}
+	add([]string{refGroup}) // root/global
+	return out
+}
+
+func filterPrefix(cands []string, partial string) []string {
+	if partial == "" {
+		return cands
+	}
+	p := strings.ToLower(partial)
+	out := make([]string, 0, len(cands))
+	for _, c := range cands {
+		if strings.HasPrefix(strings.ToLower(c), p) {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 // Save flushes the session and writes its config out under dir in dst.

--- a/pkg/tcc/session/session.go
+++ b/pkg/tcc/session/session.go
@@ -41,8 +41,9 @@ type FieldValidator interface {
 // in-scope instances are candidates. Injected by the binding.
 type Completer interface {
 	// Field returns a field's fixed candidates and, if it references a resource
-	// group, that group + the prefix to prepend to each referenced name.
-	Field(group string, field []string) (values []string, refGroup, refPrefix string)
+	// group, that group + the prefix to prepend to each referenced name. found is
+	// false when the field is unknown (no such attribute path).
+	Field(group string, field []string) (values []string, refGroup, refPrefix string, found bool)
 }
 
 // Bindings wires a Session to a specific DSL: how to compile it (required), how to
@@ -184,7 +185,7 @@ func (s *Session) ValidateField(res, field []string, value any) error {
 		}
 	}
 	if s.bind.Completer != nil {
-		if _, refGroup, refPrefix := s.bind.Completer.Field(group, field); refGroup != "" {
+		if _, refGroup, refPrefix, _ := s.bind.Completer.Field(group, field); refGroup != "" {
 			if err := s.checkRef(res, refGroup, refPrefix, value); err != nil {
 				return err
 			}
@@ -272,19 +273,25 @@ func resGroup(res []string) string {
 // partial string the user has typed (case-insensitive prefix; "" = all). Fixed
 // candidates come from the DSL (enum members, shape literals); reference fields
 // also offer the target group's instances IN SCOPE (the resource's own app plus
-// root/global), each prefixed. Returns nil if completion isn't wired.
-func (s *Session) Complete(res, field []string, partial string) []string {
+// root/global), each prefixed. An unknown field path is an error (so a typo isn't
+// mistaken for "no suggestions"); a known field with no candidates returns an
+// empty slice. Returns (nil, nil) if completion isn't wired.
+func (s *Session) Complete(res, field []string, partial string) ([]string, error) {
 	if s.bind.Completer == nil {
-		return nil
+		return nil, nil
 	}
-	values, refGroup, refPrefix := s.bind.Completer.Field(resGroup(res), field)
+	group := resGroup(res)
+	values, refGroup, refPrefix, found := s.bind.Completer.Field(group, field)
+	if !found {
+		return nil, fmt.Errorf("unknown field %q on %q", strings.Join(field, "/"), group)
+	}
 	cands := append([]string(nil), values...)
 	if refGroup != "" {
 		for _, name := range s.scopedNames(res, refGroup) {
 			cands = append(cands, refPrefix+name)
 		}
 	}
-	return filterPrefix(cands, partial)
+	return filterPrefix(cands, partial), nil
 }
 
 // scopedNames lists the instances of refGroup visible from res: its own

--- a/pkg/tcc/session/session_test.go
+++ b/pkg/tcc/session/session_test.go
@@ -29,7 +29,7 @@ func TestSessionForkMerge(t *testing.T) {
 	assert.NilError(t, afero.WriteFile(src, "/functions/foo.yaml", []byte("id: fooid\n"), 0o644))
 	assert.NilError(t, afero.WriteFile(src, "/functions/bar.yaml", []byte("id: barid\n"), 0o644))
 
-	parent, err := New(src, "/", noCompiler)
+	parent, err := New(src, "/", Bindings{CompilerFor: noCompiler})
 	assert.NilError(t, err)
 
 	fork, err := parent.Fork()

--- a/pkg/tcc/taubyte/v1/schema/session.go
+++ b/pkg/tcc/taubyte/v1/schema/session.go
@@ -58,12 +58,10 @@ func (taubyteFieldValidator) ValidateField(group string, field []string, value a
 }
 
 func (taubyteFieldValidator) Fields(group string) [][]string {
-	vfs := engine.ValidatedFields(GenerationRoot(), group)
-	out := make([][]string, len(vfs))
-	for i, vf := range vfs {
-		out[i] = vf.Path
-	}
-	return out
+	// Every partial-checkable field — single-value validators AND references —
+	// so per-resource validation covers both (the session checks reference
+	// existence against the in-scope config).
+	return engine.CheckFields(GenerationRoot(), group)
 }
 
 // ValidateField runs this DSL's single-value validator for one field of a resource

--- a/pkg/tcc/taubyte/v1/schema/session.go
+++ b/pkg/tcc/taubyte/v1/schema/session.go
@@ -19,6 +19,7 @@ type (
 var bindings = session.Bindings{
 	CompilerFor:    taubyteCompilerFor,
 	FieldValidator: taubyteFieldValidator{},
+	Completer:      taubyteCompleter{},
 }
 
 // NewSession opens an editable session over the config under dir in fs, bound to
@@ -70,4 +71,13 @@ func (taubyteFieldValidator) Fields(group string) [][]string {
 // validation semantics as Session.ValidateField.
 func ValidateField(group string, field []string, value any) error {
 	return engine.ValidateField(GenerationRoot(), group, field, value)
+}
+
+// taubyteCompleter supplies this DSL's field completion sources (enum members,
+// shape literals, and reference-group descriptors) from the live schema.
+type taubyteCompleter struct{}
+
+func (taubyteCompleter) Field(group string, field []string) (values []string, refGroup, refPrefix string) {
+	fc := engine.Completion(GenerationRoot(), group, field)
+	return fc.Values, fc.RefGroup, fc.RefPrefix
 }

--- a/pkg/tcc/taubyte/v1/schema/session.go
+++ b/pkg/tcc/taubyte/v1/schema/session.go
@@ -75,7 +75,7 @@ func ValidateField(group string, field []string, value any) error {
 // shape literals, and reference-group descriptors) from the live schema.
 type taubyteCompleter struct{}
 
-func (taubyteCompleter) Field(group string, field []string) (values []string, refGroup, refPrefix string) {
-	fc := engine.Completion(GenerationRoot(), group, field)
-	return fc.Values, fc.RefGroup, fc.RefPrefix
+func (taubyteCompleter) Field(group string, field []string) (values []string, refGroup, refPrefix string, found bool) {
+	fc, found := engine.Completion(GenerationRoot(), group, field)
+	return fc.Values, fc.RefGroup, fc.RefPrefix, found
 }

--- a/pkg/tcc/taubyte/v1/schema/session.go
+++ b/pkg/tcc/taubyte/v1/schema/session.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"github.com/spf13/afero"
+	"github.com/taubyte/tau/pkg/tcc/engine"
 	"github.com/taubyte/tau/pkg/tcc/interp"
 	"github.com/taubyte/tau/pkg/tcc/session"
 )
@@ -13,18 +14,26 @@ type (
 	CompileOptions = session.CompileOptions
 )
 
-// NewSession opens an editable session over the config under dir in fs, bound to
-// THIS DSL's compiler. Edit via Get/Set/Delete/List, Validate/Compile the whole
-// config, and Fork/Merge to validate speculative edits before adopting them —
-// same abstraction the browser wasm exposes.
-func NewSession(fs afero.Fs, dir string) (*Session, error) {
-	return session.New(fs, dir, taubyteCompilerFor)
+// bindings wires the generic session to THIS DSL: its compiler (whole-config) and
+// its single-value field validators (partial, compile-free, for live editing).
+var bindings = session.Bindings{
+	CompilerFor:    taubyteCompilerFor,
+	FieldValidator: taubyteFieldValidator{},
 }
 
-// AdoptSession opens a session directly over fs (no copy), bound to this DSL's
-// compiler — for callers that already own a private filesystem.
+// NewSession opens an editable session over the config under dir in fs, bound to
+// THIS DSL. Edit via Get/Set/Delete/List; Validate/Compile the whole config;
+// ValidateField/ValidateResource for cheap per-field / per-file checks; Fork/Merge
+// to validate speculative edits before adopting them — same abstraction the
+// browser wasm exposes.
+func NewSession(fs afero.Fs, dir string) (*Session, error) {
+	return session.New(fs, dir, bindings)
+}
+
+// AdoptSession opens a session directly over fs (no copy), bound to this DSL — for
+// callers that already own a private filesystem.
 func AdoptSession(fs afero.Fs) (*Session, error) {
-	return session.Adopt(fs, taubyteCompilerFor)
+	return session.Adopt(fs, bindings)
 }
 
 // taubyteCompilerFor binds the generic session to this DSL's compiler.
@@ -37,4 +46,28 @@ func taubyteCompilerFor(fs afero.Fs, branch, cloud string) (*interp.Compiler, er
 		opts = append(opts, WithCloud(cloud))
 	}
 	return New(opts...)
+}
+
+// taubyteFieldValidator runs this DSL's single-value field validators against the
+// live schema — the same checks the compiler runs at load, without compiling.
+type taubyteFieldValidator struct{}
+
+func (taubyteFieldValidator) ValidateField(group string, field []string, value any) error {
+	return engine.ValidateField(GenerationRoot(), group, field, value)
+}
+
+func (taubyteFieldValidator) Fields(group string) [][]string {
+	vfs := engine.ValidatedFields(GenerationRoot(), group)
+	out := make([][]string, len(vfs))
+	for i, vf := range vfs {
+		out[i] = vf.Path
+	}
+	return out
+}
+
+// ValidateField runs this DSL's single-value validator for one field of a resource
+// group, without a session — for direct callers (e.g. tau-cli). Same partial-
+// validation semantics as Session.ValidateField.
+func ValidateField(group string, field []string, value any) error {
+	return engine.ValidateField(GenerationRoot(), group, field, value)
 }

--- a/pkg/tcc/taubyte/v1/schema/session_test.go
+++ b/pkg/tcc/taubyte/v1/schema/session_test.go
@@ -67,6 +67,14 @@ func TestSession(t *testing.T) {
 		assert.ErrorContains(t, s.ValidateField(fn, []string{"execution", "timeout"}, "20x"), "invalid duration")
 		assert.NilError(t, s.ValidateField(fn, []string{"execution", "memory"}, "32GB"))
 		assert.ErrorContains(t, s.ValidateField(fn, []string{"execution", "memory"}, "banana"), "invalid size")
+
+		// a legacy Compat alias the accessors accept is recognized too — not
+		// "unknown" — and its reference is still checked. "domains" is the compat
+		// alias of the canonical "trigger/domains".
+		assert.NilError(t, s.ValidateField(fn, []string{"domains"}, []any{"test_domain1"}))
+		assert.ErrorContains(t, s.ValidateField(fn, []string{"domains"}, []any{"ghost"}), `no domains named "ghost"`)
+		// array-element addressing is still not a field
+		assert.ErrorContains(t, s.ValidateField(fn, []string{"tags", "0"}, "x"), "unknown field")
 	})
 
 	t.Run("partial validation catches bad references in scope, compile-free", func(t *testing.T) {

--- a/pkg/tcc/taubyte/v1/schema/session_test.go
+++ b/pkg/tcc/taubyte/v1/schema/session_test.go
@@ -55,6 +55,25 @@ func TestSession(t *testing.T) {
 		assert.NilError(t, s.Set(fn, []string{"trigger", "type"}, "http"))
 	})
 
+	t.Run("partial validation catches bad references in scope, compile-free", func(t *testing.T) {
+		fn := []string{"functions", "test_function1_glob"} // a root function
+		// a domain that doesn't exist -> flagged (was silent before)
+		assert.ErrorContains(t, s.ValidateField(fn, []string{"trigger", "domains"}, []any{"ghost"}), `no domains named "ghost"`)
+		// an existing global domain -> ok
+		assert.NilError(t, s.ValidateField(fn, []string{"trigger", "domains"}, []any{"test_domain1"}))
+		// a library only defined in test_app1 is out of scope for a root function
+		assert.ErrorContains(t, s.ValidateField(fn, []string{"source"}, "libraries/test_library2"), `no libraries named "test_library2"`)
+		// "." is a literal, not a reference -> ok
+		assert.NilError(t, s.ValidateField(fn, []string{"source"}, "."))
+
+		// resource-level surfaces it too
+		assert.NilError(t, s.Set(fn, []string{"trigger", "domains"}, []any{"ghost"}))
+		errs := s.ValidateResource(fn)
+		assert.Assert(t, len(errs) == 1)
+		assert.ErrorContains(t, errs[0], `no domains named "ghost"`)
+		assert.NilError(t, s.Set(fn, []string{"trigger", "domains"}, []any{"test_domain1"})) // undo
+	})
+
 	t.Run("completion: enum members and scoped references, filtered by the partial", func(t *testing.T) {
 		fn := []string{"functions", "test_function1_glob"} // a root function
 

--- a/pkg/tcc/taubyte/v1/schema/session_test.go
+++ b/pkg/tcc/taubyte/v1/schema/session_test.go
@@ -73,8 +73,22 @@ func TestSession(t *testing.T) {
 		// alias of the canonical "trigger/domains".
 		assert.NilError(t, s.ValidateField(fn, []string{"domains"}, []any{"test_domain1"}))
 		assert.ErrorContains(t, s.ValidateField(fn, []string{"domains"}, []any{"ghost"}), `no domains named "ghost"`)
-		// array-element addressing is still not a field
-		assert.ErrorContains(t, s.ValidateField(fn, []string{"tags", "0"}, "x"), "unknown field")
+		// a list element is addressable by index — valid for a free-form list, but a
+		// genuinely unknown path still errors
+		assert.NilError(t, s.ValidateField(fn, []string{"tags", "0"}, "anything"))
+		assert.ErrorContains(t, s.ValidateField(fn, []string{"trigger", "foo"}, "x"), "unknown field")
+	})
+
+	t.Run("list elements are addressable by index for validate and complete", func(t *testing.T) {
+		fn := []string{"functions", "test_function1_glob"}
+		elem := []string{"trigger", "domains", "0"} // one element of the domains list
+		// per-element reference validation
+		assert.NilError(t, s.ValidateField(fn, elem, "test_domain1"))
+		assert.ErrorContains(t, s.ValidateField(fn, elem, "ghost"), `no domains named "ghost"`)
+		// per-element completion
+		c, err := s.Complete(fn, elem, "test_")
+		assert.NilError(t, err)
+		assert.DeepEqual(t, c, []string{"test_domain1"})
 	})
 
 	t.Run("partial validation catches bad references in scope, compile-free", func(t *testing.T) {

--- a/pkg/tcc/taubyte/v1/schema/session_test.go
+++ b/pkg/tcc/taubyte/v1/schema/session_test.go
@@ -37,6 +37,23 @@ func TestSession(t *testing.T) {
 		assert.NilError(t, err)
 	})
 
+	t.Run("partial validation is compile-free and scoped", func(t *testing.T) {
+		fn := []string{"functions", "test_function1_glob"}
+		// field-level: enum on trigger.type
+		assert.NilError(t, s.ValidateField(fn, []string{"trigger", "type"}, "https"))
+		assert.ErrorContains(t, s.ValidateField(fn, []string{"trigger", "type"}, "nope"), "invalid value")
+
+		// resource-level: the fixture function is locally valid...
+		assert.Equal(t, len(s.ValidateResource(fn)), 0)
+		// ...set a bad enum, and ValidateResource surfaces it (no compile).
+		assert.NilError(t, s.Set(fn, []string{"trigger", "type"}, "nope"))
+		errs := s.ValidateResource(fn)
+		assert.Equal(t, len(errs), 1)
+		assert.ErrorContains(t, errs[0], "invalid value")
+		// undo
+		assert.NilError(t, s.Set(fn, []string{"trigger", "type"}, "http"))
+	})
+
 	t.Run("fork with a good edit validates and merges", func(t *testing.T) {
 		fork, err := s.Fork()
 		assert.NilError(t, err)

--- a/pkg/tcc/taubyte/v1/schema/session_test.go
+++ b/pkg/tcc/taubyte/v1/schema/session_test.go
@@ -55,6 +55,20 @@ func TestSession(t *testing.T) {
 		assert.NilError(t, s.Set(fn, []string{"trigger", "type"}, "http"))
 	})
 
+	t.Run("partial validation: unknown fields error, scalar formats are checked", func(t *testing.T) {
+		fn := []string{"functions", "test_function1_glob"}
+		// (a) an unknown path is reported as unknown, not silently OK
+		assert.ErrorContains(t, s.ValidateField(fn, []string{"nonexistent"}, "x"), "unknown field")
+		assert.ErrorContains(t, s.ValidateField(fn, []string{"trigger", "typo"}, "x"), "unknown field")
+		// a known field with no constraint is still valid
+		assert.NilError(t, s.ValidateField(fn, []string{"description"}, "anything"))
+		// (b) duration/bytes format is checked per-field, not only at compile
+		assert.NilError(t, s.ValidateField(fn, []string{"execution", "timeout"}, "20s"))
+		assert.ErrorContains(t, s.ValidateField(fn, []string{"execution", "timeout"}, "20x"), "invalid duration")
+		assert.NilError(t, s.ValidateField(fn, []string{"execution", "memory"}, "32GB"))
+		assert.ErrorContains(t, s.ValidateField(fn, []string{"execution", "memory"}, "banana"), "invalid size")
+	})
+
 	t.Run("partial validation catches bad references in scope, compile-free", func(t *testing.T) {
 		fn := []string{"functions", "test_function1_glob"} // a root function
 		// a domain that doesn't exist -> flagged (was silent before)

--- a/pkg/tcc/taubyte/v1/schema/session_test.go
+++ b/pkg/tcc/taubyte/v1/schema/session_test.go
@@ -96,29 +96,41 @@ func TestSession(t *testing.T) {
 		assert.NilError(t, s.Set(fn, []string{"trigger", "domains"}, []any{"test_domain1"})) // undo
 	})
 
+	complete := func(t *testing.T, res, field []string, partial string) []string {
+		t.Helper()
+		c, err := s.Complete(res, field, partial)
+		assert.NilError(t, err)
+		return c
+	}
+
 	t.Run("completion: enum members and scoped references, filtered by the partial", func(t *testing.T) {
 		fn := []string{"functions", "test_function1_glob"} // a root function
 
 		// enum field — partial filters the members
-		all := s.Complete(fn, []string{"trigger", "type"}, "")
+		all := complete(t, fn, []string{"trigger", "type"}, "")
 		assert.Assert(t, slices.Contains(all, "pubsub") && slices.Contains(all, "http"))
-		assert.DeepEqual(t, s.Complete(fn, []string{"trigger", "type"}, "p"), []string{"pubsub", "p2p"})
+		assert.DeepEqual(t, complete(t, fn, []string{"trigger", "type"}, "p"), []string{"pubsub", "p2p"})
 
 		// reference field — the shape literal "." plus in-scope libraries, prefixed.
 		// Root scope sees the global library test_library1 (not app1's test_library2).
-		src := s.Complete(fn, []string{"source"}, "")
+		src := complete(t, fn, []string{"source"}, "")
 		assert.Assert(t, slices.Contains(src, "."), "source offers the inline literal")
 		assert.Assert(t, slices.Contains(src, "libraries/test_library1"), "source offers the global library")
 		assert.Assert(t, !slices.Contains(src, "libraries/test_library2"), "a root function must not see app1's library")
 
 		// the user's partial narrows it
-		assert.DeepEqual(t, s.Complete(fn, []string{"source"}, "libraries/test_l"), []string{"libraries/test_library1"})
-		assert.DeepEqual(t, s.Complete(fn, []string{"source"}, "."), []string{"."})
+		assert.DeepEqual(t, complete(t, fn, []string{"source"}, "libraries/test_l"), []string{"libraries/test_library1"})
+		assert.DeepEqual(t, complete(t, fn, []string{"source"}, "."), []string{"."})
+
+		// compat alias resolves for completion too, and an unknown path errors
+		assert.DeepEqual(t, complete(t, fn, []string{"domains"}, ""), []string{"test_domain1"})
+		_, err := s.Complete(fn, []string{"nonexistent"}, "")
+		assert.ErrorContains(t, err, "unknown field")
 	})
 
 	t.Run("completion: an app function also sees its own app's libraries", func(t *testing.T) {
 		appFn := []string{"applications", "test_app1", "functions", "test_function2"}
-		src := s.Complete(appFn, []string{"source"}, "libraries/")
+		src := complete(t, appFn, []string{"source"}, "libraries/")
 		assert.Assert(t, slices.Contains(src, "libraries/test_library2"), "app scope sees app1's library")
 		assert.Assert(t, slices.Contains(src, "libraries/test_library1"), "and the global one")
 	})

--- a/pkg/tcc/taubyte/v1/schema/session_test.go
+++ b/pkg/tcc/taubyte/v1/schema/session_test.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"context"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -52,6 +53,33 @@ func TestSession(t *testing.T) {
 		assert.ErrorContains(t, errs[0], "invalid value")
 		// undo
 		assert.NilError(t, s.Set(fn, []string{"trigger", "type"}, "http"))
+	})
+
+	t.Run("completion: enum members and scoped references, filtered by the partial", func(t *testing.T) {
+		fn := []string{"functions", "test_function1_glob"} // a root function
+
+		// enum field — partial filters the members
+		all := s.Complete(fn, []string{"trigger", "type"}, "")
+		assert.Assert(t, slices.Contains(all, "pubsub") && slices.Contains(all, "http"))
+		assert.DeepEqual(t, s.Complete(fn, []string{"trigger", "type"}, "p"), []string{"pubsub", "p2p"})
+
+		// reference field — the shape literal "." plus in-scope libraries, prefixed.
+		// Root scope sees the global library test_library1 (not app1's test_library2).
+		src := s.Complete(fn, []string{"source"}, "")
+		assert.Assert(t, slices.Contains(src, "."), "source offers the inline literal")
+		assert.Assert(t, slices.Contains(src, "libraries/test_library1"), "source offers the global library")
+		assert.Assert(t, !slices.Contains(src, "libraries/test_library2"), "a root function must not see app1's library")
+
+		// the user's partial narrows it
+		assert.DeepEqual(t, s.Complete(fn, []string{"source"}, "libraries/test_l"), []string{"libraries/test_library1"})
+		assert.DeepEqual(t, s.Complete(fn, []string{"source"}, "."), []string{"."})
+	})
+
+	t.Run("completion: an app function also sees its own app's libraries", func(t *testing.T) {
+		appFn := []string{"applications", "test_app1", "functions", "test_function2"}
+		src := s.Complete(appFn, []string{"source"}, "libraries/")
+		assert.Assert(t, slices.Contains(src, "libraries/test_library2"), "app scope sees app1's library")
+		assert.Assert(t, slices.Contains(src, "libraries/test_library1"), "and the global one")
 	})
 
 	t.Run("fork with a good edit validates and merges", func(t *testing.T) {

--- a/pkg/tcc/wasm/main.go
+++ b/pkg/tcc/wasm/main.go
@@ -30,6 +30,8 @@ func main() {
 	tcc.Set("sessionSet", js.FuncOf(sessionSetFn))
 	tcc.Set("sessionCompile", js.FuncOf(sessionCompileFn))
 	tcc.Set("sessionValidate", js.FuncOf(sessionValidateFn))
+	tcc.Set("sessionValidateField", js.FuncOf(sessionValidateFieldFn))
+	tcc.Set("sessionValidateResource", js.FuncOf(sessionValidateResourceFn))
 	tcc.Set("sessionSave", js.FuncOf(sessionSaveFn))
 	tcc.Set("sessionDelete", js.FuncOf(sessionDeleteFn))
 	tcc.Set("sessionList", js.FuncOf(sessionListFn))

--- a/pkg/tcc/wasm/main.go
+++ b/pkg/tcc/wasm/main.go
@@ -32,6 +32,7 @@ func main() {
 	tcc.Set("sessionValidate", js.FuncOf(sessionValidateFn))
 	tcc.Set("sessionValidateField", js.FuncOf(sessionValidateFieldFn))
 	tcc.Set("sessionValidateResource", js.FuncOf(sessionValidateResourceFn))
+	tcc.Set("sessionComplete", js.FuncOf(sessionCompleteFn))
 	tcc.Set("sessionSave", js.FuncOf(sessionSaveFn))
 	tcc.Set("sessionDelete", js.FuncOf(sessionDeleteFn))
 	tcc.Set("sessionList", js.FuncOf(sessionListFn))

--- a/pkg/tcc/wasm/session_js.go
+++ b/pkg/tcc/wasm/session_js.go
@@ -262,7 +262,10 @@ func sessionCompleteFn(_ js.Value, args []js.Value) any {
 	if len(args) > 3 && args[3].Truthy() {
 		partial = args[3].String()
 	}
-	names := s.Complete(res, jsToPath(args[2]), partial)
+	names, err := s.Complete(res, jsToPath(args[2]), partial)
+	if err != nil {
+		return errResult(err.Error())
+	}
 	out := make([]any, len(names))
 	for i, n := range names {
 		out[i] = n

--- a/pkg/tcc/wasm/session_js.go
+++ b/pkg/tcc/wasm/session_js.go
@@ -202,6 +202,48 @@ func sessionValidateFn(_ js.Value, args []js.Value) any {
 	return toJS(map[string]any{"validations": validations})
 }
 
+// validateField(handle, resourcePath[], fieldPath[], value) : run one field's
+// single-value validator (enum/shape/cid/...) with no compile. null | { error }.
+func sessionValidateFieldFn(_ js.Value, args []js.Value) any {
+	s, e := lookup(args)
+	if e != nil {
+		return e
+	}
+	if len(args) < 4 {
+		return errResult("validateField: expected (handle, resourcePath, fieldPath, value)")
+	}
+	res := jsToPath(args[1])
+	if len(res) == 0 {
+		return errResult("validateField: empty resource path")
+	}
+	if err := s.ValidateField(res, jsToPath(args[2]), jsToGo(args[3])); err != nil {
+		return errResult(err.Error())
+	}
+	return js.Null()
+}
+
+// validateResource(handle, resourcePath[]) : run every single-value validator of
+// one resource, no compile. -> { errors: string[] } (empty = locally valid).
+func sessionValidateResourceFn(_ js.Value, args []js.Value) any {
+	s, e := lookup(args)
+	if e != nil {
+		return e
+	}
+	if len(args) < 2 {
+		return errResult("validateResource: expected (handle, resourcePath)")
+	}
+	res := jsToPath(args[1])
+	if len(res) == 0 {
+		return errResult("validateResource: empty resource path")
+	}
+	errs := s.ValidateResource(res)
+	msgs := make([]any, len(errs))
+	for i, er := range errs {
+		msgs[i] = er.Error()
+	}
+	return toJS(map[string]any{"errors": msgs})
+}
+
 // save(handle, fsPrimitives) : flush the session's YAML out to the fs.
 func sessionSaveFn(_ js.Value, args []js.Value) any {
 	s, e := lookup(args)

--- a/pkg/tcc/wasm/session_js.go
+++ b/pkg/tcc/wasm/session_js.go
@@ -244,6 +244,32 @@ func sessionValidateResourceFn(_ js.Value, args []js.Value) any {
 	return toJS(map[string]any{"errors": msgs})
 }
 
+// complete(handle, resourcePath[], fieldPath[], partial?) : completion candidates
+// for a field's value, filtered by the partial the user typed. -> string[].
+func sessionCompleteFn(_ js.Value, args []js.Value) any {
+	s, e := lookup(args)
+	if e != nil {
+		return e
+	}
+	if len(args) < 3 {
+		return errResult("complete: expected (handle, resourcePath, fieldPath, partial?)")
+	}
+	res := jsToPath(args[1])
+	if len(res) == 0 {
+		return errResult("complete: empty resource path")
+	}
+	partial := ""
+	if len(args) > 3 && args[3].Truthy() {
+		partial = args[3].String()
+	}
+	names := s.Complete(res, jsToPath(args[2]), partial)
+	out := make([]any, len(names))
+	for i, n := range names {
+		out[i] = n
+	}
+	return toJS(out)
+}
+
 // save(handle, fsPrimitives) : flush the session's YAML out to the fs.
 func sessionSaveFn(_ js.Value, args []js.Value) any {
 	s, e := lookup(args)

--- a/pkg/tcc/wasm/wasm_test.go
+++ b/pkg/tcc/wasm/wasm_test.go
@@ -276,6 +276,25 @@ func TestSessionForkMergeFn(t *testing.T) {
 	assert.Equal(t, val(sessionGetFn(js.Null(), []js.Value{h, res, arr("description")})).String(), "forked")
 }
 
+// Partial validation through the wasm: field + resource scope, compile-free.
+func TestSessionPartialValidateFn(t *testing.T) {
+	m := loadFixture(t)
+	h := openHandle(t, openSessionFn(js.Null(), []js.Value{m.primitives()}))
+	res := arr("functions", "test_function1_glob")
+
+	// field: good enum passes, bad enum errors
+	assert.Assert(t, val(sessionValidateFieldFn(js.Null(), []js.Value{h, res, arr("trigger", "type"), js.ValueOf("https")})).IsNull())
+	bad := val(sessionValidateFieldFn(js.Null(), []js.Value{h, res, arr("trigger", "type"), js.ValueOf("nope")}))
+	assert.Assert(t, errOf(bad) != "", "bad enum must error")
+
+	// resource: clean fixture -> no errors; after a bad set -> one error
+	r := val(sessionValidateResourceFn(js.Null(), []js.Value{h, res}))
+	assert.Equal(t, r.Get("errors").Length(), 0)
+	val(sessionSetFn(js.Null(), []js.Value{h, res, arr("trigger", "type"), js.ValueOf("nope")}))
+	r = val(sessionValidateResourceFn(js.Null(), []js.Value{h, res}))
+	assert.Equal(t, r.Get("errors").Length(), 1)
+}
+
 func TestSchemaFn(t *testing.T) {
 	r := val(schemaFn(js.Null(), nil))
 	assert.Equal(t, errOf(r), "")

--- a/pkg/tcc/wasm/wasm_test.go
+++ b/pkg/tcc/wasm/wasm_test.go
@@ -295,6 +295,27 @@ func TestSessionPartialValidateFn(t *testing.T) {
 	assert.Equal(t, r.Get("errors").Length(), 1)
 }
 
+// Completion through the wasm: enum members filtered by the partial + scoped refs.
+func TestSessionCompleteFn(t *testing.T) {
+	m := loadFixture(t)
+	h := openHandle(t, openSessionFn(js.Null(), []js.Value{m.primitives()}))
+	res := arr("functions", "test_function1_glob")
+
+	// enum, filtered by "p"
+	e := val(sessionCompleteFn(js.Null(), []js.Value{h, res, arr("trigger", "type"), js.ValueOf("p")}))
+	assert.Equal(t, e.Length(), 2) // pubsub, p2p
+
+	// reference: source offers "." and the in-scope global library, prefixed
+	src := val(sessionCompleteFn(js.Null(), []js.Value{h, res, arr("source"), js.Null()}))
+	found := false
+	for i := 0; i < src.Length(); i++ {
+		if src.Index(i).String() == "libraries/test_library1" {
+			found = true
+		}
+	}
+	assert.Assert(t, found, "source completion should include the global library")
+}
+
 func TestSchemaFn(t *testing.T) {
 	r := val(schemaFn(js.Null(), nil))
 	assert.Equal(t, errOf(r), "")

--- a/pkg/vm/backend/url/backend_test.go
+++ b/pkg/vm/backend/url/backend_test.go
@@ -29,7 +29,7 @@ func TestBackend(t *testing.T) {
 	backend := New()
 	assert.Equal(t, backend.Scheme(), "url")
 
-	httpUrl := "/dns4/get.tau.link/https/path/tau"
+	httpUrl := "/dns4/taubyte.com/https/path/llms.txt"
 	incorrectUris := []string{
 		"/dns4/ping.examples.tau",
 		"/file//tmp/test",
@@ -59,7 +59,7 @@ func TestBackend(t *testing.T) {
 	assert.NilError(t, err)
 
 	var expData bytes.Buffer
-	err = downloadFile("https://get.tau.link/tau", &expData)
+	err = downloadFile("https://taubyte.com/llms.txt", &expData)
 	assert.NilError(t, err)
 
 	assert.DeepEqual(t, data, expData.Bytes())

--- a/tools/tcc-gen/internal/gen/ts.go
+++ b/tools/tcc-gen/internal/gen/ts.go
@@ -231,6 +231,8 @@ func GenerateTS(root []*engine.Node) ([]byte, error) {
 		// field check. Cross-element refs still need Session.validate().
 		fmt.Fprintf(&b, "  validate(): Promise<string[]> {\n    return this.s.binding.validateResource(this.s.handle, this.res);\n  }\n")
 		fmt.Fprintf(&b, "  validateField(field: string[], value: unknown): Promise<void> {\n    return this.s.binding.validateField(this.s.handle, this.res, field, value);\n  }\n")
+		// completion candidates for a field's value, filtered by what the user typed.
+		fmt.Fprintf(&b, "  complete(field: string[], partial?: string): Promise<string[]> {\n    return this.s.binding.complete(this.s.handle, this.res, field, partial);\n  }\n")
 		for _, f := range r.fields {
 			// getter
 			if len(f.compat) == 0 {

--- a/tools/tcc-gen/internal/gen/ts.go
+++ b/tools/tcc-gen/internal/gen/ts.go
@@ -227,6 +227,10 @@ func GenerateTS(root []*engine.Node) ([]byte, error) {
 		fmt.Fprintf(&b, "  private res: string[];\n")
 		fmt.Fprintf(&b, "  constructor(private s: Session, name: string, app?: string) {\n    this.res = app ? [%q, app, %q, name] : [%q, name];\n  }\n", container, r.group, r.group)
 		fmt.Fprintf(&b, "\n  delete(): Promise<void> {\n    return this.s.binding.delete(this.s.handle, this.res);\n  }\n")
+		// Partial validation (compile-free): resource-scoped local checks + a single
+		// field check. Cross-element refs still need Session.validate().
+		fmt.Fprintf(&b, "  validate(): Promise<string[]> {\n    return this.s.binding.validateResource(this.s.handle, this.res);\n  }\n")
+		fmt.Fprintf(&b, "  validateField(field: string[], value: unknown): Promise<void> {\n    return this.s.binding.validateField(this.s.handle, this.res, field, value);\n  }\n")
 		for _, f := range r.fields {
 			// getter
 			if len(f.compat) == 0 {


### PR DESCRIPTION
Live editors (web UI, IDE, tau-cli) need instant per-field feedback without a full whole-config compile. This adds scoped, compile-free validation and completion, plus fixes surfaced by a frontend integration.

## Partial validation
- `engine.ValidateField` / `ValidatedFields` / `CheckFields` (generic); `session.ValidateField(res, field, value)` and `ValidateResource(res)` (returns all local failures). Wired via a new `session.Bindings` (the session core stays DSL-agnostic; `schema.NewSession` injects the Taubyte binding).
- **Reference existence in scope:** a bad/cross-app reference (a non-existent `domains` entry, a missing/out-of-scope `source` library) is caught against the resource's in-scope config (own app + root/global — the same scope the compiler resolves against), no compile.

**Cost (measured, real fixtures):** whole-config `Validate` ≈ 1.1 ms / 885 KB / 13k allocs; `ValidateResource` ≈ 13 µs; a `ValidateField` ≈ 0.3–1.8 µs — **80–3400× cheaper**. Intended use: field per keystroke, resource on blur, whole-config on save (the latter still owns deferred external checks like DNS).

## Completion
- `engine.Completion` + `session.Complete(res, field, partial)`: enum members + string-shape literals + a reference field's **in-scope instances** (prefixed), filtered by the partial the user typed (case-insensitive prefix; empty = all). Enums/field-names are also in the emitted JSON Schema for client-side use; the value here is the scope-aware reference candidates the schema can't know.

## Field-recognition fixes (from frontend feedback)
- Unknown field paths now **error** (validate *and* complete) instead of silently returning OK — so a typo isn't mistaken for "valid" / "no suggestions".
- `Duration`/`Bytes` gained load-time validators, so `20x` / `banana` is flagged per-field, not only at compile.
- Field lookup matches an attribute's canonical Path **or** legacy Compat alias (e.g. a function's `domains` == `trigger/domains`).
- **List elements are addressable by index** (`trigger/domains/0`) for both validate and complete — a per-element reference is checked / completed like the field.

## Surface
- wasm: `sessionValidateField` / `sessionValidateResource` / `sessionComplete`. Generated TS resource configs gain `validate()` / `validateField()` / `complete()`.

All generic in `pkg/tcc/engine` (the Taubyte schema is a consumer); the parity oracle is unchanged and `tcc-gen --check` shows 0 drift. Verified locally: full tcc + tcc-gen + parity suites, the js/wasm suite, `--check`, and `bun run build`.