### PR TITLE
fix(accounts): key the slug index per claimant, and document kvdb design rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,105 @@
+# AGENTS.md
+
+Working notes for anyone — human or agent — changing this codebase. Rules here exist
+because getting them wrong produced a real bug, not because they sound tidy.
+
+## Designing around kvdb
+
+`core/kvdb` is a **CRDT key-value store** (go-ds-crdt), not a database. It replicates
+between nodes and merges concurrent writes with **last-write-wins per key**. There are no
+transactions, no compare-and-swap, and no cross-key atomicity. Design for that or lose
+data.
+
+### 1. One key per entry. Never a contended key.
+
+The single most important rule. If two nodes can write the same key with different
+content, one write is silently discarded.
+
+```
+BAD   /lookup/org/{provider}/{owner}          → account_id
+GOOD  /lookup/org/{provider}/{owner}/{account_id} → linked-at
+```
+
+In the bad layout two nodes claiming the same namespace both write one key and LWW picks a
+winner — the loser vanishes with no error. In the good layout they write **different**
+keys, so nothing is lost.
+
+Same rule kills read-modify-write on a collection. Never store a CBOR slice or map that
+callers append to: reader A and reader B both read `[x]`, write `[x,y]` and `[x,z]`, and
+one entry disappears. Split the collection into one key per element.
+
+`services/accounts/paths.go` states this convention and the layouts follow it — lookup
+indexes, passkey sub-collections, all one key per entry.
+
+### 2. Put the discriminator in the key path.
+
+If an entry belongs to a `(provider, owner, account)` tuple, all three go in the path. Any
+part you leave out of the key is a part two writers can collide on.
+
+Corollary: keys are also your index. `List(ctx, prefix)` is the only query mechanism, so
+lay paths out so the prefix scans you need are cheap and the ones you don't need are
+impossible.
+
+### 3. Make conflict visible, then resolve it deterministically.
+
+Rule 1 means a genuine conflict — two accounts legitimately claiming one namespace — shows
+up as two entries rather than one silently winning. That is the point. Do not try to
+prevent it with a lock you do not have; resolve it on read:
+
+- scan the prefix
+- order by a stable value carried **in the entry** (a timestamp), with a second key
+  (the id) breaking ties for a total order
+- take the first
+
+Every node then computes the same answer from the same replicated state, with no
+coordination and no dependence on write ordering or clock skew between nodes mattering to
+correctness. `services/accounts/account.go`'s `lookupIDBySlug` does exactly this.
+
+### 4. Read-then-write guards are UX, not correctness.
+
+Checking "is this already claimed?" before writing is worth doing — it gives a clear error
+in the overwhelmingly common uncontended case. It guarantees nothing under concurrency,
+because another node can write between your read and your write. Never let correctness
+depend on one. Rule 3 is what makes the outcome safe.
+
+### 5. Deletes are writes too.
+
+A delete is LWW against a concurrent write to the same key. A delete racing a re-create can
+lose. If ordering matters, carry it in the value and resolve on read.
+
+### 6. Only subscribed instances replicate.
+
+A kvdb replicates to instances that are **open and subscribed**. A write acknowledged by a
+single node can die with that node if no other holder had the database open. Anything doing
+load/unload must keep claimants co-loaded during active writes and barrier on acknowledgement
+from more than one holder. See `pkg/kvdb` and the hoarder replication path.
+
+### 7. Byte order is your only sort order.
+
+`List` returns keys in byte order. To scan chronologically, zero-pad the numeric segment to
+fixed width so lexicographic order matches numeric order — `pkg/raft/storage.go:40` and
+`pkg/raft/queue.go:60` pad indices to 20 digits for this reason. Unpadded numbers sort
+`1, 10, 2`.
+
+### 8. Key naming: path segments, not compound words.
+
+Use `/lookup/account/slug/{slug}`, not `/lookup/account_slug/{slug}`. Segments are what the
+prefix scanner understands; an underscore is invisible to it and forecloses scanning the
+intermediate level later.
+
+### 9. Normalise before keying.
+
+Anything case-insensitive in the real world (email, provider namespaces) must be
+canonicalised before it becomes part of a key, or `Acme` and `acme` become two entries for
+one thing and every uniqueness property built on that key quietly fails. The store
+lowercases emails in several places; do the same for any new identifier.
+
+### Checklist
+
+- [ ] Can two nodes write this exact key with different content? If yes, redesign.
+- [ ] Am I appending to a stored collection? If yes, split it into keys.
+- [ ] Is every part of the entry's identity in the key path?
+- [ ] If a conflict happens anyway, does every node resolve it the same way?
+- [ ] Does correctness rest on a read-then-write guard? It must not.
+- [ ] Are numeric key segments zero-padded to fixed width?
+- [ ] Are case-insensitive identifiers normalised before keying?

