### PR TITLE
feat(node): the community build no longer ships the accounts service

### DIFF
--- a/cli/node/node.go
+++ b/cli/node/node.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	accountsService "github.com/taubyte/tau/services/accounts"
 	authService "github.com/taubyte/tau/services/auth"
 	"github.com/taubyte/tau/services/gateway"
 	hoarderService "github.com/taubyte/tau/services/hoarder"
@@ -19,7 +18,6 @@ import (
 
 var available = map[string]config.ProtoCommandIface{
 	"auth":      authService.Package(),
-	"accounts":  accountsService.Package(),
 	"hoarder":   hoarderService.Package(),
 	"monkey":    monkeyService.Package(),
 	"substrate": nodeService.Package(),

--- a/dream/service.go
+++ b/dream/service.go
@@ -25,7 +25,17 @@ func (u *Universe) createService(name string, config *commonIface.ServiceConfig)
 		config.Root = u.root
 	}
 
-	serviceCount := len(u.service[name].nodes)
+	// Create the slot on demand, for the same reason handlerRegistry.Set does:
+	// the map is pre-seeded from commonSpecs.Services, and a build-tag-gated
+	// service registered from an init() is not in that list. Without this the
+	// lookup is a nil map entry and the deref below panics.
+	si, ok := u.service[name]
+	if !ok {
+		si = &serviceInfo{nodes: make(map[string]commonIface.Service)}
+		u.service[name] = si
+	}
+
+	serviceCount := len(si.nodes)
 	config.Root = path.Join(config.Root, fmt.Sprintf("%s-%d", name, serviceCount))
 	// Ignoring error in case of opening
 	os.MkdirAll(config.Root, 0750)

--- a/dream/simple.go
+++ b/dream/simple.go
@@ -16,7 +16,6 @@ import (
 	tnsIface "github.com/taubyte/tau/core/services/tns"
 	"github.com/taubyte/tau/p2p/keypair"
 	commonSpecs "github.com/taubyte/tau/pkg/specs/common"
-	"golang.org/x/exp/slices"
 
 	peerCore "github.com/libp2p/go-libp2p/core/peer"
 
@@ -203,11 +202,17 @@ func (u *Universe) CreateSimpleNode(name string, config *SimpleConfig) (peer.Nod
 
 	simple := &Simple{Node: simpleNode, clients: make(map[string]commonIface.Client)}
 	for name, clientCfg := range config.Clients {
-		// make sure the client asked for is a valid client
-		if slices.Contains(commonSpecs.Clients, name) {
-			if err = simple.startClient(name, clientCfg); err != nil {
-				return nil, fmt.Errorf("starting client `%s` failed with: %w", name, err)
-			}
+		// A client is valid when something registered a creator for it, which
+		// is not the same as being in commonSpecs.Clients: that list is
+		// pre-seeded and cannot know about a build-tag-gated service whose
+		// client registers from an init(). Checking the list instead would
+		// silently drop a client the caller explicitly asked for, and surface
+		// far away as "client for protocol `x` does not exist".
+		if _, err := Registry.client(name); err != nil {
+			continue
+		}
+		if err = simple.startClient(name, clientCfg); err != nil {
+			return nil, fmt.Errorf("starting client `%s` failed with: %w", name, err)
 		}
 	}
 

--- a/pkg/specs/common/vars.go
+++ b/pkg/specs/common/vars.go
@@ -29,8 +29,8 @@ const (
 )
 
 var (
-	Services          = []string{Auth, Patrick, Monkey, TNS, Hoarder, Substrate, Seer, Gateway, Accounts}
-	Clients           = []string{Auth, Patrick, Monkey, TNS, Hoarder, Substrate, Seer, Accounts}
-	HTTPServices      = []string{Patrick, Substrate, Seer, Auth, Gateway, Accounts}
-	P2PStreamServices = []string{Seer, Auth, Patrick, TNS, Monkey, Hoarder, Substrate, Accounts}
+	Services          = []string{Auth, Patrick, Monkey, TNS, Hoarder, Substrate, Seer, Gateway}
+	Clients           = []string{Auth, Patrick, Monkey, TNS, Hoarder, Substrate, Seer}
+	HTTPServices      = []string{Patrick, Substrate, Seer, Auth, Gateway}
+	P2PStreamServices = []string{Seer, Auth, Patrick, TNS, Monkey, Hoarder, Substrate}
 )


### PR DESCRIPTION
A community cloud stops carrying the accounts service at all. Not registered-and-unused, not disabled by config — absent from the binary. `go list -deps ./cli/...` reaches `services/accounts` **zero** times in the community build.

That is the last piece of the redundancy #505 started removing: since #503 a community cloud has answered identity from its own tenancy, and the service it no longer consults was still being compiled in, registered, and offered as something a shape could run.

## What changed

Two lines of intent: drop the registration in `cli/node/node.go`, and drop `accounts` from the four service vocabularies in `pkg/specs/common/vars.go` (`Services`, `Clients`, `HTTPServices`, `P2PStreamServices`).

## Two bugs that fell out, both older than this change

Removing a name from those vocabularies is meant to be routine — services register themselves. Two places had quietly assumed the vocabulary was the whole world, and both were broken for *any* service that registers from an `init()` rather than appearing in the list:

**`Universe.createService` panicked.** It indexed `u.service[name]` directly, and that map is seeded from `commonSpecs.Services`. A name outside the list is a nil map entry, so the deref segfaulted rather than erroring. The registry one layer beneath it — `handlerRegistry.Set` — already creates slots on demand, with a comment describing exactly this case; the universe map never got the same treatment. It does now.

**`CreateSimpleNode` silently dropped clients.** It filtered requested clients against `commonSpecs.Clients`, so a test asking *explicitly* for a client outside the list had it discarded with no error, surfacing much later and somewhere else as ``client for protocol `x` does not exist``. It now asks whether a creator is registered, which is the question it meant to ask.

Neither is specific to accounts. Any build-tag-gated service's dream wiring hit both.

## Verification

Every suite, both tag sets, all three client languages:

- `make test` · `make test-dreaming` 36/36, plus every other suite this repo defines
- TypeScript client 16/16; Python client 256/256
- `go build` and `go vet` clean on every build configuration

The Python client suite failed intermittently while testing this, on a different test each run, always at `service_manager.py:228` failing to start a subprocess. That harness drives a **downloaded release binary** (`spore_drive/bin/drive`, dated May 7) rather than anything built from this tree, and the same suite passed on `main`. Four runs total, final one clean at 256/256. Flaky harness, unrelated to this change, but worth knowing it will cost false signals again.

