### PR TITLE
fix(common): reserve the accounts service name and protocol

### DIFF
--- a/services/common/names.go
+++ b/services/common/names.go
@@ -28,5 +28,11 @@ var (
 	Patrick         = "patrick"
 	PatrickProtocol = "/patrick/v1"
 
+	// Reserved rather than used: no service in this build answers on it. The
+	// name and the protocol are claimed here so nothing else can take either,
+	// since a collision would only surface in a build that does run it.
+	Accounts         = "accounts"
+	AccountsProtocol = "/accounts/v1"
+
 	OraclePubSubPath = "/seer/oracle/v1"
 )


### PR DESCRIPTION
`services/common/names.go` is what stops two services claiming the same name or the same protocol path. `accounts` and `/accounts/v1` were dropped from it when that subsystem left this tree, which left both free for something else to take.

A collision would not show up here. Nothing in this build answers on either, so the tests would stay green and the table would look consistent. It surfaces only where the service actually runs, which is the worst place to find out.

So they go back, reserved rather than used:

```go
// Reserved rather than used: no service in this build answers on it. The
// name and the protocol are claimed here so nothing else can take either,
// since a collision would only surface in a build that does run it.
Accounts         = "accounts"
AccountsProtocol = "/accounts/v1"
```

There is deliberately no test. One asserting the table contains `"accounts"` would only assert a constant equals itself, and nothing in this build reads either value.

That is the honest limit of this change: the comment is what protects the entry. Wiring the consumer to derive from the table would make deletion a build failure, but the consumer is not in this tree and coupling it across that boundary costs more than the guard is worth.

## Verification

Vet clean in both configurations. Packages passed / failed:

| suite | ok | FAIL |
|---|---|---|
| `make test` | 209 | 0 |
| `make test-dreaming` | 35 | 0 |
| `make test-raft` | 1 | 0 |
| tagged build | 212 | 0 |
| tagged build, dreaming | 39 | 0 |
| `docker_integration` | 210 | 0 |
| `containerd_integration` | 209 | 0 |

