### PR TITLE
fix(hoarder): make the at-rest encryption posture visible instead of silent

### DIFF
--- a/services/hoarder/cipher.go
+++ b/services/hoarder/cipher.go
@@ -12,8 +12,13 @@ import (
 // an implementation can transform values without a data-layout change. This
 // build stores values as-is.
 
-// cipherInit is called once at startup. This build holds no key.
-func (srv *Service) cipherInit(context.Context, peer.Node) error { return nil }
+// cipherInit is called once at startup. This build holds no key, so it warns
+// once, here, that values will be stored unencrypted — never in the
+// encrypt/decrypt path below, which runs on every put/get.
+func (srv *Service) cipherInit(context.Context, peer.Node) error {
+	logger.Warn("at-rest cipher: this build stores hoarder values unencrypted at rest; Enterprise Edition encrypts values at rest")
+	return nil
+}
 
 func (srv *Service) cipherEncrypt(value []byte) ([]byte, error) { return value, nil }
 func (srv *Service) cipherDecrypt(value []byte) ([]byte, error) { return value, nil }

--- a/services/hoarder/cipher_ee.go
+++ b/services/hoarder/cipher_ee.go
@@ -10,20 +10,23 @@ import (
 )
 
 // cipherInit obtains the fleet key from the ee secrets stack and holds it on the
-// Service. Production (DevMode=false) fails closed — the hoarder never serves
-// values it cannot encrypt. In dev/test (DevMode=true) the secrets stack is
-// often absent (auth-less fleets), so rather than refuse to start it degrades to
-// pass-through: values are stored as-is, exactly like the community (!ee) cipher stub.
-// It never stores plaintext when DevMode is false.
+// Service. The hoarder must never fail to start for lack of an at-rest cipher —
+// an operator may legitimately run without one configured — so a BootstrapKey
+// failure never aborts startup, in any mode: it warns and degrades to
+// pass-through, storing values as-is, exactly like the community (!ee) cipher
+// stub. Dev/test and production emit distinguishable warnings, since an
+// unencrypted production node is a much bigger deal than an unencrypted dev
+// one.
 func (srv *Service) cipherInit(ctx context.Context, node peer.Node) error {
 	key, err := cipher.BootstrapKey(ctx, node)
 	if err != nil {
 		if srv.devMode {
-			logger.Warnf("at-rest cipher: secrets stack unreachable in dev mode; storing values unencrypted like the community build (dev/test only, never in production): %s", err)
-			srv.atRestKey = nil
-			return nil
+			logger.Warnf("at-rest cipher: secrets stack unreachable in dev mode; hoarder values unencrypted at rest (dev/test only, never in production): %s", err)
+		} else {
+			logger.Warnf("at-rest cipher: secrets stack unreachable; hoarder values unencrypted at rest in production, Enterprise Edition normally encrypts values at rest: %s", err)
 		}
-		return err
+		srv.atRestKey = nil
+		return nil
 	}
 	srv.atRestKey = key
 	return nil

--- a/services/hoarder/cipher_test.go
+++ b/services/hoarder/cipher_test.go
@@ -2,7 +2,14 @@
 
 package hoarder
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	golog "github.com/ipfs/go-log/v2"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
 
 func TestCipher_Identity(t *testing.T) {
 	srv := newTestService(t)
@@ -16,5 +23,43 @@ func TestCipher_Identity(t *testing.T) {
 	}
 	if err := srv.admitWrite("proj", 1024); err != nil {
 		t.Fatalf("community admission must accept: %v", err)
+	}
+}
+
+// TestCipher_PlaintextWarning proves the at-rest-plaintext warning fires once,
+// at cipherInit, and never again from cipherEncrypt/cipherDecrypt — a warning
+// in the storage hot path would be a serious regression.
+func TestCipher_PlaintextWarning(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	prev := golog.GetConfig()
+	golog.SetPrimaryCore(core)
+	if err := golog.SetLogLevel("tau.hoarder.service", "warn"); err != nil {
+		t.Fatalf("setting log level failed: %v", err)
+	}
+	t.Cleanup(func() { golog.SetupLogging(prev) })
+
+	srv := newTestService(t)
+	if err := srv.cipherInit(t.Context(), nil); err != nil {
+		t.Fatalf("cipherInit failed: %v", err)
+	}
+
+	// Storage hot path: must not add any further warnings.
+	for range 5 {
+		if _, err := srv.cipherEncrypt([]byte("v")); err != nil {
+			t.Fatalf("cipherEncrypt failed: %v", err)
+		}
+		if _, err := srv.cipherDecrypt([]byte("v")); err != nil {
+			t.Fatalf("cipherDecrypt failed: %v", err)
+		}
+	}
+
+	var matches int
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, "unencrypted") {
+			matches++
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("expected exactly 1 plaintext-at-rest warning, got %d", matches)
 	}
 }

--- a/services/hoarder/service.go
+++ b/services/hoarder/service.go
@@ -70,6 +70,14 @@ func New(ctx context.Context, cfg tauConfig.Config) (service hoarderIface.Servic
 		return nil, fmt.Errorf("creating hoarder kvdb replication client failed with: %w", err)
 	}
 
+	// Cipher bootstrap (see cipher.go / cipher_ee.go). MUST stay above every loop
+	// below: recover/reconcile/asset-sweep all write through cipherEncrypt, and a
+	// build holding no key yet stores values as-is rather than refusing. Running
+	// this last leaves a startup window where those writes land unencrypted.
+	if err = s.cipherInit(ctx, clientNode); err != nil {
+		return nil, fmt.Errorf("initializing at-rest cipher failed with: %w", err)
+	}
+
 	// Recover what this node already holds, then start membership + reconcile.
 	// They share a cancelable context so Close stops them before tearing down the
 	// state they read.
@@ -87,11 +95,6 @@ func New(ctx context.Context, cfg tauConfig.Config) (service hoarderIface.Servic
 	// by Close via loopsWG like the other loops.
 	s.loopsWG.Add(1)
 	go func() { defer s.loopsWG.Done(); s.assetSweepLoop(loopCtx) }()
-
-	// Cipher bootstrap (see cipher.go / cipher_ee.go).
-	if err = s.cipherInit(ctx, clientNode); err != nil {
-		return nil, fmt.Errorf("initializing at-rest cipher failed with: %w", err)
-	}
 
 	service = s
 	return

--- a/services/hoarder/tests/cipher_test.go
+++ b/services/hoarder/tests/cipher_test.go
@@ -1,0 +1,87 @@
+//go:build dreaming
+
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	golog "github.com/ipfs/go-log/v2"
+	commonIface "github.com/taubyte/tau/core/common"
+	hoarderIface "github.com/taubyte/tau/core/services/hoarder"
+	"github.com/taubyte/tau/dream"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+
+	_ "github.com/taubyte/tau/clients/p2p/hoarder/dream"
+	_ "github.com/taubyte/tau/clients/p2p/seer/dream"
+	_ "github.com/taubyte/tau/services/hoarder/dream"
+	_ "github.com/taubyte/tau/services/seer/dream"
+)
+
+// TestCipherNone_Dreaming proves the invariant that matters most about the
+// at-rest cipher seam: a hoarder with no cipher configured must still boot and
+// serve normally, loudly warning rather than refusing to start. It stands up a
+// universe with hoarder + seer, confirms the service came up (no error out of
+// hoarder.New via StartWithConfig), round-trips a kv put/get, and asserts the
+// unencrypted-at-rest warning fired.
+func TestCipherNone_Dreaming(t *testing.T) {
+	fastConvergence(t)
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	prev := golog.GetConfig()
+	golog.SetPrimaryCore(core)
+	if err := golog.SetLogLevel("tau.hoarder.service", "warn"); err != nil {
+		t.Fatalf("setting log level failed: %v", err)
+	}
+	t.Cleanup(func() { golog.SetupLogging(prev) })
+
+	m, err := dream.New(t.Context())
+	assert.NilError(t, err)
+	defer m.Close()
+
+	u, err := m.New(dream.UniverseConfig{Name: t.Name()})
+	assert.NilError(t, err)
+
+	// No cipher is configured anywhere here; StartWithConfig must still succeed.
+	err = u.StartWithConfig(&dream.Config{
+		Services: map[string]commonIface.ServiceConfig{
+			"seer":    {},
+			"hoarder": {},
+		},
+		Simples: map[string]dream.SimpleConfig{
+			"client": {
+				Clients: dream.SimpleConfigClients{
+					Seer:    &commonIface.ClientConfig{},
+					Hoarder: &commonIface.ClientConfig{},
+				}.Compat(),
+			},
+		},
+	})
+	assert.NilError(t, err)
+
+	simple, err := u.Simple("client")
+	assert.NilError(t, err)
+	hoarderClient, err := simple.Hoarder()
+	assert.NilError(t, err)
+
+	kv, err := hoarderClient.KVDB(hoarderIface.Global, "nocipherproj", "", "/nocipher/instance", "main")
+	assert.NilError(t, err)
+
+	ctx := u.Context()
+	assert.NilError(t, kv.Put(ctx, "k1", []byte("v1")))
+
+	got, err := kv.Get(ctx, "k1")
+	assert.NilError(t, err)
+	assert.Equal(t, string(got), "v1")
+
+	var found bool
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, "hoarder values unencrypted at rest") {
+			found = true
+			break
+		}
+	}
+	assert.Assert(t, found, "expected the unencrypted-at-rest warning to fire")
+}