--- a/services/accounts/account.go
+++ b/services/accounts/account.go
@@ -2,8 +2,10 @@ package accounts
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/taubyte/tau/core/kvdb"
@@ -53,7 +55,7 @@ func (s *accountStore) Create(ctx context.Context, in accountsIface.CreateAccoun
 	if err := putKV(ctx, s.db, AccountProfilePath(acc.ID), acc); err != nil {
 		return nil, err
 	}
-	if err := s.db.Put(ctx, LookupAccountSlugPath(in.Slug), []byte(acc.ID)); err != nil {
+	if err := s.db.Put(ctx, LookupAccountSlugEntryPath(in.Slug, acc.ID), unixNanoBytes(now)); err != nil {
 		_ = s.db.Delete(ctx, AccountProfilePath(acc.ID))
 		return nil, fmt.Errorf("accounts: index slug: %w", err)
 	}
@@ -130,7 +132,7 @@ func (s *accountStore) Delete(ctx context.Context, accountID string) error {
 	if err := batch.Delete(AccountProfilePath(accountID)); err != nil {
 		return fmt.Errorf("accounts: batch delete profile: %w", err)
 	}
-	if err := batch.Delete(LookupAccountSlugPath(acc.Slug)); err != nil {
+	if err := batch.Delete(LookupAccountSlugEntryPath(acc.Slug, accountID)); err != nil {
 		return fmt.Errorf("accounts: batch delete slug index: %w", err)
 	}
 	if err := batch.Commit(); err != nil {
@@ -140,15 +142,48 @@ func (s *accountStore) Delete(ctx context.Context, accountID string) error {
 }
 
 // lookupIDBySlug returns "" (not ErrNotFound) when the slug is missing.
+//
+// The index is one key per claimant, so a slug claimed concurrently by two
+// accounts yields two entries rather than one being lost. Earliest created-at
+// wins, account id breaking ties for a total order, so every node resolves the
+// same way from the same replicated state.
 func (s *accountStore) lookupIDBySlug(ctx context.Context, slug string) (string, error) {
-	raw, err := s.db.Get(ctx, LookupAccountSlugPath(slug))
+	prefix := LookupAccountSlugPrefix(slug)
+	keys, err := s.db.List(ctx, prefix)
 	if err != nil {
 		if isMissing(err) {
 			return "", nil
 		}
 		return "", fmt.Errorf("accounts: lookup slug: %w", err)
 	}
-	return string(raw), nil
+
+	best, bestAt := "", int64(0)
+	for _, k := range keys {
+		accountID := strings.TrimPrefix(k, prefix)
+		if accountID == "" || strings.Contains(accountID, "/") {
+			continue
+		}
+		raw, err := s.db.Get(ctx, k)
+		if err != nil {
+			if isMissing(err) {
+				continue
+			}
+			return "", fmt.Errorf("accounts: lookup slug: %w", err)
+		}
+		at := int64(binary.BigEndian.Uint64(raw))
+		if best == "" || at < bestAt || (at == bestAt && accountID < best) {
+			best, bestAt = accountID, at
+		}
+	}
+	return best, nil
+}
+
+// unixNanoBytes encodes a timestamp as 8 big-endian bytes, matching the other
+// lookup indexes in this package.
+func unixNanoBytes(t time.Time) []byte {
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], uint64(t.UnixNano()))
+	return b[:]
 }
 
 // validateAccountSlug is case-sensitive — "Pro" and "pro" are distinct.

--- a/services/accounts/paths.go
+++ b/services/accounts/paths.go
@@ -16,10 +16,10 @@ import (
 //   /accounts/{id}/users/{user_id}/profile                        → User
 //   /accounts/{id}/signing_key                                    → 32 raw random bytes
 //
-//   /lookup/account_slug/{slug}                                       → account_id (raw bytes)
+//   /lookup/account/slug/{slug}/{account_id}                          → 8-byte unixnano created-at
 //   /lookup/email/{sha256(lower(email))}/{account_id}/{member_id}     → 8-byte unixnano added-at
 //   /lookup/external/{provider}/{subject}/{account_id}/{member_id}    → 8-byte unixnano added-at
-//   /lookup/git_user/{provider}/{external_id}/{account_id}/{user_id}  → 8-byte unixnano added-at
+//   /lookup/git/user/{provider}/{external_id}/{account_id}/{user_id} → 8-byte unixnano added-at
 //
 // Lookup indexes are one KV key per entry (not a single CBOR slice) so
 // concurrent writes from different nodes for distinct (account, member|user)
@@ -59,8 +59,19 @@ func UserProfilePath(accountID, userID string) string {
 	return AccountUsersPrefix(accountID) + userID + "/profile"
 }
 
-func LookupAccountSlugPath(slug string) string {
-	return prefixLookup + "account_slug/" + slug
+// LookupAccountSlugPrefix / LookupAccountSlugEntryPath: one key per claimant
+// rather than a single key per slug holding the owning account id. A contended
+// key would let two nodes creating accounts with the same slug both write it,
+// last-write-wins discard one, and leave the losing account existing with a
+// slug that resolves to somebody else — an orphan nothing can detect. Per
+// claimant, both claims survive and lookupIDBySlug settles them
+// deterministically. See AGENTS.md, "Designing around kvdb".
+func LookupAccountSlugPrefix(slug string) string {
+	return prefixLookup + "account/slug/" + slug + "/"
+}
+
+func LookupAccountSlugEntryPath(slug, accountID string) string {
+	return LookupAccountSlugPrefix(slug) + accountID
 }
 
 func LookupEmailPrefix(email string) string {
@@ -80,7 +91,7 @@ func LookupExternalEntryPath(provider, subject, accountID, memberID string) stri
 }
 
 func LookupGitUserPrefix(provider, externalID string) string {
-	return prefixLookup + "git_user/" + provider + "/" + externalID + "/"
+	return prefixLookup + "git/user/" + provider + "/" + externalID + "/"
 }
 
 func LookupGitUserEntryPath(provider, externalID, accountID, userID string) string {

--- a/services/accounts/store_test.go
+++ b/services/accounts/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/ipfs/go-log/v2"
 	"github.com/taubyte/tau/core/kvdb"
@@ -185,5 +186,62 @@ func TestMemberStore_InviteAndIndex(t *testing.T) {
 	idx, err = readMemberIndexByPrefix(ctx, srv.db, LookupEmailPrefix("alice@example.com"))
 	if err != nil || len(idx) != 0 {
 		t.Fatalf("index after Remove: idx=%+v err=%v", idx, err)
+	}
+}
+
+// TestAccountStore_ConcurrentSlugClaim covers what the per-claimant slug index
+// is for: two nodes creating accounts with the same slug, neither having seen
+// the other's write. A single contended key would lose one claim to
+// last-write-wins and leave that account existing with a slug resolving to
+// somebody else. Both claims must survive and every reader must agree.
+func TestAccountStore_ConcurrentSlugClaim(t *testing.T) {
+	srv := newTestService(t)
+	store := newAccountStore(srv.db)
+	ctx := context.Background()
+
+	// Write both index entries directly: Create's guard cannot see a
+	// concurrent write on another node, so this is the state that replicates.
+	early := time.Now().UTC().Add(-time.Hour)
+	late := time.Now().UTC()
+	if err := srv.db.Put(ctx, LookupAccountSlugEntryPath("acme", "accZ"), unixNanoBytes(early)); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.db.Put(ctx, LookupAccountSlugEntryPath("acme", "accA"), unixNanoBytes(late)); err != nil {
+		t.Fatal(err)
+	}
+
+	keys, err := srv.db.List(ctx, LookupAccountSlugPrefix("acme"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("both claims must survive, got %d", len(keys))
+	}
+
+	// Earliest created-at wins, not write order and not lexicographic id.
+	for range 5 {
+		got, err := store.lookupIDBySlug(ctx, "acme")
+		if err != nil {
+			t.Fatalf("lookup: %v", err)
+		}
+		if got != "accZ" {
+			t.Fatalf("expected the earliest claim to win, got %q", got)
+		}
+	}
+
+	// Equal timestamps fall back to account id, so nodes still converge.
+	same := time.Now().UTC()
+	if err := srv.db.Put(ctx, LookupAccountSlugEntryPath("tie", "accB"), unixNanoBytes(same)); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.db.Put(ctx, LookupAccountSlugEntryPath("tie", "accA"), unixNanoBytes(same)); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.lookupIDBySlug(ctx, "tie")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "accA" {
+		t.Fatalf("tie must break on account id, got %q", got)
 	}
 }


### PR DESCRIPTION
Writes down how to design against a CRDT store, and fixes the accounts violation that prompted it.

## The rule

`core/kvdb` is a CRDT (go-ds-crdt), not a database. It merges concurrent writes with **last-write-wins per key**, and there are no transactions, no compare-and-swap, and no cross-key atomicity.

So: **never a key two nodes can write with different content.** If they can, one write is silently discarded — no error, no trace.

`services/accounts/paths.go` already documented the consequence for lookup indexes ("one KV key per entry ... no read-modify-write blob, no CRDT loss"), and the layouts there follow it. It was written in one file's comment, so it was easy to not apply.

## The violation

```go
// before, services/accounts/account.go
db.Put(ctx, LookupAccountSlugPath(in.Slug), []byte(acc.ID))
```

One key per slug holding the owning account id. Two nodes creating accounts with the same slug concurrently both write it, last-write-wins picks one, and **the losing account keeps existing** with a slug that resolves to somebody else's account. Nothing can detect that afterwards, because the losing index entry no longer exists.

```
after
/lookup/account/slug/{slug}/{account_id}   → 8-byte unixnano created-at
```

Per claimant, both claims survive. `lookupIDBySlug` prefix-scans and settles them deterministically — earliest created-at, account id breaking ties for a total order — so every node resolves identically from the same replicated state, with no coordination and no dependence on write ordering.

The guard in `Create` stays: it gives a clear error in the overwhelmingly common uncontended case. Correctness no longer rests on it, which it previously did.

## Naming

`account_slug/` → `account/slug/`, and `git_user/` → `git/user/`.

Compound words are invisible to the prefix scanner. `/lookup/account_slug/{slug}` cannot be scanned at the intermediate level; `/lookup/account/slug/{slug}` can. `git_user`'s layout was already correct — only its name wasn't.

Note the CBOR/JSON field names spelled `account_slug` are wire field naming, a separate concern, and are untouched.

## AGENTS.md

New file. Nine rules with a checklist, each grounded in something already in the tree rather than invented:

one key per entry, never contended · discriminator in the key path · make conflict visible then resolve deterministically · read-then-write guards are UX not correctness · deletes are writes too · only subscribed instances replicate · byte order is your only sort order · path segments not compound words · normalise before keying

Related violations found while sweeping, filed rather than fixed here: #498 (patrick cluster heartbeat, every node writing the same two keys) and #499 (auth repo→project, a contended key that may be intended overwrite semantics — filed as a question).

## Tests

`TestAccountStore_ConcurrentSlugClaim` writes both index entries directly, since `Create`'s guard cannot see a concurrent write on another node and that is the state which actually replicates. It asserts both claims survive and the winner is stable across repeated reads, plus that equal timestamps fall back to account id so nodes still converge.

Local runs, all green: `make test-all` (unit, dreaming, raft), `go vet` clean.
