### PR TITLE
fix(auth): a tenancy is enforced exactly as configured, or not at all

### DIFF
--- a/services/auth/http_auth_tenancy.go
+++ b/services/auth/http_auth_tenancy.go
@@ -39,10 +39,11 @@ func (srv *AuthService) authorizeRegistrant(ctx http.Context) error {
 		return ErrNoTenancy
 	}
 
-	// No app credential means membership is unanswerable. Repository ownership
-	// still applies at registration, so this is a narrower gate, not an open one.
+	// Startup refuses a configured tenancy without one, so this is unreachable.
+	// It stays because the alternative on an authorization path is a nil-deref
+	// panic rather than a refusal.
 	if srv.membership == nil {
-		return nil
+		return errors.New("membership verifier unavailable")
 	}
 
 	client, err := getGithubClientFromContext(ctx)
@@ -57,9 +58,9 @@ func (srv *AuthService) authorizeRegistrant(ctx http.Context) error {
 
 	member, err := srv.membership.IsActiveMember(ctx.Request().Context(), srv.tenancy.Owner, me.GetLogin())
 	if err != nil {
-		// Distinct from a refusal on purpose: a caller told "not a member" when
-		// the check never ran has nothing to act on.
-		return fmt.Errorf("could not verify your membership in `%s`: %w", srv.tenancy.Owner, err)
+		// Relayed as-is. A check that never ran is not a refusal, and the
+		// provider's own message is the only thing that says what to fix.
+		return err
 	}
 	if !member {
 		return fmt.Errorf("`%s` is not a member of `%s`", me.GetLogin(), srv.tenancy.Owner)

--- a/services/auth/service.go
+++ b/services/auth/service.go
@@ -83,11 +83,13 @@ func New(ctx context.Context, cfg tauConfig.Config) (*AuthService, error) {
 		}
 	}
 
+	// A configured tenancy requires a usable app credential. Without one,
+	// membership is unanswerable, and there is no narrower gate to fall back to:
+	// refusing at startup surfaces the missing credential now rather than at
+	// whichever registration first needs it.
 	srv.tenancy = cfg.Tenancy()
-	if srv.tenancy.Configured() && srv.tenancy.App.Key != "" {
-		if srv.membership, err = newGitHubAppVerifier(srv.tenancy.App.ClientId, srv.tenancy.App.Key); err != nil {
-			return nil, fmt.Errorf("tenancy app credential unusable: %w", err)
-		}
+	if srv.membership, err = tenancyVerifier(srv.tenancy); err != nil {
+		return nil, err
 	}
 
 	srv.setupStreamRoutes()

--- a/services/auth/tenancy.go
+++ b/services/auth/tenancy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/go-github/v71/github"
 	"github.com/jellydator/ttlcache/v3"
+	tauConfig "github.com/taubyte/tau/pkg/config"
 	"golang.org/x/oauth2"
 )
 
@@ -65,6 +66,24 @@ type githubAppVerifier struct {
 type tokenEntry struct {
 	token   string
 	expires time.Time
+}
+
+// tenancyVerifier returns the verifier a tenancy requires: none when no
+// namespace is configured, and otherwise one built from the app credential.
+//
+// A configured tenancy has no ownership-only fallback. Membership is
+// unanswerable without the credential, so a missing or unusable one is an error
+// here — at startup — rather than a quietly narrower gate discovered at
+// whichever registration first needs it.
+func tenancyVerifier(t tauConfig.Tenancy) (MembershipVerifier, error) {
+	if !t.Configured() {
+		return nil, nil
+	}
+	v, err := newGitHubAppVerifier(t.App.ClientId, t.App.Key)
+	if err != nil {
+		return nil, fmt.Errorf("tenancy `%s` needs a usable app credential: %w", t.Owner, err)
+	}
+	return v, nil
 }
 
 // newGitHubAppVerifier builds a verifier from a PEM private key. It fails on a

--- a/services/auth/tenancy_test.go
+++ b/services/auth/tenancy_test.go
@@ -122,12 +122,59 @@ func TestMembership_ForbiddenIsAnErrorNotARefusal(t *testing.T) {
 	assert.Equal(t, atomic.LoadInt64(&calls), int64(2), "errors must not be cached")
 }
 
-func TestMembership_RejectsMalformedKey(t *testing.T) {
-	_, err := newGitHubAppVerifier("Iv1.test", "not a pem")
-	assert.Assert(t, err != nil)
+// No namespace configured means no verifier and no error — the cloud refuses
+// registration outright, so there is nothing to verify against.
+func TestTenancyVerifier_UnconfiguredNeedsNoCredential(t *testing.T) {
+	v, err := tenancyVerifier(tauConfig.Tenancy{})
+	assert.NilError(t, err)
+	assert.Assert(t, v == nil)
+}
 
-	_, err = newGitHubAppVerifier("", testAppKey(t))
-	assert.Assert(t, err != nil, "an empty client id cannot sign a usable jwt")
+// The other half of "no fallback": once an owner is set, startup fails unless
+// the credential is usable. Without this, a tenancy with no app would silently
+// degrade to an ownership-only gate.
+func TestTenancyVerifier_ConfiguredRequiresCredential(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		app  tauConfig.TenancyApp
+	}{
+		{"no app at all", tauConfig.TenancyApp{}},
+		{"client id but no key", tauConfig.TenancyApp{ClientId: "Iv1.test"}},
+		{"key but no client id", tauConfig.TenancyApp{Key: testAppKey(t)}},
+		{"malformed key", tauConfig.TenancyApp{ClientId: "Iv1.test", Key: "not a pem"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := tenancyVerifier(tauConfig.Tenancy{Owner: "acme", App: tc.app})
+			assert.Assert(t, err != nil, "%s must refuse startup", tc.name)
+			assert.Assert(t, v == nil)
+		})
+	}
+
+	v, err := tenancyVerifier(tauConfig.Tenancy{
+		Owner: "acme",
+		App:   tauConfig.TenancyApp{ClientId: "Iv1.test", Key: testAppKey(t)},
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, v != nil)
+}
+
+// A configured tenancy has no ownership-only fallback, so every way of not
+// supplying a usable credential has to be an error the service refuses to start
+// on, not a quietly narrower gate.
+func TestMembership_RejectsUnusableCredential(t *testing.T) {
+	for _, tc := range []struct {
+		name, clientID, key string
+	}{
+		{"malformed key", "Iv1.test", "not a pem"},
+		{"empty key", "Iv1.test", ""},
+		{"empty client id", "", testAppKey(t)},
+		{"nothing at all", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := newGitHubAppVerifier(tc.clientID, tc.key)
+			assert.Assert(t, err != nil, "%s must not yield a usable verifier", tc.name)
+		})
+	}
 }
 
 // --- repository ownership ------------------------------------------------


### PR DESCRIPTION
A cloud you build with Taubyte belongs to a namespace: your GitHub org, your GitLab group, your Bitbucket workspace. Configure it and the rule is simple — only members of that namespace can register repositories on your cloud, and only repositories the namespace owns are allowed to be registered.

This makes that promise unconditional. A cloud now enforces the tenancy you configured, exactly as you configured it, or it tells you why it can't.

## Your cloud can no longer run weaker than it looks

Membership is answered with a credential the namespace itself granted — a provider app scoped to reading members, nothing more. That credential is what makes "is this person one of ours?" answerable at all.

Before this change, a cloud configured with an owner but no app credential would quietly start anyway and fall back to checking repository ownership alone. Still a real gate — a stranger could not bring their own repository onto your cloud — but a narrower one than the config implied, and nothing said so. The operator's config said "members of acme"; the running cloud enforced something else.

Now that state is refused at startup, with a message naming the namespace and the missing credential:

```
tenancy `acme` needs a usable app credential: parsing tenancy app key failed with ...
```

You find out when you deploy, not on the day someone outside your org registers a repository you assumed was covered. A cloud with no tenancy configured is unaffected — it declines registration outright, so there is nothing to verify against and no credential to require.

## When the provider can't answer, you hear the provider

A membership check has three outcomes, not two: yes, no, and *couldn't ask*. The third one used to be rewrapped as a membership problem, which sent operators looking in the wrong place — the app may be blocked by the org, the installation may have been removed, the API may be rate limiting. None of those are facts about the person registering.

Provider errors are now relayed as-is, so the message you get is the one that tells you what to fix. Registration still declines while the provider is unreachable: a check that could not run is never treated as a pass.

## Under the hood

The credential decision moved out of service construction into `tenancyVerifier`, which returns no verifier for an unconfigured tenancy and an error for a configured one that can't be served. Small change, but it makes the rule testable in its own right rather than only reachable through a full service boot — the previous tests would have kept passing if the fallback were reintroduced.

## Verification

- `make test`, `make test-dreaming` (36/36) and `make test-raft` all green
- `go build` and `go vet` clean on every build configuration
- Reintroducing the fallback fails `TestTenancyVerifier_ConfiguredRequiresCredential` across all four ways a credential can be unusable: no app, client id without key, key without client id, malformed key