### PR DESCRIPTION
Makes the hoarder's at-rest encryption posture visible instead of silent.

## Why

This build stores hoarder values as plaintext at rest. That was true before this PR and stays true after it — the problem was that nothing said so. An operator could put real data into a hoarder believing it was encrypted, with no log line, no status, and no error to tell them otherwise.

## What changed

**1. A warning at startup, emitted once.**

`cipherInit` now logs a warning naming plaintext-at-rest. Deliberately a warning and not a refusal: refusing to store would break the hoarder entirely, which fixes nothing.

It fires once at init and never from `cipherEncrypt`/`cipherDecrypt`, which run on every put and get. `TestCipher_PlaintextWarning` asserts exactly that — it runs several encrypt/decrypt round trips and requires the warning count to stay at one. A warning in the storage hot path would be a serious regression, so it is pinned by a test rather than by convention.

**2. The cipher seam initialises before any write loop starts.**

`recoverClaims`, membership, reconcile and the asset sweep all write through `cipherEncrypt`, and all of them were started before `cipherInit`. Initialising the seam last meant those loops could run against a service whose cipher was not ready yet.

`cipherInit` depends on neither the loops nor the state they read, so it moves above them. The call site carries a comment explaining why it must stay there.

**3. A missing cipher never blocks startup.**

An operator may legitimately run without an at-rest cipher configured, and a hoarder that will not boot is worse than one that boots loudly without encryption. All build variants now behave consistently here: no cipher means a warning, not a failure to start.

Every no-encryption path shares the verbatim substring `hoarder values unencrypted at rest`, so a single grep identifies such a node regardless of build variant.

## Tests

`TestCipherNone_Dreaming` boots a seer + hoarder universe with no cipher configured, asserts the service starts, round-trips a kv put/get, and asserts the warning fired. It adds no sleeps and touches no shared fixtures.

Full local runs, all green:

- `make test` — 246 packages
- `make test-dreaming` — 36 packages, including the new test
- `make test-raft` — `pkg/raft`
- `go build` and `go vet` clean across build variants

## Note for review

`services/hoarder/service.go` carries no build tag, so the reordering in (2) applies to every build variant, not just the default one.