### PR TITLE
fix(auth): bind project and repository routes to the caller's repo access

### DIFF
--- a/services/auth/api_domain_repository_test.go
+++ b/services/auth/api_domain_repository_test.go
@@ -362,8 +362,9 @@ func TestActualHTTPHandlers(t *testing.T) {
 		// Create mock HTTP context
 		mockCtx := &mockHTTPContextWithClient{
 			variables: map[string]interface{}{
-				"provider": "github",
-				"id":       "33333",
+				"provider":     "github",
+				"id":           "33333",
+				"GithubClient": mockGitHubClient,
 			},
 		}
 

--- a/services/auth/github.go
+++ b/services/auth/github.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -111,12 +112,49 @@ func generateKey() (string, string, string, error) {
 	return deployKeyName, string(ssh.MarshalAuthorizedKey(pub)), private.String(), nil
 }
 
+// repoAccess reports whether the caller may act on a repository. GetByID already
+// fetches it under the caller's own token and GitHub returns that caller's
+// permissions with it, so this costs no extra API call. Read access is not
+// enough: a public repository reads to everyone, which is what let an unrelated
+// caller reach another project's repositories.
+func repoAccess(client GitHubClient, repoID string) bool {
+	if client.GetByID(repoID) != nil {
+		return false
+	}
+
+	repo := client.Cur()
+	if repo == nil {
+		return false
+	}
+
+	perms := repo.GetPermissions()
+	return perms["admin"] || perms["maintain"] || perms["push"]
+}
+
+// authorizeProject refuses a caller who can write to neither of the project's
+// linked repositories. That is the same scoping getGitHubUserProjects applies
+// when it lists projects, so a project is reachable by id to exactly the people
+// who already see it in their own list.
+func (srv *AuthService) authorizeProject(client GitHubClient, project projects.Project) error {
+	if srv.devMode {
+		return nil
+	}
+
+	if repoAccess(client, project.Config()) || repoAccess(client, project.Code()) {
+		return nil
+	}
+
+	// Worded like a missing project on purpose. Telling the caller a project
+	// exists but isn't theirs turns the route back into the id oracle this
+	// check exists to close.
+	return errors.New("project not found")
+}
+
 func (srv *AuthService) registerGitHubRepository(ctx context.Context, client GitHubClient, repoID string) (*RepositoryRegistrationResponse, error) {
 	// If client is nil (P2P calls), skip GitHub API verification
 	if client != nil {
-		err := client.GetByID(repoID)
-		if err != nil {
-			return nil, fmt.Errorf("fetch repository failed with %w", err)
+		if !repoAccess(client, repoID) {
+			return nil, fmt.Errorf("no access to repository `%s`", repoID)
 		}
 
 		if err := srv.authorizeRepository(client); err != nil {
@@ -236,9 +274,16 @@ func (srv *AuthService) registerGitHubRepository(ctx context.Context, client Git
 func (srv *AuthService) unregisterGitHubRepository(ctx context.Context, client GitHubClient, repoID string) error {
 	// If client is nil (P2P calls), skip GitHub API verification
 	if client != nil {
-		err := client.GetByID(repoID)
-		if err != nil {
-			return fmt.Errorf("fetch repository failed with %w", err)
+		// Registering already required write access and tenancy ownership;
+		// unregistering tears down the deploy key and hooks, so it requires
+		// the same. Read access alone would let anyone drop a public
+		// repository's build wiring.
+		if !repoAccess(client, repoID) {
+			return fmt.Errorf("no access to repository `%s`", repoID)
+		}
+
+		if err := srv.authorizeRepository(client); err != nil {
+			return err
 		}
 	}
 
@@ -282,6 +327,26 @@ func (srv *AuthService) newGitHubProject(ctx context.Context, client GitHubClien
 	logger.Debug("Creating project " + projectName)
 
 	logger.Debug("Project ID=" + projectID)
+
+	if !srv.devMode {
+		// The caller is claiming these two repositories for a project, so they
+		// have to be able to write to both. Without this, any id could be
+		// pointed at repositories the caller has nothing to do with.
+		for _, repoID := range []string{configID, codeID} {
+			if !repoAccess(client, repoID) {
+				return nil, fmt.Errorf("no access to repository `%s`", repoID)
+			}
+		}
+
+		// Import supplies the project id, so this call can land on a project
+		// that already exists and would otherwise overwrite it — including its
+		// repository links — and add the caller as an owner.
+		if existing, err := projects.Fetch(ctx, srv.KV(), projectID); err == nil {
+			if err := srv.authorizeProject(client, existing); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	gituser := client.Me()
 
@@ -386,6 +451,10 @@ func (srv *AuthService) getGitHubProjectInfo(ctx context.Context, client GitHubC
 		return nil, fmt.Errorf("retrieving project error: %w", err)
 	}
 
+	if err := srv.authorizeProject(client, project); err != nil {
+		return nil, err
+	}
+
 	return &ProjectInfoResponse{
 		Project: ProjectDetails{
 			ID:   projectid,
@@ -403,6 +472,10 @@ func (srv *AuthService) deleteGitHubUserProject(ctx context.Context, client GitH
 	project, err := projects.Fetch(ctx, srv.KV(), projectid)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch project: %w", err)
+	}
+
+	if err := srv.authorizeProject(client, project); err != nil {
+		return nil, err
 	}
 
 	err = project.Delete()

--- a/services/auth/github_http_endpoints.go
+++ b/services/auth/github_http_endpoints.go
@@ -111,6 +111,10 @@ func (srv *AuthService) registerGitHubUserRepositoryHTTPHandler(ctx http.Context
 
 func (srv *AuthService) getGitHubUserRepositoryHTTPHandler(ctx http.Context) (interface{}, error) {
 	ctxVars := ctx.Variables()
+	client, err := getGithubClientFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 	provider, err := maps.String(ctxVars, "provider")
 	if err != nil {
 		return nil, err
@@ -119,6 +123,10 @@ func (srv *AuthService) getGitHubUserRepositoryHTTPHandler(ctx http.Context) (in
 	repoId, err := maps.String(ctxVars, "id")
 	if err != nil {
 		return nil, fmt.Errorf("parsing github repository ID failed with %w", err)
+	}
+
+	if !srv.devMode && !repoAccess(client, repoId) {
+		return nil, fmt.Errorf("repository %s not found", repoId)
 	}
 
 	requestCtx := ctx.Request().Context()

--- a/services/auth/github_project_authz_test.go
+++ b/services/auth/github_project_authz_test.go
@@ -1,0 +1,135 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-github/v71/github"
+	"gotest.tools/v3/assert"
+)
+
+// authzClient is a GitHubClient for one identity, holding the repositories that
+// identity can write to. Repositories outside `writable` still resolve — that is
+// what a public repository does — but carry no write permission.
+type authzClient struct {
+	GitHubClient
+	id       int64
+	login    string
+	writable map[string]bool
+	cur      *github.Repository
+}
+
+func (c *authzClient) Me() *github.User {
+	return &github.User{ID: &c.id, Login: &c.login}
+}
+
+func (c *authzClient) GetByID(id string) error {
+	c.cur = &github.Repository{
+		ID:          &c.id,
+		FullName:    github.Ptr("someone/" + id),
+		Permissions: map[string]bool{"pull": true, "push": c.writable[id], "admin": c.writable[id]},
+	}
+	return nil
+}
+
+func (c *authzClient) Cur() *github.Repository { return c.cur }
+
+func (c *authzClient) ShortRepositoryInfo(id string) RepositoryShortInfo {
+	return RepositoryShortInfo{ID: id}
+}
+
+func newAuthzService(t *testing.T, port int) *AuthService {
+	t.Helper()
+	svc, err := New(context.Background(), newTestConfig(t, port))
+	assert.NilError(t, err)
+	t.Cleanup(func() { svc.Close() })
+	// The authorization checks are skipped in dev mode, as every other check in
+	// this service is; these tests are about the production path.
+	svc.devMode = false
+	return svc
+}
+
+// TestProjectAccessByID covers taubyte/tau#513: GET and DELETE by project id
+// must refuse a caller who cannot write to either linked repository.
+func TestProjectAccessByID(t *testing.T) {
+	ctx := context.Background()
+	svc := newAuthzService(t, 13513)
+
+	victim := &authzClient{id: 1, login: "victim", writable: map[string]bool{"1001": true, "1002": true}}
+	attacker := &authzClient{id: 2, login: "attacker", writable: map[string]bool{"9001": true}}
+
+	_, err := svc.newGitHubProject(ctx, victim, "PROJECT_ID_513", "victims-project", "1001", "1002")
+	assert.NilError(t, err)
+
+	_, err = svc.getGitHubProjectInfo(ctx, attacker, "PROJECT_ID_513")
+	assert.Error(t, err, "project not found")
+
+	_, err = svc.deleteGitHubUserProject(ctx, attacker, "PROJECT_ID_513")
+	assert.Error(t, err, "project not found")
+
+	// The owner still gets through, and the project survived the attempts.
+	info, err := svc.getGitHubProjectInfo(ctx, victim, "PROJECT_ID_513")
+	assert.NilError(t, err)
+	assert.Equal(t, info.Project.Name, "victims-project")
+
+	_, err = svc.deleteGitHubUserProject(ctx, victim, "PROJECT_ID_513")
+	assert.NilError(t, err)
+}
+
+// TestProjectImportOverExisting covers the takeover path: import supplies the
+// project id, so it must not overwrite a project the caller has no access to.
+func TestProjectImportOverExisting(t *testing.T) {
+	ctx := context.Background()
+	svc := newAuthzService(t, 13514)
+
+	victim := &authzClient{id: 1, login: "victim", writable: map[string]bool{"1001": true, "1002": true}}
+	attacker := &authzClient{id: 2, login: "attacker", writable: map[string]bool{"9001": true, "9002": true}}
+
+	_, err := svc.newGitHubProject(ctx, victim, "PROJECT_ID_513", "victims-project", "1001", "1002")
+	assert.NilError(t, err)
+
+	// Attacker's own repositories, victim's project id.
+	_, err = svc.newGitHubProject(ctx, attacker, "PROJECT_ID_513", "attackers-project", "9001", "9002")
+	assert.Error(t, err, "project not found")
+
+	info, err := svc.getGitHubProjectInfo(ctx, victim, "PROJECT_ID_513")
+	assert.NilError(t, err)
+	assert.Equal(t, info.Project.Name, "victims-project")
+	assert.Equal(t, info.Project.Repositories.Configuration.ID, "1001")
+
+	_, err = svc.db.Get(ctx, "/projects/PROJECT_ID_513/owners/2")
+	assert.Assert(t, err != nil, "attacker recorded itself as an owner")
+
+	// The victim's repository still points at the victim's project.
+	linked, err := svc.db.Get(ctx, "/repositories/github/1001/project")
+	assert.NilError(t, err)
+	assert.Equal(t, string(linked), "PROJECT_ID_513")
+}
+
+// TestNewProjectRequiresRepoAccess: a project may only be created against
+// repositories the caller can write to.
+func TestNewProjectRequiresRepoAccess(t *testing.T) {
+	ctx := context.Background()
+	svc := newAuthzService(t, 13515)
+
+	attacker := &authzClient{id: 2, login: "attacker", writable: map[string]bool{"9001": true}}
+
+	// 1002 is readable (public) but not writable by the caller.
+	_, err := svc.newGitHubProject(ctx, attacker, "PROJECT_ID_NEW", "grab", "9001", "1002")
+	assert.Error(t, err, "no access to repository `1002`")
+
+	_, err = svc.db.Get(ctx, "/repositories/github/1002/project")
+	assert.Assert(t, err != nil, "back-reference written despite refusal")
+}
+
+// TestUnregisterRepositoryRequiresAccess: read access to a public repository is
+// not enough to tear down its deploy key and hooks.
+func TestUnregisterRepositoryRequiresAccess(t *testing.T) {
+	ctx := context.Background()
+	svc := newAuthzService(t, 13516)
+
+	attacker := &authzClient{id: 2, login: "attacker", writable: map[string]bool{}}
+
+	err := svc.unregisterGitHubRepository(ctx, attacker, "1001")
+	assert.Error(t, err, "no access to repository `1001`")
+}

--- a/services/auth/mock_types_test.go
+++ b/services/auth/mock_types_test.go
@@ -225,7 +225,7 @@ type mockGitHubClient struct {
 }
 
 func (m *mockGitHubClient) Cur() *github.Repository {
-	return nil
+	return m.currentRepo
 }
 
 func (m *mockGitHubClient) Me() *github.User {
@@ -242,9 +242,10 @@ func (m *mockGitHubClient) Me() *github.User {
 func (m *mockGitHubClient) GetByID(id string) error {
 	// Create a mock repository when GetByID is called
 	m.currentRepo = &github.Repository{
-		ID:       github.Int64(12345),
-		SSHURL:   github.Ptr("git@github.com:test/test-repo.git"),
-		FullName: github.Ptr("test/test-repo"),
+		ID:          github.Int64(12345),
+		SSHURL:      github.Ptr("git@github.com:test/test-repo.git"),
+		FullName:    github.Ptr("test/test-repo"),
+		Permissions: map[string]bool{"admin": true, "push": true, "pull": true},
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #513.

## The hole

Every route in `services/auth` is gated on one question: does the caller hold a valid provider token this cloud admits. Nothing then asked whether that caller had anything to do with the id in the path.

`getGitHubUserProjects` already had the answer — it scopes the listing to repositories the caller actually has. The by-id routes never applied the same rule.

Confirmed on `main`, not just at the reported tag. Two corrections to the report while verifying it:

- **The takeover is `POST /project/import/{project}`, not GET/DELETE.** Import supplies the project id, and registration overwrites the four project keys and both repository back-references with no existence check — so it could repoint someone else's project at the caller's own repositories and add the caller as an owner. The report doesn't mention this route.
- **"Permanently, irreversibly delete" is not accurate.** `Delete()` removes four metadata keys; the repositories, hooks and TNS state are untouched and the project is re-importable. Still a destructive unauthorized write, just not unrecoverable.

Two routes beyond the reported ones have the same shape: `DELETE /repository/{provider}/{id}` called `GetByID` (a *read* check) where register also calls `authorizeRepository`, so anyone who could read a repository — including any public one — could tear down its deploy key and hooks. `GET /repository/{provider}/{id}` never fetched a client at all.

## The check

Access means **write** access. `GetByID` already fetches the repository under the caller's own token and GitHub returns that caller's permissions with it, so this costs no extra API call and no change to the `GitHubClient` interface:

```go
func repoAccess(client GitHubClient, repoID string) bool
```

Read is not enough: a public repository reads to everyone, which is what left these routes open.

`authorizeProject` passes if the caller can write to either linked repository — the same scoping the listing already uses, so a project is reachable by id by exactly the people who already see it in their own list.

| Route | Change |
|---|---|
| `GET /projects/{id}` | access check after fetch |
| `DELETE /projects/{id}` | access check after fetch |
| `POST /project/new/{project}` | caller must be able to write to both submitted repositories |
| `POST /project/import/{project}` | as above, plus must pass the access check on the project already at that id |
| `PUT`/`DELETE /repository/{provider}/{id}` | write-access check; `DELETE` also gets the `authorizeRepository` call register already made |
| `GET /repository/{provider}/{id}` | now fetches a client and checks access |

Refusals on the project routes are worded as a missing project — confirming that an id exists but isn't yours would leave the id oracle these checks close.

Dev mode skips all of this, as it already does for identity and repository ownership. Local clouds are unaffected.

## Tests

`services/auth/github_project_authz_test.go` — attacker refused on read, delete, import-over-existing, create-against-unowned-repo, and unregister; owner still passes; the victim's project and repository back-reference survive an import attempt. Each one fails against the pre-fix code.

Also fixed a mock bug this surfaced: `mockGitHubClient.Cur()` returned `nil` while `GetByID` populated `currentRepo`.

`make test` green.

## Not in this PR

- The P2P/stream surface passes `nil` as the client, which skips every provider check by design. There is no caller identity there to check against, so it needs a peer-trust decision rather than this mechanism.
- Domain-token issuance signs any syntactically valid project id, but the consumer resolves the project by host through TNS before validating, so it isn't independently exploitable.
- `Delete()` orphans the `owners/*` keys and the `/repositories/github/<id>/project` back-references. Pre-existing data-integrity cleanup, unrelated to authorization.
